### PR TITLE
docs: Adds rust docs GitHub workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,44 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Generate rust docs
+        run: |
+          echo "Generating docs..."
+          cargo doc --no-deps
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: 'target/doc'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
# What :computer: 
* Adds rust docs GitHub workflow

# Why :hand:
* This will produce API documentation for the code, so we don't need to maintain separate docs repeating information from inline comments

# Evidence :camera:
Running `make rust-doc` locally:
<img width="1243" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/75016e98-0b50-4187-a572-5c2dfa734f69">


# Notes :memo:
* From what I've researched, there's no good way to test the publish of GitHub Pages without the workflow deployed to `main` branch
