### PR TITLE
Make era-test-node a library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,7 +1712,7 @@ checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "era_test_node"
-version = "0.0.1-alpha"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "bigdecimal",

--- a/src/configuration_api.rs
+++ b/src/configuration_api.rs
@@ -8,7 +8,9 @@ use jsonrpc_derive::rpc;
 // Workspace uses
 
 // Local uses
-use crate::{formatter::ShowCalls, node::InMemoryNodeInner, ShowStorageLogs, ShowVMDetails};
+use crate::{
+    formatter::ShowCalls, node::InMemoryNodeInner, node::ShowStorageLogs, node::ShowVMDetails,
+};
 
 pub struct ConfigurationApiNamespace {
     node: Arc<RwLock<InMemoryNodeInner>>,

--- a/src/configuration_api.rs
+++ b/src/configuration_api.rs
@@ -8,7 +8,7 @@ use jsonrpc_derive::rpc;
 // Workspace uses
 
 // Local uses
-use crate::{node::InMemoryNodeInner, ShowCalls};
+use crate::{node::InMemoryNodeInner, formatter::ShowCalls};
 
 pub struct ConfigurationApiNamespace {
     node: Arc<RwLock<InMemoryNodeInner>>,

--- a/src/configuration_api.rs
+++ b/src/configuration_api.rs
@@ -8,9 +8,7 @@ use jsonrpc_derive::rpc;
 // Workspace uses
 
 // Local uses
-use crate::{
-    formatter::ShowCalls, node::InMemoryNodeInner, node::ShowStorageLogs, node::ShowVMDetails,
-};
+use crate::{node::InMemoryNodeInner, node::ShowCalls, node::ShowStorageLogs, node::ShowVMDetails};
 
 pub struct ConfigurationApiNamespace {
     node: Arc<RwLock<InMemoryNodeInner>>,

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -2,9 +2,9 @@
 use crate::resolver;
 
 use colored::Colorize;
-use serde::Deserialize;
-use std::{collections::HashMap,  str::FromStr};
 use core::fmt::Display;
+use serde::Deserialize;
+use std::{collections::HashMap, str::FromStr};
 
 use crate::fork::block_on;
 use zksync_basic_types::H160;
@@ -13,7 +13,6 @@ use vm::vm::VmPartialExecutionResult;
 use zksync_types::{vm_trace::Call, StorageLogQuery, StorageLogQueryType, VmEvent};
 
 use lazy_static::lazy_static;
-
 
 #[derive(Debug, clap::Parser, Clone, clap::ValueEnum, PartialEq, Eq)]
 pub enum ShowCalls {
@@ -42,7 +41,6 @@ impl Display for ShowCalls {
         write!(f, "{:?}", self)
     }
 }
-
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub enum ContractType {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,9 +1,10 @@
 //! Helper methods to display transaction data in more human readable way.
-use crate::{resolver, ShowCalls};
+use crate::resolver;
 
 use colored::Colorize;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::{collections::HashMap,  str::FromStr};
+use core::fmt::Display;
 
 use crate::fork::block_on;
 use zksync_basic_types::H160;
@@ -11,6 +12,36 @@ use zksync_basic_types::H160;
 use zksync_types::{vm_trace::Call, VmEvent};
 
 use lazy_static::lazy_static;
+
+
+#[derive(Debug, clap::Parser, Clone, clap::ValueEnum, PartialEq, Eq)]
+pub enum ShowCalls {
+    None,
+    User,
+    System,
+    All,
+}
+
+impl FromStr for ShowCalls {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_ref() {
+            "none" => Ok(ShowCalls::None),
+            "user" => Ok(ShowCalls::User),
+            "system" => Ok(ShowCalls::System),
+            "all" => Ok(ShowCalls::All),
+            _ => Err(()),
+        }
+    }
+}
+
+impl Display for ShowCalls {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{:?}", self)
+    }
+}
+
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub enum ContractType {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,10 +1,9 @@
 //! Helper methods to display transaction data in more human readable way.
-use crate::resolver;
+use crate::{node::ShowCalls, resolver};
 
 use colored::Colorize;
-use core::fmt::Display;
 use serde::Deserialize;
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
 
 use crate::fork::block_on;
 use zksync_basic_types::H160;
@@ -13,34 +12,6 @@ use vm::vm::VmPartialExecutionResult;
 use zksync_types::{vm_trace::Call, StorageLogQuery, StorageLogQueryType, VmEvent};
 
 use lazy_static::lazy_static;
-
-#[derive(Debug, clap::Parser, Clone, clap::ValueEnum, PartialEq, Eq)]
-pub enum ShowCalls {
-    None,
-    User,
-    System,
-    All,
-}
-
-impl FromStr for ShowCalls {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_ref() {
-            "none" => Ok(ShowCalls::None),
-            "user" => Ok(ShowCalls::User),
-            "system" => Ok(ShowCalls::System),
-            "all" => Ok(ShowCalls::All),
-            _ => Err(()),
-        }
-    }
-}
-
-impl Display for ShowCalls {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{:?}", self)
-    }
-}
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub enum ContractType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod configuration_api;
+pub mod console_log;
+pub mod deps;
+pub mod fork;
+pub mod formatter;
+pub mod node;
+pub mod resolver;
+pub mod utils;
+pub mod zks;

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@
 use clap::{Parser, Subcommand};
 use configuration_api::ConfigurationApiNamespaceT;
 use fork::ForkDetails;
+use formatter::ShowCalls;
 use zks::ZkMockNamespaceImpl;
 
 mod configuration_api;
@@ -57,7 +58,6 @@ mod resolver;
 mod utils;
 mod zks;
 
-use core::fmt::Display;
 use node::InMemoryNode;
 use zksync_core::api_server::web3::namespaces::NetNamespace;
 
@@ -186,34 +186,6 @@ struct Cli {
     #[arg(long)]
     /// If true, will load the locally compiled system contracts (useful when doing changes to system contracts or bootloader)
     dev_use_local_contracts: bool,
-}
-
-#[derive(Debug, Parser, Clone, clap::ValueEnum, PartialEq, Eq)]
-pub enum ShowCalls {
-    None,
-    User,
-    System,
-    All,
-}
-
-impl FromStr for ShowCalls {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_ref() {
-            "none" => Ok(ShowCalls::None),
-            "user" => Ok(ShowCalls::User),
-            "system" => Ok(ShowCalls::System),
-            "all" => Ok(ShowCalls::All),
-            _ => Err(()),
-        }
-    }
-}
-
-impl Display for ShowCalls {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{:?}", self)
-    }
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ use crate::node::{ShowStorageLogs, ShowVMDetails};
 use clap::{Parser, Subcommand};
 use configuration_api::ConfigurationApiNamespaceT;
 use fork::ForkDetails;
