### PR TITLE
Add debugging configurations for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ etc/system-contracts/bootloader/build
 etc/**/*.zbin
 .vscode/*
 !.vscode/extensions.json
+!.vscode/launch.json
+!.vscode/tasks.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,7 +42,7 @@
                 "ZKSYNC_HOME": "${workspaceFolder}"
             },
             "args": ["--dev-use-local-contracts", "run"],
-            "preLaunchTask": "compile-yul-preprocess",
+            "preLaunchTask": "rebuild-contracts",
             "cwd": "${workspaceFolder}"
         },
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,49 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug era_test_node",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=era_test_node",
+                    "--package=era_test_node"
+                ],
+                "filter": {
+                    "name": "era_test_node",
+                    "kind": "bin"
+                }
+            },
+            "args": ["run"],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug era_test_node w/ system-contracts",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=era_test_node",
+                    "--package=era_test_node"
+                ],
+                "filter": {
+                    "name": "era_test_node",
+                    "kind": "bin"
+                }
+            },
+            "env": {
+                "RUST_LOG": "vm=trace",
+                "ZKSYNC_HOME": "${workspaceFolder}"
+            },
+            "args": ["--dev-use-local-contracts", "run"],
+            "preLaunchTask": "compile-yul-preprocess",
+            "cwd": "${workspaceFolder}"
+        },
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,8 +5,6 @@
         "command": "make rebuild-contracts",
         "type": "shell",
         "presentation": {
-            "reveal": "silent",
-            "revealProblems": "onProblem",
             "close": true
         }
     }]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    "version": "2.0.0",
+    "tasks": [{
+        "label": "compile-yul-preprocess",
+        "command": "cd etc/system-contracts && yarn preprocess && yarn hardhat run ./scripts/compile-yul.ts && cd ../..",
+        "type": "shell",
+        "presentation": {
+            "reveal": "silent",
+            "revealProblems": "onProblem",
+            "close": true
+        }
+    }]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,8 +1,8 @@
 {
     "version": "2.0.0",
     "tasks": [{
-        "label": "compile-yul-preprocess",
-        "command": "cd etc/system-contracts && yarn preprocess && yarn hardhat run ./scripts/compile-yul.ts && cd ../..",
+        "label": "rebuild-contracts",
+        "command": "make rebuild-contracts",
         "type": "shell",
         "presentation": {
             "reveal": "silent",


### PR DESCRIPTION
# What :computer: 
* Add debugging configurations for VSCode

# Why :hand:
* To make debugging the application a one-click process (especially if you want to debug local contracts)

# Evidence :camera:

https://github.com/matter-labs/era-test-node/assets/1890113/28c43f24-2efb-4227-a9ed-33a486fd7fdb


