### PR TITLE
Update color of console log lines to yellow

### DIFF
--- a/src/console_log.rs
+++ b/src/console_log.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, str::FromStr};
 
+use colored::Colorize;
 use ethabi::{Contract, Function};
 use itertools::Itertools;
 use serde_json::Value;
@@ -67,6 +68,6 @@ impl ConsoleLogHandler {
                         tokens.iter().map(|t| format!("{}", t)).join(" ")
                     })
                 });
-        println!("{}", message);
+        println!("{}", format!("{}", message).yellow());
     }
 }


### PR DESCRIPTION
# What :computer: 
* Update color of console log lines to yellow

# Why :hand:
* So they're easier to read

# Evidence :camera:
Example of `era_test_node run` with a transaction containing console logs:
<img width="653" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/593243f5-c98b-40e1-ba25-f8a5033832b6">

