### PR TITLE
feat: implements required api methods for deploying contracts with `hardhat-zksync-deploy` plugin

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -114,8 +114,7 @@ pub fn print_call(call: &Call, padding: usize, show_calls: &ShowCalls, resolve_h
             } else {
                 block_on(async move {
                     let fetch = resolver::decode_function_selector(&sig).await.unwrap();
-                    fetch
-                        .unwrap_or(format!("{:>16}", format!("0x{}", sig).dimmed()))
+                    fetch.unwrap_or(format!("{:>16}", format!("0x{}", sig).dimmed()))
                 })
             }
         } else {
@@ -136,7 +135,10 @@ pub fn print_call(call: &Call, padding: usize, show_calls: &ShowCalls, resolve_h
             call.r#type,
             address_to_human_readable(call.to)
                 .map(|x| format!("{:<52}", x))
-                .unwrap_or(format!("{}", format!("{:<52}", format!("{:?}", call.to).bold()))),
+                .unwrap_or(format!(
+                    "{}",
+                    format!("{:<52}", format!("{:?}", call.to).bold())
+                )),
             function_signature,
             call.revert_reason
                 .as_ref()

--- a/src/node.rs
+++ b/src/node.rs
@@ -21,7 +21,7 @@ use zksync_contracts::{
 };
 use zksync_core::api_server::web3::backend_jsonrpc::namespaces::eth::EthNamespaceT;
 use zksync_types::{
-    api::{TransactionReceipt, TransactionVariant, Log},
+    api::{Log, TransactionReceipt, TransactionVariant},
     get_code_key, get_nonce_key,
     l2::L2Tx,
     transaction_request::{l2_tx_from_call_req, TransactionRequest},
@@ -30,7 +30,7 @@ use zksync_types::{
     vm_trace::VmTrace,
     zk_evm::block_properties::BlockProperties,
     StorageKey, StorageLogQueryType, Transaction, ACCOUNT_CODE_STORAGE_ADDRESS,
-    L2_ETH_TOKEN_ADDRESS
+    L2_ETH_TOKEN_ADDRESS,
 };
 use zksync_utils::{
     bytecode::hash_bytecode, bytes_to_be_words, h256_to_account_address, h256_to_u256, h256_to_u64,
@@ -314,7 +314,7 @@ impl InMemoryNode {
         HashMap<StorageKey, H256>,
         VmTxExecutionResult,
         BlockInfo,
-        HashMap<U256, Vec<U256>>
+        HashMap<U256, Vec<U256>>,
     ) {
         let inner = self.inner.write().unwrap();
 
@@ -345,7 +345,7 @@ impl InMemoryNode {
             bootloader_code,
             execution_mode,
         );
-        
+
         let tx: Transaction = l2_tx.into();
 
         push_transaction_to_bootloader_memory(&mut vm, &tx, execution_mode, None);
@@ -588,35 +588,42 @@ impl EthNamespaceT for InMemoryNode {
                 U64::from(0)
             };
 
-            let logs: Vec<Log> = info.result.result.logs.events.iter().map(|log| {
-                let address = log.address;
-                let topics = &log.indexed_topics;
-                let data = log.value.clone();
-                let block_hash = Some(hash);
-                let block_number = Some(U64::from(info.miniblock_number));
-                let l1_batch_number = Some(U64::from(info.batch_number as u64));
-                let transaction_hash = Some(hash);
-                let transaction_index = Some(U64::from(1).into());
-                let log_index = Some(U256::default());
-                let transaction_log_index = Some(U256::default());
-                let log_type = None;
-                let removed = None;
-            
-                Log {
-                    address,
-                    topics: topics.to_vec(),
-                    data: zksync_types::Bytes(data),
-                    block_hash,
-                    block_number,
-                    l1_batch_number,
-                    transaction_hash,
-                    transaction_index,
-                    log_index,
-                    transaction_log_index,
-                    log_type,
-                    removed,
-                }
-            }).collect();
+            let logs: Vec<Log> = info
+                .result
+                .result
+                .logs
+                .events
+                .iter()
+                .map(|log| {
+                    let address = log.address;
+                    let topics = &log.indexed_topics;
+                    let data = log.value.clone();
+                    let block_hash = Some(hash);
+                    let block_number = Some(U64::from(info.miniblock_number));
+                    let l1_batch_number = Some(U64::from(info.batch_number as u64));
+                    let transaction_hash = Some(hash);
+                    let transaction_index = Some(U64::from(1).into());
+                    let log_index = Some(U256::default());
+                    let transaction_log_index = Some(U256::default());
+                    let log_type = None;
+                    let removed = None;
+
+                    Log {
+                        address,
+                        topics: topics.to_vec(),
+                        data: zksync_types::Bytes(data),
+                        block_hash,
+                        block_number,
+                        l1_batch_number,
+                        transaction_hash,
+                        transaction_index,
+                        log_index,
+                        transaction_log_index,
+                        log_type,
+                        removed,
+                    }
+                })
+                .collect();
 
             TransactionReceipt {
                 transaction_hash: hash,

--- a/src/node.rs
+++ b/src/node.rs
@@ -637,7 +637,8 @@ impl EthNamespaceT for InMemoryNode {
     // Methods below are not currently implemented.
 
     fn get_block_number(&self) -> jsonrpc_core::Result<zksync_basic_types::U64> {
-        not_implemented()
+        let reader = self.inner.read().unwrap();
+        Ok(U64::from(reader.current_miniblock))
     }
 
     fn estimate_gas(
@@ -645,11 +646,13 @@ impl EthNamespaceT for InMemoryNode {
         _req: zksync_types::transaction_request::CallRequest,
         _block: Option<zksync_types::api::BlockNumber>,
     ) -> jsonrpc_core::Result<U256> {
-        not_implemented()
+        let gas_used = U256::from(ETH_CALL_GAS_LIMIT);
+        Ok(gas_used)
     }
 
     fn gas_price(&self) -> jsonrpc_core::Result<U256> {
-        not_implemented()
+        let fair_l2_gas_price: u64 = 250_000_000; // 0.25 gwei
+        Ok(U256::from(fair_l2_gas_price))
     }
 
     fn new_filter(&self, _filter: Filter) -> jsonrpc_core::Result<U256> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -21,7 +21,7 @@ use zksync_contracts::{
 };
 use zksync_core::api_server::web3::backend_jsonrpc::namespaces::eth::EthNamespaceT;
 use zksync_types::{
-    api::{TransactionReceipt, TransactionVariant},
+    api::{TransactionReceipt, TransactionVariant, Log},
     get_code_key, get_nonce_key,
     l2::L2Tx,
     transaction_request::{l2_tx_from_call_req, TransactionRequest},
@@ -30,7 +30,7 @@ use zksync_types::{
     vm_trace::VmTrace,
     zk_evm::block_properties::BlockProperties,
     StorageKey, StorageLogQueryType, Transaction, ACCOUNT_CODE_STORAGE_ADDRESS,
-    L2_ETH_TOKEN_ADDRESS,
+    L2_ETH_TOKEN_ADDRESS
 };
 use zksync_utils::{
     bytecode::hash_bytecode, bytes_to_be_words, h256_to_account_address, h256_to_u256, h256_to_u64,
@@ -314,7 +314,7 @@ impl InMemoryNode {
         HashMap<StorageKey, H256>,
         VmTxExecutionResult,
         BlockInfo,
-        HashMap<U256, Vec<U256>>,
+        HashMap<U256, Vec<U256>>
     ) {
         let inner = self.inner.write().unwrap();
 
@@ -345,7 +345,7 @@ impl InMemoryNode {
             bootloader_code,
             execution_mode,
         );
-
+        
         let tx: Transaction = l2_tx.into();
 
         push_transaction_to_bootloader_memory(&mut vm, &tx, execution_mode, None);
@@ -588,10 +588,40 @@ impl EthNamespaceT for InMemoryNode {
                 U64::from(0)
             };
 
+            let logs: Vec<Log> = info.result.result.logs.events.iter().map(|log| {
+                let address = log.address;
+                let topics = &log.indexed_topics;
+                let data = log.value.clone();
+                let block_hash = Some(hash);
+                let block_number = Some(U64::from(info.miniblock_number));
+                let l1_batch_number = Some(U64::from(info.batch_number as u64));
+                let transaction_hash = Some(hash);
+                let transaction_index = Some(U64::from(1).into());
+                let log_index = Some(U256::default());
+                let transaction_log_index = Some(U256::default());
+                let log_type = None;
+                let removed = None;
+            
+                Log {
+                    address,
+                    topics: topics.to_vec(),
+                    data: zksync_types::Bytes(data),
+                    block_hash,
+                    block_number,
+                    l1_batch_number,
+                    transaction_hash,
+                    transaction_index,
+                    log_index,
+                    transaction_log_index,
+                    log_type,
+                    removed,
+                }
+            }).collect();
+
             TransactionReceipt {
                 transaction_hash: hash,
                 transaction_index: U64::from(1),
-                block_hash: None,
+                block_hash: Some(hash),
                 block_number: Some(U64::from(info.miniblock_number)),
                 l1_batch_tx_index: None,
                 l1_batch_number: Some(U64::from(info.batch_number as u64)),
@@ -600,7 +630,7 @@ impl EthNamespaceT for InMemoryNode {
                 cumulative_gas_used: Default::default(),
                 gas_used: Some(info.tx.common_data.fee.gas_limit - info.result.gas_refunded),
                 contract_address: contract_address_from_tx_result(&info.result),
-                logs: vec![],
+                logs: logs,
                 l2_to_l1_logs: vec![],
                 status: Some(status),
                 root: None,


### PR DESCRIPTION
# What 💻
- Implements `get_block_number` 
- Adds placeholder values for `estimate_gas` and `gas_price` 
- Constructs and adds `logs` to `get_transaction_receipt` 
- Formats using `cargo fmt` 

# Why ✋
- The current implementation did not have these fields populated so deployment transactions were being stuck in an infinite loop and never resolving the necessary promises. A more detailed review of the issue can be found here: https://github.com/matter-labs/era-test-node/issues/8

- Closes #8 

# Evidence 📷 

- Successfully deploys tutorial `Greeter.sol` contract 

![Screenshot 2023-07-06 at 10 59 21 AM](https://github.com/matter-labs/era-test-node/assets/29983536/e8225a6e-a974-46b8-9322-df4fd46da7ac)

**era-test-node console**
```
Executing 0x44a66ef7c96b228f8bdeed592ae123714b7533775c5c67e900317f204b11ec68
Transaction: SUCCESS
Initiator: 0x36615cf349d7f6344891b1e7ca7c72883f5dc049 Payer: 0x36615cf349d7f6344891b1e7ca7c72883f5dc049
Gas Limit: 80000000 used: 19896380 refunded: 60103620

==== Console logs:

==== 20 call traces.  Use --show-calls flag to display more info.

==== 5 events
EthToken System Contract                   0xddf2…b3ef, 0x0000…c049, 0x0000…8001
L1 messenger                               0x3a36…e241, 0x0000…800e, 0x07b6…748b
Known code storage                         0xc947…8287, 0x0100…e999, 0x0000…0000
L2 deployer                                0x290a…f8e5, 0x0000…c049, 0x0100…e999, 0x0000…e021
EthToken System Contract                   0xddf2…b3ef, 0x0000…8001, 0x0000…c049
```
