### PR TITLE
chore: Bump version of Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "0.0.1-alpha"
+version = "0.1.0"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"


### PR DESCRIPTION
# What :computer: 
* Increase version in `Cargo.toml`

# Why :hand:
* To match `0.1.0` release (Releases/tags are still manually managed while awaiting automation blockers)

# Evidence :camera:
<img src="https://github.com/matter-labs/era-test-node/assets/1890113/fb01a913-7cb5-4105-9727-f7360ca0b22e" width="300px" />

