### PR TITLE
chore: Update version of rust crate to match latest GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
           
           ## 📋 Summary
           
-          🐛 **Critical Bug Fixes:** 
+          🐛 **Bug Fixes:** 
           ✨ **New Features:** 
           ⚠️ **Breaking Changes:**
           

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,7 +1712,7 @@ checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "era_test_node"
-version = "1.0.3"
+version = "0.0.1-alpha"
 dependencies = [
  "anyhow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "1.0.3"
+version = "0.0.1-alpha"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"

--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,11 @@ all: build-contracts rust-build
 # Clean everything
 clean: clean-contracts
 
-.PHONY: build-contracts clean-contracts rebuild-contracts rust-build lint test all clean build-%
+# Create new draft release based on Cargo.toml version
+new-release-tag:
+	@VERSION_NUMBER=$$(grep '^version =' Cargo.toml | awk -F '"' '{print $$2}') && \
+	git tag -a v$$VERSION_NUMBER -m "Release v$$VERSION_NUMBER" && \
+	echo "\n\033[0;32mGit tag creation SUCCESSFUL! Use the following command to push the tag:\033[0m" && \
+	echo "git push origin v$$VERSION_NUMBER"
+
+.PHONY: build-contracts clean-contracts rebuild-contracts rust-build lint test all clean build-% new-release-tag

--- a/docs/release.md
+++ b/docs/release.md
@@ -30,11 +30,8 @@ Once the draft is reviewed and any required changes are made, we can finalize an
 To trigger the release pipeline, you'll need to create and push a Git tag. Here are the commands:
 
 ```bash
-# Create a tag
-git tag -a v[VERSION_NUMBER] -m "Release v[VERSION_NUMBER]"
-
-# Push the tag to the repository
-git push origin v[VERSION_NUMBER]
+make new-release-tag
+# Be sure to run the 'git push' command included in the output
 ```
 
-Replace `[VERSION_NUMBER]` with the desired version number. This will trigger the `check.yaml` and `test.yaml` workflows, and `release.yaml`.
+The version number comes from [Cargo.toml](../Cargo.toml). This will trigger the `check.yaml` and `test.yaml` workflows, and `release.yaml`.


### PR DESCRIPTION
# What :computer: 
* Add `new-release-tag` command to Makefile
* Update version of rust crate to match GitHub release version
* Update release template

# Why :hand:
* To better automate the management of versions and consolidate to just the `Cargo.toml` file
* Having the versions match reduces confusion for end users
* We manually removed `Critical` adjective during the latest pre-release, so adding that change here permanently

# Evidence :camera:
<img width="562" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/f91c3ac7-b3d7-447b-808f-62816e189c3f">

