### PR TITLE
ci: publishes crate to crates.io once a release is published

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,16 +9,33 @@ jobs:
     name: crates.io
     runs-on: ubuntu-latest
     steps:
+      # Checkout the release tag
+      # This will publish the tag version to crates.io
     - name: Checkout sources
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.release.tag_name }}
+        token: ${{ secrets.GITHUB_TOKEN }}
       
+      # Note: This is a placeholder until proper user is set up with correct permissoins
+      # It is this "user" that will either open a PR or push directly to main with the updated version
+    - name: Set up Git user
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+      # We can standardize or customize the commit message here
     - name: Update Cargo.toml version
       run: |
         chmod +x ./update_version.sh
         ./update_version.sh "${{ github.event.release.tag_name }}"
-      
+        git add Cargo.toml
+        git commit -m "Bump version to ${{ github.event.release.tag_name }}"
+     # Note: Right now this is pushing directly to main, but we can change this to open a PR instead.
+     # If PR is desirable the action will install github cli and then run `gh pr create --title "Bump version to ${{ github.event.release.tag_name }}" --body "Updated Cargo.toml version" --base main --head $BRANCH_NAME` 
+    - name: Push to main
+      run: git push origin HEAD:main
+     # Publish to crates.io
+     # NOTE: we need the org to provide a token for this to work 
     - name: Publish to crates.io
       run: cargo publish
       env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,20 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-to-crates:
+    name: crates.io
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.release.tag_name }}
+      
+    - name: Publish to crates.io
+      run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,11 @@ jobs:
       with:
         ref: ${{ github.event.release.tag_name }}
       
+    - name: Update Cargo.toml version
+      run: |
+        chmod +x ./update_version.sh
+        ./update_version.sh "${{ github.event.release.tag_name }}"
+      
     - name: Publish to crates.io
       run: cargo publish
       env:

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Extract version from tag
+VERSION="$1"
+# If tag has a 'v' prefix, remove it
+if [[ $VERSION == v* ]]; then
+    VERSION=${VERSION:1}
+fi
+
+# Update Cargo.toml with the version extracted from the tag
+sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml


### PR DESCRIPTION
⚠️ This is in a DRAFT state as I do not have permissions to create a `CARGO_REGISTRY_TOKEN` on behalf of matter labs on crates.io. This will remain in a DRAFT state until the secret has been added to the repo. 

# What :computer: 
* Github action for automating the publishing of era_test_node to crates.io once a release has been published.

# Why :hand:
* Consistent publishing of crate to crates.io is good

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:

This is the second part of the automated release pipeline. Once a release is published (draft release is created via `release.yml`), this action will trigger. The intended functionality is to do the following:

- Checkout the release tag branch
- Run the `update_version` script to bump the Cargo.toml version to reflect the tag 
- Configure a bot user to either update `main` with updated Cargo.toml version or open a PR that we can approve and merge accordingly. This is a decision we need to make. 
- Publish tag version to crates.io 

This completes the automated release pipeline for `era_test_node` at this time. An request has been made to the org to provide the required crates.io token as we do not have the appropriate permissions. See linear ticket [here](https://linear.app/matterlabs/issue/ITS-165/request-for-matter-labs-org-cratesio-registry-token). CC: @MexicanAce 