-use formatter::ShowCalls;
+use node::ShowCalls;
 use zks::ZkMockNamespaceImpl;
 
 mod configuration_api;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@
 //!
 //! Contributions to improve `era-test-node` are welcome. Please refer to the contribution guidelines for more details.
 
+use crate::node::{ShowStorageLogs, ShowVMDetails};
 use clap::{Parser, Subcommand};
 use configuration_api::ConfigurationApiNamespaceT;
 use fork::ForkDetails;
@@ -192,86 +193,6 @@ struct Cli {
     #[arg(long)]
     /// If true, will load the locally compiled system contracts (useful when doing changes to system contracts or bootloader)
     dev_use_local_contracts: bool,
-}
-
-#[derive(Debug, Parser, Clone, clap::ValueEnum, PartialEq, Eq)]
-pub enum ShowCalls {
-    None,
-    User,
-    System,
-    All,
-}
-
-impl FromStr for ShowCalls {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_ref() {
-            "none" => Ok(ShowCalls::None),
-            "user" => Ok(ShowCalls::User),
-            "system" => Ok(ShowCalls::System),
-            "all" => Ok(ShowCalls::All),
-            _ => Err(()),
-        }
-    }
-}
-
-impl Display for ShowCalls {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{:?}", self)
-    }
-}
-
-#[derive(Debug, Parser, Clone, clap::ValueEnum, PartialEq, Eq)]
-pub enum ShowStorageLogs {
-    None,
-    Read,
-    Write,
-    All,
-}
-
-impl FromStr for ShowStorageLogs {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_ref() {
-            "none" => Ok(ShowStorageLogs::None),
-            "read" => Ok(ShowStorageLogs::Read),
-            "write" => Ok(ShowStorageLogs::Write),
-            "all" => Ok(ShowStorageLogs::All),
-            _ => Err(()),
-        }
-    }
-}
-
-impl Display for ShowStorageLogs {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{:?}", self)
-    }
-}
-
-#[derive(Debug, Parser, Clone, clap::ValueEnum, PartialEq, Eq)]
-pub enum ShowVMDetails {
-    None,
-    All,
-}
-
-impl FromStr for ShowVMDetails {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_ref() {
-            "none" => Ok(ShowVMDetails::None),
-            "all" => Ok(ShowVMDetails::All),
-            _ => Err(()),
-        }
-    }
-}
-
-impl Display for ShowVMDetails {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{:?}", self)
-    }
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -5,7 +5,7 @@ use crate::{
     fork::{ForkDetails, ForkStorage},
     formatter,
     utils::{adjust_l1_gas_price_for_tx, derive_gas_estimation_overhead, IntoBoxedFuture},
-    ShowCalls,
+    formatter::ShowCalls,
 };
 use colored::Colorize;
 use futures::FutureExt;

