### PR TITLE
Db/handle panics api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ rebuild-contracts:
 rust-build:
 	cargo build --release
 
+# Build the Rust documentation
+rust-doc:
+	cargo doc --no-deps --open
+
 # Lint checks for Rust code
 lint:
 	cargo fmt --all -- --check

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,7 +234,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     if !transactions_to_replay.is_empty() {
-        node.apply_txs(transactions_to_replay);
+        let _ = node.apply_txs(transactions_to_replay);
     }
 
     println!("\nRich Accounts");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,47 @@
+//! zkSync Era In-Memory Node
+//!
+//! The `era-test-node` crate provides an in-memory node designed primarily for local testing.
+//! It supports forking the state from other networks, making it a valuable tool for integration testing,
+//! bootloader and system contract testing, and prototyping.
+//!
+//! ## Overview
+//!
+//! - **In-Memory Database**: The node uses an in-memory database for storing state information,
+//!   and employs simplified hashmaps for tracking blocks and transactions.
+//!
+//! - **Forking**: In fork mode, the node fetches missing storage data from a remote source if not available locally.
+//!
+//! - **Remote Server Interaction**: The node can use the remote server (openchain) to resolve the ABI and topics
+//!   to human-readable names.
+//!
+//! - **Local Testing**: Designed for local testing, this node is not intended for production use.
+//!
+//! ## Features
+//!
+//! - Fork the state of mainnet, testnet, or a custom network.
+//! - Replay existing mainnet or testnet transactions.
+//! - Use local bootloader and system contracts.
+//! - Operate deterministically in non-fork mode.
+//! - Start quickly with pre-configured 'rich' accounts.
+//! - Resolve names of ABI functions and Events using openchain.
+//!
+//! ## Limitations
+//!
+//! - No communication between Layer 1 and Layer 2.
+//! - Many APIs are not yet implemented.
+//! - No support for accessing historical data.
+//! - Only one transaction allowed per Layer 1 batch.
+//! - Fixed values returned for zk Gas estimation.
+//!
+//! ## Usage
+//!
+//! To start the node, use the command `era_test_node run`. For more advanced functionalities like forking or
+//! replaying transactions, refer to the official documentation.
+//!
+//! ## Contributions
+//!
+//! Contributions to improve `era-test-node` are welcome. Please refer to the contribution guidelines for more details.
+
 use clap::{Parser, Subcommand};
 use configuration_api::ConfigurationApiNamespaceT;
 use fork::ForkDetails;

--- a/src/node.rs
+++ b/src/node.rs
@@ -887,13 +887,9 @@ impl EthNamespaceT for InMemoryNode {
             let tx_result = reader.tx_results.get(&hash);
 
             Ok(tx_result.and_then(|info| {
-                let input_data = info.tx.common_data.input.clone().or_else(|| {
-                    return None;
-                })?;
+                let input_data = info.tx.common_data.input.clone().or(None)?;
 
-                let chain_id = info.tx.extract_chain_id().or_else(|| {
-                    return None;
-                })?;
+                let chain_id = info.tx.extract_chain_id().or(None)?;
 
                 Some(zksync_types::api::Transaction {
                     hash,


### PR DESCRIPTION
⚠️ I attempted to follow the same error responses as zkSync Era [here](https://github.com/matter-labs/zksync-era/blob/main/core/bin/zksync_core/src/api_server/web3/namespaces/eth.rs).

# What :computer: 
* Replaces `unwrap()` in `node.rs` to handle panics
* Makes use of `Web3Error` for returning errors to _attempt_ to follow zkSync Era API
* Documents each implemented `node.rs` API
* Adds crate-level documentation to `main.rs` 
* Adds new makefile command `make rust-doc` which compiles, builds and opens rust docs page

# Why :hand:
* Handling the `unwrap()`'s to prevent the node from panics 
* Tried to keep parity between zkSync Era API and `node.rs` API. Although lots of more work is need here :)
* Inline documentation for readability and future devs
* First page shown in rust docs, provides description of the crate, and features
* Make it easy to spin up rust docs 

# Evidence :camera:

Crate documentation with `make rust-docs`: 
<img width="1454" alt="Screenshot 2023-08-03 at 4 44 42 PM" src="https://github.com/matter-labs/era-test-node/assets/29983536/15fab461-2ada-4fef-a09a-e9835a471d9e">

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
