### PR TITLE
Add new configuration RPC endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ etc/system-contracts/.yarnrc.yml
 etc/system-contracts/bootloader/build
 
 etc/**/*.zbin
-.vscode/
+.vscode/*
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+	"recommendations": [
+		"rust-lang.rust-analyzer",
+		"humao.rest-client",
+	],
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,7 +1712,7 @@ checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "era_test_node"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -7374,8 +7374,6 @@ dependencies = [
  "num_cpus",
  "rocksdb",
  "vlog",
- "zksync_types",
- "zksync_utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,6 +1805,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
+name = "era_test_node"
+version = "1.0.1"
+dependencies = [
+ "anyhow",
+ "bigdecimal",
+ "clap 4.3.8",
+ "colored",
+ "ethabi",
+ "eyre",
+ "futures 0.3.28",
+ "hex",
+ "itertools",
+ "jsonrpc-core 18.0.0 (git+https://github.com/matter-labs/jsonrpc.git?branch=master)",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "jsonrpc-http-server",
+ "lazy_static",
+ "once_cell",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "vlog",
+ "vm",
+ "zksync_basic_types",
+ "zksync_contracts",
+ "zksync_core",
+ "zksync_state",
+ "zksync_types",
+ "zksync_utils",
+ "zksync_web3_decl",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7421,40 +7457,6 @@ dependencies = [
  "vlog",
  "zksync_types",
  "zksync_utils",
-]
-
-[[package]]
-name = "zksync_test_node"
-version = "1.0.1"
-dependencies = [
- "anyhow",
- "bigdecimal",
- "clap 4.3.8",
- "colored",
- "ethabi",
- "eyre",
- "futures 0.3.28",
- "hex",
- "itertools",
- "jsonrpc-core 18.0.0 (git+https://github.com/matter-labs/jsonrpc.git?branch=master)",
- "jsonrpc-http-server",
- "lazy_static",
- "once_cell",
- "reqwest",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "vlog",
- "vm",
- "zksync_basic_types",
- "zksync_contracts",
- "zksync_core",
- "zksync_state",
- "zksync_types",
- "zksync_utils",
- "zksync_web3_decl",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ once_cell = "1.7"
 
 jsonrpc-http-server = { git = "https://github.com/matter-labs/jsonrpc.git", branch = "master" }
 jsonrpc-core = { git = "https://github.com/matter-labs/jsonrpc.git", branch = "master" }
+jsonrpc-core-client = { git = "https://github.com/matter-labs/jsonrpc.git", branch = "master" }
+jsonrpc-derive = { git = "https://github.com/matter-labs/jsonrpc.git", branch = "master" }
 
 clap = { version = "4.2.4", features = ["derive"] }
 reqwest = { version = "0.11", features = ["blocking"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Here's a list of the available rich wallets:
 
 Feel free to use these wallets in your tests, but remember, they are for development purposes only and should not be used in production or with real assets.
 
+## 🔧 Supported APIs
+
+See our list of [Supported APIs here](SUPPORTED_APIS.md).
+
 ## 🤝 Contributing
 
 We welcome contributions from the community! If you're interested in contributing to the zkSync Era In-Memory Node, please take a look at our [CONTRIBUTING.md](./.github/CONTRIBUTING.md) for guidelines and details on the process.

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -1,0 +1,82 @@
+# 🔧 Supported APIs for In-Memory Node 🔧
+
+> ⚠️ **WORK IN PROGRESS**: This list is non-comprehensive and being updated
+
+# Key
+
+The `status` options are:
+
++ `SUPPORTED` - Basic support is complete
++ `PARTIALLY` - Partial support and a description including more specific details
++ `NOT IMPLEMENTED` - Currently not supported/implemented
+
+# `CONFIG NAMESPACE`
+
+## `config_getShowCalls`
+
+[source](src/configuration_api.rs)
+
+Gets the current value of `show_calls` that's originally set with `--show-calls` option
+
+### Arguments
+
++ _NONE_
+
+### Status
+
+`SUPPORTED`
+
+### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{"jsonrpc": "2.0","id": "1","method": "config_getShowCalls","params": []}'
+```
+
+## `config_setShowCalls`
+
+[source](src/configuration_api.rs)
+
+Updates `show_calls` to print more detailed call traces
+
+### Arguments
+
++ `value: String ('None', 'User', 'System', 'All')`
+
+### Status
+
+`SUPPORTED`
+
+### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{"jsonrpc": "2.0","id": "1","method": "config_setShowCalls","params": ["all"]}'
+```
+
+## `config_setResolveHashes`
+
+[source](src/configuration_api.rs)
+
+Updates `resolve-hashes` to call OpenChain for human-readable ABI names in call traces
+
+### Arguments
+
++ `value: boolean`
+
+### Status
+
+`SUPPORTED`
+
+### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{"jsonrpc": "2.0","id": "1","method": "config_setResolveHashes","params": [true]}'
+```

--- a/src/configuration_api.rs
+++ b/src/configuration_api.rs
@@ -28,7 +28,7 @@ pub trait ConfigurationApiNamespaceT {
     /// The current `show_calls` value for the InMemoryNodeInner.
     #[rpc(name = "config_getShowCalls", returns = "String")]
     fn config_get_show_calls(&self) -> Result<String>;
-    
+
     /// Set show_calls for the InMemoryNodeInner
     ///
     /// # Parameters
@@ -57,19 +57,17 @@ impl ConfigurationApiNamespaceT for ConfigurationApiNamespace {
     }
 
     fn config_set_show_calls(&self, value: String) -> Result<String> {
-        let show_calls = ShowCalls::from_str(&value);
-        
-        match show_calls {
-            Some(show_calls) => {
-                let mut inner = self.node.write().unwrap();
-                inner.show_calls = show_calls;
-                Ok(inner.show_calls.to_string())
-            },
-            None => {
+        let show_calls = match value.parse::<ShowCalls>() {
+            Ok(value) => value,
+            Err(_) => {
                 let reader = self.node.read().unwrap();
-                Ok(reader.show_calls.to_string())
+                return Ok(reader.show_calls.to_string());
             }
-        }
+        };
+
+        let mut inner = self.node.write().unwrap();
+        inner.show_calls = show_calls;
+        Ok(inner.show_calls.to_string())
     }
 
     fn config_set_resolve_hashes(&self, value: bool) -> Result<bool> {

--- a/src/configuration_api.rs
+++ b/src/configuration_api.rs
@@ -1,0 +1,62 @@
+// Built-in uses
+use std::sync::{Arc, RwLock};
+
+// External uses
+use jsonrpc_core::Result;
+use jsonrpc_derive::rpc;
+
+// Workspace uses
+
+// Local uses
+use crate::{node::InMemoryNodeInner, ShowCalls};
+
+pub struct ConfigurationApiNamespace {
+    node: Arc<RwLock<InMemoryNodeInner>>,
+}
+
+impl ConfigurationApiNamespace {
+    pub fn new(node: Arc<RwLock<InMemoryNodeInner>>) -> Self {
+        Self { node }
+    }
+}
+
+#[rpc]
+pub trait ConfigurationApiNamespaceT {
+    #[rpc(name = "config_getShowCalls", returns = "String")]
+    fn config_get_show_calls(&self) -> Result<String>;
+    
+    #[rpc(name = "config_setShowCalls", returns = "String")]
+    fn config_set_show_calls(&self, value: String) -> Result<String>;
+
+    #[rpc(name = "config_setResolveHashes", returns = "bool")]
+    fn config_get_resolve_hashes(&self, value: bool) -> Result<bool>;
+}
+
+impl ConfigurationApiNamespaceT for ConfigurationApiNamespace {
+    fn config_get_show_calls(&self) -> Result<String> {
+        let reader = self.node.read().unwrap();
+        Ok(reader.show_calls.to_string())
+    }
+
+    fn config_set_show_calls(&self, value: String) -> Result<String> {
+        let show_calls = ShowCalls::from_str(&value);
+        
+        match show_calls {
+            Some(show_calls) => {
+                let mut inner = self.node.write().unwrap();
+                inner.show_calls = show_calls;
+                Ok(inner.show_calls.to_string())
+            },
+            None => {
+                let reader = self.node.read().unwrap();
+                Ok(reader.show_calls.to_string())
+            }
+        }
+    }
+
+    fn config_get_resolve_hashes(&self, value: bool) -> Result<bool> {
+        let mut inner = self.node.write().unwrap();
+        inner.resolve_hashes = value;
+        Ok(inner.resolve_hashes)
+    }
+}

--- a/src/configuration_api.rs
+++ b/src/configuration_api.rs
@@ -22,14 +22,32 @@ impl ConfigurationApiNamespace {
 
 #[rpc]
 pub trait ConfigurationApiNamespaceT {
+    /// Get the InMemoryNodeInner's show_calls property as a string
+    ///
+    /// # Returns
+    /// The current `show_calls` value for the InMemoryNodeInner.
     #[rpc(name = "config_getShowCalls", returns = "String")]
     fn config_get_show_calls(&self) -> Result<String>;
     
+    /// Set show_calls for the InMemoryNodeInner
+    ///
+    /// # Parameters
+    /// - `value`: A ShowCalls enum to update show_calls to
+    ///
+    /// # Returns
+    /// The updated/current `show_calls` value for the InMemoryNodeInner.
     #[rpc(name = "config_setShowCalls", returns = "String")]
     fn config_set_show_calls(&self, value: String) -> Result<String>;
 
+    /// Set resolve_hashes for the InMemoryNodeInner
+    ///
+    /// # Parameters
+    /// - `value`: A bool to update resolve_hashes to
+    ///
+    /// # Returns
+    /// The updated `resolve_hashes` value for the InMemoryNodeInner.
     #[rpc(name = "config_setResolveHashes", returns = "bool")]
-    fn config_get_resolve_hashes(&self, value: bool) -> Result<bool>;
+    fn config_set_resolve_hashes(&self, value: bool) -> Result<bool>;
 }
 
 impl ConfigurationApiNamespaceT for ConfigurationApiNamespace {
@@ -54,7 +72,7 @@ impl ConfigurationApiNamespaceT for ConfigurationApiNamespace {
         }
     }
 
-    fn config_get_resolve_hashes(&self, value: bool) -> Result<bool> {
+    fn config_set_resolve_hashes(&self, value: bool) -> Result<bool> {
         let mut inner = self.node.write().unwrap();
         inner.resolve_hashes = value;
         Ok(inner.resolve_hashes)

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,11 +134,11 @@ pub enum ShowCalls {
 
 impl ShowCalls {
     pub fn from_str(s: &str) -> Option<Self> {
-        match s {
-            "None" => Some(ShowCalls::None),
-            "User" => Some(ShowCalls::User),
-            "System" => Some(ShowCalls::System),
-            "All" => Some(ShowCalls::All),
+        match &s.to_lowercase()[..] {
+            "none" => Some(ShowCalls::None),
+            "user" => Some(ShowCalls::User),
+            "system" => Some(ShowCalls::System),
+            "all" => Some(ShowCalls::All),
             _ => None,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use configuration_api::ConfigurationApiNamespaceT;
 use fork::ForkDetails;
 use zks::ZkMockNamespaceImpl;
 
+mod configuration_api;
 mod console_log;
 mod deps;
 mod fork;
@@ -11,7 +12,6 @@ mod node;
 mod resolver;
 mod utils;
 mod zks;
-mod configuration_api;
 
 use core::fmt::Display;
 use node::InMemoryNode;
@@ -34,14 +34,9 @@ use futures::{
 use jsonrpc_core::IoHandler;
 use zksync_basic_types::{L2ChainId, H160, H256};
 
+use crate::{configuration_api::ConfigurationApiNamespace, node::TEST_NODE_NETWORK_ID};
 use zksync_core::api_server::web3::backend_jsonrpc::namespaces::{
-    eth::EthNamespaceT,
-    zks::ZksNamespaceT,
-    net::NetNamespaceT,
-};
-use crate::{
-    node::TEST_NODE_NETWORK_ID,
-    configuration_api::ConfigurationApiNamespace,
+    eth::EthNamespaceT, net::NetNamespaceT, zks::ZksNamespaceT,
 };
 
 /// List of wallets (address, private key) that we seed with tokens at start.
@@ -132,14 +127,16 @@ pub enum ShowCalls {
     All,
 }
 
-impl ShowCalls {
-    pub fn from_str(s: &str) -> Option<Self> {
-        match &s.to_lowercase()[..] {
-            "none" => Some(ShowCalls::None),
-            "user" => Some(ShowCalls::User),
-            "system" => Some(ShowCalls::System),
-            "all" => Some(ShowCalls::All),
-            _ => None,
+impl FromStr for ShowCalls {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_ref() {
+            "none" => Ok(ShowCalls::None),
+            "user" => Ok(ShowCalls::User),
+            "system" => Ok(ShowCalls::System),
+            "all" => Ok(ShowCalls::All),
+            _ => Err(()),
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -223,6 +223,10 @@ impl InMemoryNode {
         }
     }
 
+    pub fn get_inner(&self) -> Arc<RwLock<InMemoryNodeInner>> {
+        self.inner.clone()
+    }
+
     /// Applies multiple transactions - but still one per L1 batch.
     pub fn apply_txs(&self, txs: Vec<L2Tx>) {
         println!("Running {:?} transactions (one per batch)", txs.len());

--- a/src/node.rs
+++ b/src/node.rs
@@ -386,7 +386,7 @@ impl InMemoryNode {
         }
 
         println!(
-            "\n==== {} Use --show-calls flag to display more info.",
+            "\n==== {} Use --show-calls flag or call config_setResolveHashes to display more info.",
             format!("{:?} call traces. ", tx_result.call_traces.len()).bold()
         );
 

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -1,0 +1,56 @@
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "eth_blockNumber",
+    "params": []
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "net_version",
+    "params": []
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "config_getShowCalls",
+    "params": []
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "config_setShowCalls",
+    "params": ["All"]
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "config_setResolveHashes",
+    "params": [true]
+}
+
+###
+


### PR DESCRIPTION
# What :computer: 
* Add new configuration RPC endpoints (`config_getShowCalls`, `config_setShowCalls`, and `config_setResolveHashes`)
* Add example http REST file for quickly testing the node locally
* Add recommended plugins for VSCode

# Why :hand:
* These endpoints help update the configuration of stream output from the in-memory node without requiring a restart of the node (potentially losing information)
* Having the `.http` file has made an easy way for developers to make requests to the available RPC endpoints without memorizing or copy/pasting long CURL commands
* Recommended plugins will help developers use `.http` files and setup their local environment faster

# Evidence :camera:
In this video, I start a node with just `era_test_node run` and update the `--show-calls` and `--resolve-hashes` parameters via RPC calls while the node is still running:

https://github.com/matter-labs/era-test-node/assets/1890113/89d3f378-b559-4257-b728-7b025e9341ee


# Notes :memo:
* I'm open to changing the name of these endpoints as `config_` was just the start.
* I really REALLY think this will be super useful when we get to the point of allowing end users to dynamically configure things like the delta of `current_timestamp` or the gas price (currently hard-coded to 0.25 gwei)