### PR TITLE
Update formatting of call stacks in `zksync_test_node` CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7425,7 +7425,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_test_node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_test_node"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"


### PR DESCRIPTION
# What :computer: 
* Increase padding of addresses
* Improve padding alignment for function signatures
* Update the background color to red for stack calls that are errors or reverts
* Increased the version from `1.0.0` to `1.0.1`

# Why :hand: 
* When there are multiple nested calls, their addresses (when not converted to a human readable format) start to misalign the content to the right, making things difficult to read
* Function signatures have all sorts of quirky styling (some due to `colorize` cargo oddities), but with the right-aligned formatting, it fixes 90% of the issues
* Having the background color for errors be red makes troubleshooting faster, as running a command like `replay_tx` can stream a lot of calls in rapid succession. This will make Errors immediately noticeable. 
* Updating the version seemed like the correct way to publish these updates appropriately, let me know otherwise

# Evidence :camera: 
* BEFORE
  * ![image](https://github.com/matter-labs/era-test-node/assets/1890113/84540a34-22a5-43f0-a747-42e1848d27e0)
* AFTER
  * ![image](https://github.com/matter-labs/era-test-node/assets/1890113/ad9698b7-3caf-40e4-a823-20a9b0522c28)

# Notes :pencil2: 
* I attempted to remove the padding for the function signatures (so they'd all be perfectly lined up, and easier to read) but quickly ran into 2 problems:

1. It became difficult to associate with call the function signature was related to. I attempted to solve this with an alternating background color, but this was non-trivial to implement in Rust
2. The function signatures naming conventions are a bit different for each one. As you can see when I added dots to "connect" the address to the function signature, spaces are being prepended in various locations
![image](https://github.com/matter-labs/era-test-node/assets/1890113/e1087ba5-f221-4bce-b030-e4c186a8ff3a)
