### PR TITLE
chore: implements `get_block_number` and updates `estimate_gas` and `gas_price`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zksync_test_node"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"

--- a/src/node.rs
+++ b/src/node.rs
@@ -634,22 +634,25 @@ impl EthNamespaceT for InMemoryNode {
         Ok(hash)
     }
 
-    // Methods below are not currently implemented.
-
     fn get_block_number(&self) -> jsonrpc_core::Result<zksync_basic_types::U64> {
-        not_implemented()
+        let reader = self.inner.read().unwrap();
+        Ok(U64::from(reader.current_miniblock))
     }
+
+    // Methods below are not currently implemented or using default values.
 
     fn estimate_gas(
         &self,
         _req: zksync_types::transaction_request::CallRequest,
         _block: Option<zksync_types::api::BlockNumber>,
     ) -> jsonrpc_core::Result<U256> {
-        not_implemented()
+        let gas_used = U256::from(ETH_CALL_GAS_LIMIT);
+        Ok(gas_used)
     }
 
     fn gas_price(&self) -> jsonrpc_core::Result<U256> {
-        not_implemented()
+        let fair_l2_gas_price: u64 = 250_000_000; // 0.25 gwei
+        Ok(U256::from(fair_l2_gas_price))
     }
 
     fn new_filter(&self, _filter: Filter) -> jsonrpc_core::Result<U256> {


### PR DESCRIPTION
**Changes introduced in this PR:**

- Adds implementation for `get_block_number`
- Adds placeholder value for `estimate_gas`
- Adds placeholder value for `gas_price`

These changes were introduced to further testing the documented tutorials running against `era-test-node`. The existing scripts in place make use of `zksync-web3` and `ethers` which depend on these methods. 

Please note that this PR is in a **DRAFT** state, as they're still challenges to work through with tutorial deployments. Despite seemingly successful contract deployment via the `era-test-node` logs (see below), the client is stuck waiting for the promise to resolve on the [`wait`](https://github.com/ethers-io/ethers.js/blob/0bfa7f497dc5793b66df7adfb42c6b846c51d794/packages/abstract-provider/src.ts/index.ts#L57) method which never resolves :( 

```
Executing 0x44a66ef7c96b228f8bdeed592ae123714b7533775c5c67e900317f204b11ec68
Transaction: SUCCESS
Initiator: 0x36615cf349d7f6344891b1e7ca7c72883f5dc049 Payer: 0x36615cf349d7f6344891b1e7ca7c72883f5dc049
Gas Limit: 80000000 used: 10469800 refunded: 69530200

==== Console logs:

==== 20 call traces.  Use --show-calls flag to display more info.

==== 5 events
EthToken System Contract                   0xddf2…b3ef, 0x0000…c049, 0x0000…8001
L1 messenger                               0x3a36…e241, 0x0000…800e, 0x07b6…748b
Known code storage                         0xc947…8287, 0x0100…e999, 0x0000…0000
L2 deployer                                0x290a…f8e5, 0x0000…c049, 0x0100…e999, 0x0000…e021
EthToken System Contract                   0xddf2…b3ef, 0x0000…8001, 0x0000…c049
```

