### PR TITLE
ci: adds release workflow for automated draft releases

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -3,6 +3,8 @@ name: checks
 on:
   push:
     branches: [main]
+    tags:
+      - '*'
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     tags:
-      - '*'
+      - 'v*'
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -23,7 +23,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v1.3.0
+        uses: Swatinem/rust-cache@v2
 
       - name: Run Linters
         run: |
@@ -46,7 +46,7 @@ jobs:
           toolchain: stable
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v1.3.0
+        uses: Swatinem/rust-cache@v2
 
       - name: Build Code
         run: make all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
     strategy:
       matrix:
         # TODO: fix and add aarch64-unknown-linux-gnu target
+        # See: https://github.com/matter-labs/era-test-node/issues/56
         arch: [x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
         include:
           -   arch: x86_64-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,164 @@
+# This workflow is borrowed from reth, which is borrowed from Lighthouse: https://github.com/sigp/lighthouse/blob/693886b94176faa4cb450f024696cb69cda2fe58/.github/workflows/release.yml
+# This workflow is borrowed from reth: https://github.com/paradigmxyz/reth/blob/500b0fac135fe07635d871d64467326599e2b27e/.github/workflows/release.yml
+
+on:
+ push:
+    tags:
+      - v*
+ workflow_run:
+    workflows: ["checks", "tests"]
+    types:
+      - completed
+
+env:
+  REPO_NAME: ${{ github.repository_owner }}/era-test-node
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Requires the tests and checks workflow to have completed successfully.
+  prerequisite-check:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - run: echo "Both checks and tests have passed!"
+  extract-version:
+    needs: [prerequisite-check]
+    name: extract version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version
+        run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
+        id: extract_version
+    outputs:
+      VERSION: ${{ steps.extract_version.outputs.VERSION }}
+
+  build:
+    name: build release
+    strategy:
+      matrix:
+        # TODO: fix and add aarch64-unknown-linux-gnu
+        arch: [x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
+        include:
+          -   arch: x86_64-unknown-linux-gnu
+              platform: ubuntu-20.04
+          -   arch: x86_64-apple-darwin
+              platform: macos-latest
+          -   arch: aarch64-apple-darwin
+              platform: macos-latest
+
+    runs-on: ${{ matrix.platform }}
+    needs: [prerequisite-check, extract-version]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+      - name: Install target
+        run: rustup target add ${{ matrix.arch }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      # ==============================
+      #       Builds
+      # ==============================
+      - name: Build era-test-node for ${{ matrix.arch }}
+        run: |
+          cargo install cross
+          make build-${{ matrix.arch }}
+    
+      - name: Rename and move binary
+        run: |      
+          mkdir artifacts
+          mv target/${{ matrix.arch }}/release/era_test_node ./artifacts
+      
+      - name: Create artifacts
+        run: |
+          cd artifacts
+          tar -czf era_test_node-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz era_test_node*
+          mv *tar.gz* ..
+    
+        # =======================================================================
+        # Upload artifacts
+        # This is required to share artifacts between different jobs
+        # =======================================================================
+      - name:  Upload artifact
+        uses:  actions/upload-artifact@v3
+        with:
+          name: era_test_node-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
+          path: era_test_node-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
+
+      - name: Upload signature
+        uses: actions/upload-artifact@v3
+        with:
+          name: era_test_node-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz.asc
+          path: era_test_node-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz.asc
+
+  draft-release:
+    name: draft release
+    needs:  [build, extract-version]
+    runs-on: ubuntu-latest
+    env:
+      VERSION:  ${{ needs.extract-version.outputs.VERSION }}
+    permissions:
+      # Required to post the release
+      contents: write
+    steps:
+      # This is necessary for generating the changelog. It has to come before "Download Artifacts" or else it deletes the artifacts.
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # ==============================
+      #       Download artifacts
+      # ==============================
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+
+      # ==============================
+      #       Create release draft
+      # ==============================
+      - name: Generate full changelog
+        id: changelog
+        run: |
+          echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
+          echo "$(git log --pretty=format:"- %s" $(git describe --tags --abbrev=0 ${{ env.VERSION }}^)..${{ env.VERSION }})" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create release draft
+        env:
+          GITHUB_USER: ${{ github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        # The formatting here is borrowed from reth which borrowed it from Lighthouse (which is borrowed from OpenEthereum): https://github.com/openethereum/openethereum/blob/main/.github/workflows/build.yml
+        run: |
+          body=$(cat <<- "ENDBODY"
+          # Release: <Release Name>
+          
+          ## 📋 Summary
+          
+          - 🐛 **Critical Bug Fixes:** 
+          - ✨ **New Features:** 
+          - ⚠️ **Breaking Changes:**
+          
+          ## 📜 All Changes
+          
+          ${{ steps.changelog.outputs.CHANGELOG }}
+          
+          ## 📥 Binaries
+          
+          | System | Architecture | Binary |
+          |:---:|:---:|:---:|
+          | <img src="https://simpleicons.org/icons/linux.svg" style="width: 32px;"/> | x86_64 | [era-test-node-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/era_test_node-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz) | 
+          | <img src="https://simpleicons.org/icons/apple.svg" style="width: 32px;"/> | x86_64 | [era-test-node-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/era_test_node-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz) | 
+          | <img src="https://simpleicons.org/icons/apple.svg" style="width: 32px;"/> | aarch64 | [era-test-node-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/era_test_node-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz) |
+          | | | | 
+          ENDBODY
+          )
+          assets=()
+          for asset in ./era_test_node-*.tar.gz*; do
+              assets+=("-a" "$asset/$asset")
+          done
+          tag_name="${{ env.VERSION }}"
+          echo "$body" | hub release create --draft "${assets[@]}" -F "-" "$tag_name"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,24 +5,13 @@ on:
  push:
     tags:
       - v*
- workflow_run:
-    workflows: ["checks", "tests"]
-    types:
-      - completed
 
 env:
   REPO_NAME: ${{ github.repository_owner }}/era-test-node
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Requires the tests and checks workflow to have completed successfully.
-  prerequisite-check:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
-    steps:
-      - run: echo "Both checks and tests have passed!"
   extract-version:
-    needs: [prerequisite-check]
     name: extract version
     runs-on: ubuntu-latest
     steps:
@@ -47,7 +36,7 @@ jobs:
               platform: macos-latest
 
     runs-on: ${{ matrix.platform }}
-    needs: [prerequisite-check, extract-version]
+    needs: [extract-version]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -138,9 +127,9 @@ jobs:
           
           ## 📋 Summary
           
-          - 🐛 **Critical Bug Fixes:** 
-          - ✨ **New Features:** 
-          - ⚠️ **Breaking Changes:**
+          🐛 **Critical Bug Fixes:** 
+          ✨ **New Features:** 
+          ⚠️ **Breaking Changes:**
           
           ## 📜 All Changes
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
-# This workflow is borrowed from reth, which is borrowed from Lighthouse: https://github.com/sigp/lighthouse/blob/693886b94176faa4cb450f024696cb69cda2fe58/.github/workflows/release.yml
-# This workflow is borrowed from reth: https://github.com/paradigmxyz/reth/blob/500b0fac135fe07635d871d64467326599e2b27e/.github/workflows/release.yml
+# This workflow is borrowed from reth, which is borrowed from Lighthouse: 
+# reth: https://github.com/paradigmxyz/reth/blob/500b0fac135fe07635d871d64467326599e2b27e/.github/workflows/release.yml
+# lighthouse: https://github.com/sigp/lighthouse/blob/693886b94176faa4cb450f024696cb69cda2fe58/.github/workflows/release.yml
+
+name: release
 
 on:
  push:
@@ -25,7 +28,7 @@ jobs:
     name: build release
     strategy:
       matrix:
-        # TODO: fix and add aarch64-unknown-linux-gnu
+        # TODO: fix and add aarch64-unknown-linux-gnu target
         arch: [x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
         include:
           -   arch: x86_64-unknown-linux-gnu

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,11 +4,10 @@ on:
   push:
     branches: [main]
     tags:
-      - '*'
+      - 'v*'
   pull_request:
     branches: [main]
   workflow_dispatch:
-
 jobs:
   test:
     name: unit-tests
@@ -27,7 +26,7 @@ jobs:
         toolchain: stable
 
     - name: Cache Rust Dependencies
-      uses: Swatinem/rust-cache@v1.3.0
+      uses: Swatinem/rust-cache@v2
     
     - name: Install cargo-nextest
       run: cargo +stable install cargo-nextest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,8 @@ name: run
 on:
   push:
     branches: [main]
+    tags:
+      - '*'
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,6 @@
+# Cross.toml
+
+[build]
+pre-build = [
+    "apt-get update && apt-get install --assume-yes apt-utils --no-install-recommends pkg-config libssl-dev libsasl2-dev llvm-dev libclang-6.0-dev clang-6.0"
+]

--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,4 @@ all: build-contracts rust-build
 # Clean everything
 clean: clean-contracts
 
-.PHONY: build-contracts clean-contracts rebuild-contracts rust-build lint test all clean
+.PHONY: build-contracts clean-contracts rebuild-contracts rust-build lint test all clean build-%

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ rebuild-contracts:
 rust-build:
 	cargo build --release
 
+# Build the Rust project for a specific target. Primarily used for CI.
+build-%:
+	cross build --bin era_test_node --target $* --release
+
 # Build the Rust documentation
 rust-doc:
 	cargo doc --no-deps --open

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,40 @@
+## Overview: `release.yaml`
+
+The release pipeline is aimed at automating the creation of GitHub releases, ensuring consistency and efficiency in our delivery process. The workflow is inspired by practices from [reth](https://github.com/paradigmxyz/reth/blob/main/.github/workflows/release.yml) and  [Lighthouse](https://github.com/sigp/lighthouse/blob/693886b94176faa4cb450f024696cb69cda2fe58/.github/workflows/release.yml).
+
+### Release Workflow
+
+1. **Extract version**: The workflow extracts the version from the Git tag. The Git tag is being used to trigger the workflow.
+2. **Build**: A matrix build is executed to generate binaries for multiple architectures.
+3. **Draft Release**: A release draft is prepared with an automatically generated changelog and attached binaries.
+
+### First Run
+
+On the first execution of this workflow, the "All Changes" section of the release draft will be empty. This behaviour occurs because the action fetches commits between tags. Since there will be no prior tag for the first run, it does not populate this section. However, for subsequent runs, this section will feature all commits up to the given tag. The first run we will have to do so manually by running `git log main --oneline` and adding the commits. 
+
+### Draft Release
+
+The workflow creates a **draft release** instead of a public one. This approach is intentional. It allows us to:
+
+- Add any additional commentary.
+- Ensure checks and test CI jobs pass successfully.
+- Prepare announcements or tweets related to the release prior to the release. 
+- Ensure it works as intended, and all the changes intended are present.
+  
+Once the draft is reviewed and any required changes are made, we can finalize and create the release accordingly. 
+
+**Note:** The binaries links in the table will not resolve until the release is made. That is, when a release is in "draft" form on GitHub, it is given an untagged-... URL. So when the release is made it will be tagged with the corresponding tag. 
+
+### Triggering the Release Pipeline
+
+To trigger the release pipeline, you'll need to create and push a Git tag. Here are the commands:
+
+```bash
+# Create a tag
+git tag -a v[VERSION_NUMBER] -m "Release v[VERSION_NUMBER]"
+
+# Push the tag to the repository
+git push origin v[VERSION_NUMBER]
+```
+
+Replace `[VERSION_NUMBER]` with the desired version number. This will trigger the `check.yaml` and `test.yaml` workflows, and `release.yaml`.


### PR DESCRIPTION
# What :computer: 
* Adds `release.yaml` to the CI
* Adds push tag workflow trigger for check and test workflows
* Updates ci deps for rust cache
* Adds make command
* Adds a `Cross.toml` file for `release.yaml` workflow

# Why :hand:
* Automates the preparation of binaries for multiple targets and drafts a release. 
* When we push a tag (e.g. `v0.0.1-alpha`) it will trigger the test, checks, and release workflows 
* Outdated CI dep 
* `make rust-<target>` command added to makefile for ci convenience and readability 
* Toml file is used for cross configuration in the ci. See docs here: [cross](https://github.com/cross-rs/cross#option-2-configuring-cross-via-a-crosstoml-file) 

# Evidence :camera:
The release will be presented as such 👇 :

<img width="884" alt="release" src="https://github.com/matter-labs/era-test-node/assets/29983536/16ba027c-fa54-450c-9218-7ce3fc23ee22">
<img width="928" alt="release2" src="https://github.com/matter-labs/era-test-node/assets/29983536/f0d745d7-4320-4b53-889c-52505bf2bcbb">

# Notes :memo:
Specifics on the release workflow 👇 

## Overview: `release.yaml`

This PR introduces a new release pipeline aimed at automating the creation of GitHub releases, ensuring consistency and efficiency in our delivery process. The workflow is inspired by practices from [reth](https://github.com/paradigmxyz/reth/blob/main/.github/workflows/release.yml) and  [Lighthouse](https://github.com/sigp/lighthouse/blob/693886b94176faa4cb450f024696cb69cda2fe58/.github/workflows/release.yml).

### Release Workflow

1. **Extract version**: The workflow extracts the version from the Git tag. The Git tag is being used to trigger the workflow.
2. **Build**: A matrix build is executed to generate binaries for multiple architectures.
3. **Draft Release**: A release draft is prepared with an automatically generated changelog and attached binaries.

### First Run

On the first execution of this workflow, the "All Changes" section of the release draft will be empty. This behaviour occurs because the action fetches commits between tags. Since there will be no prior tag for the first run, it does not populate this section. However, for subsequent runs, this section will feature all commits up to the given tag. The first run we will have to do so manually by running `git log main --oneline` and adding the commits. 

### Draft Release

The workflow creates a **draft release** instead of a public one. This approach is intentional. It allows us to:

- Add any additional commentary.
- Ensure checks and test CI jobs pass successfully.
- Prepare announcements or tweets related to the release prior to the release. 
- Ensure it works as intended, and all the changes intended are present.
  
Once the draft is reviewed and any required changes are made, we can finalize and create the release accordingly. 

**Note:** The binaries links in the table will not resolve until the release is made. That is, when a release is in "draft" form on GitHub, it is given an untagged-... URL. So when the release is made it will be tagged with the corresponding tag. 

### Triggering the Release Pipeline

To trigger the release pipeline, you'll need to create and push a Git tag. Here are the commands:

```bash
# Create a tag
git tag -a v[VERSION_NUMBER] -m "Release v[VERSION_NUMBER]"

# Push the tag to the repository
git push origin v[VERSION_NUMBER]
```

Replace `[VERSION_NUMBER]` with the desired version number. This will trigger the `check.yaml` and `test.yaml` workflows, and `release.yaml`.