--- a/src/zks.rs
+++ b/src/zks.rs
@@ -299,9 +299,9 @@ mod tests {
         // Arrange
         let node = InMemoryNode::new(
             None,
-            crate::ShowCalls::None,
-            crate::ShowStorageLogs::None,
-            crate::ShowVMDetails::None,
+            ShowCalls::None,
+            crate::node::ShowStorageLogs::None,
+            crate::node::ShowVMDetails::None,
             false,
             false,
         );

--- a/src/zks.rs
+++ b/src/zks.rs
@@ -236,6 +236,7 @@ mod tests {
     use std::str::FromStr;
 
     use crate::node::InMemoryNode;
+    use crate::formatter::ShowCalls;
 
     use super::*;
     use zksync_basic_types::Address;
@@ -243,7 +244,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_estimate_fee() {
-        let node = InMemoryNode::new(None, crate::ShowCalls::None, false, false);
+        let node = InMemoryNode::new(None, ShowCalls::None, false, false);
         let namespace = ZkMockNamespaceImpl::new(node.get_inner());
 
         let mock_request = CallRequest {
@@ -280,7 +281,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_token_price_given_eth_should_return_price() {
         // Arrange
-        let node = InMemoryNode::new(None, crate::ShowCalls::None, false, false);
+        let node = InMemoryNode::new(None, ShowCalls::None, false, false);
         let namespace = ZkMockNamespaceImpl::new(node.get_inner());
 
         let mock_address = Address::from_str("0x0000000000000000000000000000000000000000")
@@ -296,7 +297,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_token_price_given_capitalized_link_address_should_return_price() {
         // Arrange
-        let node = InMemoryNode::new(None, crate::ShowCalls::None, false, false);
+        let node = InMemoryNode::new(None, ShowCalls::None, false, false);
         let namespace = ZkMockNamespaceImpl::new(node.get_inner());
 
         let mock_address = Address::from_str("0x40609141Db628BeEE3BfAB8034Fc2D8278D0Cc78")
@@ -312,7 +313,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_token_price_given_unknown_address_should_return_error() {
         // Arrange
-        let node = InMemoryNode::new(None, crate::ShowCalls::None, false, false);
+        let node = InMemoryNode::new(None, ShowCalls::None, false, false);
         let namespace = ZkMockNamespaceImpl::new(node.get_inner());
 
         let mock_address = Address::from_str("0x0000000000000000000000000000000000000042")

--- a/src/zks.rs
+++ b/src/zks.rs
@@ -235,8 +235,8 @@ impl ZksNamespaceT for ZkMockNamespaceImpl {
 mod tests {
     use std::str::FromStr;
 
-    use crate::formatter::ShowCalls;
     use crate::node::InMemoryNode;
+    use crate::node::ShowCalls;
 
     use super::*;
     use zksync_basic_types::Address;


### PR DESCRIPTION
# What :computer: 
* Adding lib.rs that allows other rust programs to include era-test-node as a library
* moved ShowCalls into this crate (before it was in main.rs)

# Why :hand:
* This allows other rust programs (for example forge testing) to include era test node as a library.

# Evidence :camera:
You can include era-test-node from other crates.
```
[dependencies]
era_test_node = {path = "../era-test-node"}
```