### PR TITLE
Implement get transaction by hash rpc endpoint

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -752,6 +752,50 @@ impl EthNamespaceT for InMemoryNode {
         Ok(Some(block)).into_boxed_future()
     }
 
+    fn get_transaction_by_hash(
+        &self,
+        hash: zksync_basic_types::H256,
+    ) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<Option<zksync_types::api::Transaction>>> {
+        let reader = self.inner.read().unwrap();
+        let tx_result = reader.tx_results.get(&hash);
+
+        let tx = tx_result.map(|info| zksync_types::api::Transaction {
+            hash,
+            nonce: U256::from(info.tx.common_data.nonce.0),
+            block_hash: Some(hash),
+            block_number: Some(U64::from(info.miniblock_number)),
+            transaction_index: Some(U64::from(1)),
+            from: Some(info.tx.initiator_account()),
+            to: Some(info.tx.recipient_account()),
+            value: info.tx.execute.value,
+            gas_price: Default::default(),
+            gas: Default::default(),
+            input: info.tx.common_data.input.clone().unwrap().data.into(),
+            v: Some(info.tx.extract_chain_id().unwrap().into()),
+            r: Some(U256::zero()),
+            s: Some(U256::zero()),
+            raw: None,
+            transaction_type: {
+                let tx_type = match info.tx.common_data.transaction_type {
+                    zksync_types::l2::TransactionType::LegacyTransaction => 0,
+                    zksync_types::l2::TransactionType::EIP2930Transaction => 1,
+                    zksync_types::l2::TransactionType::EIP1559Transaction => 2,
+                    zksync_types::l2::TransactionType::EIP712Transaction => 113,
+                    zksync_types::l2::TransactionType::PriorityOpTransaction => 255,
+                };
+                Some(tx_type.into())
+            },
+            access_list: None,
+            max_fee_per_gas: Some(info.tx.common_data.fee.max_fee_per_gas),
+            max_priority_fee_per_gas: Some(info.tx.common_data.fee.max_priority_fee_per_gas),
+            chain_id: info.tx.extract_chain_id().unwrap().into(),
+            l1_batch_number: Some(U64::from(info.batch_number as u64)),
+            l1_batch_tx_index: None,
+        });
+
+        Ok(tx).into_boxed_future()
+    }
+
     // Methods below are not currently implemented.
 
     fn get_block_number(
@@ -835,50 +879,6 @@ impl EthNamespaceT for InMemoryNode {
         _block: Option<zksync_types::api::BlockIdVariant>,
     ) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<zksync_basic_types::H256>> {
         not_implemented("get_storage")
-    }
-
-    fn get_transaction_by_hash(
-        &self,
-        hash: zksync_basic_types::H256,
-    ) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<Option<zksync_types::api::Transaction>>> {
-        let reader = self.inner.read().unwrap();
-        let tx_result = reader.tx_results.get(&hash);
-
-        let tx = tx_result.map(|info| zksync_types::api::Transaction {
-            hash,
-            nonce: U256::from(info.tx.common_data.nonce.0),
-            block_hash: Some(hash),
-            block_number: Some(U64::from(info.miniblock_number)),
-            transaction_index: Some(U64::from(1)),
-            from: Some(info.tx.initiator_account()),
-            to: Some(info.tx.recipient_account()),
-            value: info.tx.execute.value,
-            gas_price: Default::default(),
-            gas: Default::default(),
-            input: info.tx.common_data.input.clone().unwrap().data.into(),
-            v: Some(info.tx.extract_chain_id().unwrap().into()),
-            r: Some(U256::zero()),
-            s: Some(U256::zero()),
-            raw: None,
-            transaction_type: {
-                let tx_type = match info.tx.common_data.transaction_type {
-                    zksync_types::l2::TransactionType::LegacyTransaction => 0,
-                    zksync_types::l2::TransactionType::EIP2930Transaction => 1,
-                    zksync_types::l2::TransactionType::EIP1559Transaction => 2,
-                    zksync_types::l2::TransactionType::EIP712Transaction => 113,
-                    zksync_types::l2::TransactionType::PriorityOpTransaction => 255,
-                };
-                Some(tx_type.into())
-            },
-            access_list: None,
-            max_fee_per_gas: Some(info.tx.common_data.fee.max_fee_per_gas),
-            max_priority_fee_per_gas: Some(info.tx.common_data.fee.max_priority_fee_per_gas),
-            chain_id: info.tx.extract_chain_id().unwrap().into(),
-            l1_batch_number: Some(U64::from(info.batch_number as u64)),
-            l1_batch_tx_index: None,
-        });
-
-        Ok(tx).into_boxed_future()
     }
 
     fn get_transaction_by_block_hash_and_index(

--- a/src/node.rs
+++ b/src/node.rs
@@ -856,9 +856,9 @@ impl EthNamespaceT for InMemoryNode {
             gas_price: Default::default(),
             gas: Default::default(),
             input: info.tx.common_data.input.clone().unwrap().data.into(),
-            v: Default::default(),
-            r: Default::default(),
-            s: Default::default(),
+            v: Some(info.tx.extract_chain_id().unwrap().into()),
+            r: Some(U256::zero()),
+            s: Some(U256::zero()),
             raw: None,
             transaction_type: {
                 let tx_type = match info.tx.common_data.transaction_type {

--- a/src/node.rs
+++ b/src/node.rs
@@ -856,11 +856,9 @@ impl EthNamespaceT for InMemoryNode {
             gas_price: Default::default(),
             gas: Default::default(),
             input: info.tx.common_data.input.clone().unwrap().data.into(),
-            v: Some(U64::from_big_endian(&info.tx.common_data.signature[0..8])),
-            r: Some(U256::from_big_endian(&info.tx.common_data.signature[8..40])),
-            s: Some(U256::from_big_endian(
-                &info.tx.common_data.signature[40..72],
-            )),
+            v: Default::default(),
+            r: Default::default(),
+            s: Default::default(),
             raw: None,
             transaction_type: {
                 let tx_type = match info.tx.common_data.transaction_type {


### PR DESCRIPTION
# What :computer: 
* Implementation of `get_transaction_by_hash` RPC endpoint

# Why :hand:
* Some operations done in the [zksync-era Rust SDK](https://github.com/lambdaclass/zksync-web3-rs) need the implementation of this method to get the transaction receipts.

# Evidence :camera:
This video demonstrates a test for contract deployment using the `era-test-node` with the `Rust SDK`. The deployment process completes successfully once it can retrieve the transaction receipt. The receipt is obtained using the `get_transaction_by_hash` endpoint and then printed in the console.

https://github.com/matter-labs/era-test-node/assets/63374472/99fc9d45-dd70-47a0-8a40-d12604983a4e



<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* This implementation may be incorrect and not entirely accurate. I used the other implementations as a reference.
