### PR TITLE
docs: Fix file permissions for rust docs GitHub page

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,6 +35,11 @@ jobs:
         run: |
           echo "Generating docs..."
           cargo doc --no-deps
+      - name: Fix permissions
+        run: |
+          chmod -c -R +rX "target/doc/" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:


### PR DESCRIPTION
# What :computer: 
* Fix file permissions for rust docs GitHub page

# Why :hand:
* With current file permissions, we're receiving the `deployment_perms_error` during deployment of the GitHub Page. Fix outlined here: https://github.com/actions/upload-pages-artifact#file-permissions

# Evidence :camera:
No way to validate outside of a workflow from `main` branch (that I know of).

Error from current workflow:
<img width="1023" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/524faca6-899c-4a97-a9eb-9bc29955c050">

