### PR TITLE
Update default l1 gas price value, add CLI arg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,11 @@ struct Cli {
     #[arg(long)]
     /// If true, will load the locally compiled system contracts (useful when doing changes to system contracts or bootloader)
     dev_use_local_contracts: bool,
+
+    #[arg(long)]
+    /// Whether to override the l1 gas price.
+    /// If not set - fork or default value(`1 gwei`) will be used.
+    override_l1_gas_price: Option<u64>,
 }
 
 #[derive(Debug, Parser, Clone, clap::ValueEnum, PartialEq, Eq)]
@@ -170,10 +175,11 @@ struct ForkArgs {
     ///  - http://XXX:YY
     network: String,
     #[arg(long)]
-    // Fork at a given L2 miniblock height.
-    // If not set - will use the current finalized block from the network.
+    /// Fork at a given L2 miniblock height.
+    /// If not set - will use the current finalized block from the network.
     fork_at: Option<u64>,
 }
+
 #[derive(Debug, Parser)]
 struct ReplayArgs {
     /// Whether to fork from existing network.
@@ -228,6 +234,7 @@ async fn main() -> anyhow::Result<()> {
 
     let node = InMemoryNode::new(
         fork_details,
+        opt.override_l1_gas_price,
         opt.show_calls,
         opt.resolve_hashes,
         opt.dev_use_local_contracts,


### PR DESCRIPTION
# What :computer: 
* The default l1 gas price value was changed from 50 gwei to 1 gwei
* CLI argument to set the l1 gas price was added

# Why :hand:
With the l1 gas price of 50 gwei, the gas price per pubdata is 17 * 50*10^9 / 250000000 = 3400. It means that we can publish only 80*10^6 / 3400 ~ 23529 bytes of the pubdata in one tx(with 80*10^6 gas limit). That's definitely not enough for the tests, usually, contracts are bigger. Also, the possible solution was to increase the gas limit instead, as I know, that's allowed to have a bigger gas limit when the gas is spent on the pubdata, but it can cause issues when the transaction wants to spend more on computation. I think it makes sense to think about it when the gas limit estimation will be implemented.