### PR TITLE
Adding ForkSource trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,7 +1712,7 @@ checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "era_test_node"
-version = "0.0.1-alpha"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "bigdecimal",

--- a/src/configuration_api.rs
+++ b/src/configuration_api.rs
@@ -10,12 +10,12 @@ use jsonrpc_derive::rpc;
 // Local uses
 use crate::{node::InMemoryNodeInner, ShowCalls};
 
-pub struct ConfigurationApiNamespace {
-    node: Arc<RwLock<InMemoryNodeInner>>,
+pub struct ConfigurationApiNamespace<S> {
+    node: Arc<RwLock<InMemoryNodeInner<S>>>,
 }
 
-impl ConfigurationApiNamespace {
-    pub fn new(node: Arc<RwLock<InMemoryNodeInner>>) -> Self {
+impl<S> ConfigurationApiNamespace<S> {
+    pub fn new(node: Arc<RwLock<InMemoryNodeInner<S>>>) -> Self {
         Self { node }
     }
 }
@@ -50,7 +50,9 @@ pub trait ConfigurationApiNamespaceT {
     fn config_set_resolve_hashes(&self, value: bool) -> Result<bool>;
 }
 
-impl ConfigurationApiNamespaceT for ConfigurationApiNamespace {
+impl<S: std::marker::Send + std::marker::Sync + 'static> ConfigurationApiNamespaceT
+    for ConfigurationApiNamespace<S>
+{
     fn config_get_show_calls(&self) -> Result<String> {
         let reader = self.node.read().unwrap();
         Ok(reader.show_calls.to_string())

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -187,7 +187,9 @@ pub trait ForkSource {
     /// Returns the Storage value at a given index for given address.
     fn get_storage_at(&self, address: Address, idx: U256, block: Option<BlockIdVariant>) -> H256;
 
+    /// Returns the bytecode stored under this hash (if available).
     fn get_bytecode_by_hash(&self, hash: H256) -> Option<Vec<u8>>;
+    /// Returns the transaction for a given hash.
     fn get_transaction_by_hash(&self, hash: H256) -> Option<Transaction>;
 
     /// Gets all transactions that belong to a given miniblock.

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use tokio::runtime::Builder;
-use zksync_basic_types::{L1BatchNumber, L2ChainId, MiniblockNumber, H256, U64, Address, U256};
+use zksync_basic_types::{Address, L1BatchNumber, L2ChainId, MiniblockNumber, H256, U256, U64};
 
 use zksync_types::{
     api::{BlockIdVariant, BlockNumber, Transaction},
@@ -25,9 +25,9 @@ use zksync_utils::{bytecode::hash_bytecode, h256_to_u256};
 use zksync_web3_decl::{jsonrpsee::http_client::HttpClient, namespaces::EthNamespaceClient};
 use zksync_web3_decl::{jsonrpsee::http_client::HttpClientBuilder, namespaces::ZksNamespaceClient};
 
-use crate::deps::InMemoryStorage;
 use crate::deps::ReadStorage as RS;
 use crate::node::TEST_NODE_NETWORK_ID;
+use crate::{deps::InMemoryStorage, http_fork_source::HttpForkSource};
 
 pub fn block_on<F: Future + Send + 'static>(future: F) -> F::Output
 where
@@ -46,14 +46,15 @@ where
 
 /// In memory storage, that allows 'forking' from other network.
 /// If forking is enabled, it reads missing data from remote location.
+/// S - is a struct that is used for source of the fork.
 #[derive(Debug)]
-pub struct ForkStorage {
-    pub inner: Arc<RwLock<ForkStorageInner>>,
+pub struct ForkStorage<S> {
+    pub inner: Arc<RwLock<ForkStorageInner<S>>>,
     pub chain_id: L2ChainId,
 }
 
 #[derive(Debug)]
-pub struct ForkStorageInner {
+pub struct ForkStorageInner<S> {
     // Underlying local storage
     pub raw_storage: InMemoryStorage,
     // Cache of data that was read from remote location.
@@ -62,11 +63,11 @@ pub struct ForkStorageInner {
     pub factory_dep_cache: HashMap<H256, Option<Vec<u8>>>,
     // If set - it hold the necessary information on where to fetch the data.
     // If not set - it will simply read from underlying storage.
-    pub fork: Option<ForkDetails>,
+    pub fork: Option<ForkDetails<S>>,
 }
 
-impl ForkStorage {
-    pub fn new(fork: Option<ForkDetails>, dev_use_local_contracts: bool) -> Self {
+impl<S: ForkSource> ForkStorage<S> {
+    pub fn new(fork: Option<ForkDetails<S>>, dev_use_local_contracts: bool) -> Self {
         let chain_id = fork
             .as_ref()
             .and_then(|d| d.overwrite_chain_id)
@@ -100,23 +101,16 @@ impl ForkStorage {
             if let Some(value) = mutator.value_read_cache.get(key) {
                 return *value;
             }
-            let fork_ = (*fork).clone();
+            let l2_miniblock = fork.l2_miniblock;
             let key_ = *key;
 
-            let client = fork.create_client();
-
-            let result = block_on(async move {
-                client
-                    .get_storage_at(
-                        *key_.account().address(),
-                        h256_to_u256(*key_.key()),
-                        Some(BlockIdVariant::BlockNumber(BlockNumber::Number(U64::from(
-                            fork_.l2_miniblock,
-                        )))),
-                    )
-                    .await
-            })
-            .unwrap();
+            let result = fork.fork_source.get_storage_at(
+                *key_.account().address(),
+                h256_to_u256(*key_.key()),
+                Some(BlockIdVariant::BlockNumber(BlockNumber::Number(U64::from(
+                    l2_miniblock,
+                )))),
+            );
 
             mutator.value_read_cache.insert(*key, result);
             result
@@ -136,8 +130,7 @@ impl ForkStorage {
                 return value.clone();
             }
 
-            let client = fork.create_client();
-            let result = block_on(async move { client.get_bytecode_by_hash(hash).await }).unwrap();
+            let result = fork.fork_source.get_bytecode_by_hash(hash);
             mutator.factory_dep_cache.insert(hash, result.clone());
             result
         } else {
@@ -146,7 +139,7 @@ impl ForkStorage {
     }
 }
 
-impl ReadStorage for ForkStorage {
+impl<S: std::fmt::Debug + ForkSource> ReadStorage for ForkStorage<S> {
     fn is_write_initial(&mut self, key: &StorageKey) -> bool {
         let mut mutator = self.inner.write().unwrap();
         mutator.raw_storage.is_write_initial(key)
@@ -161,7 +154,7 @@ impl ReadStorage for ForkStorage {
     }
 }
 
-impl ReadStorage for &ForkStorage {
+impl<S: std::fmt::Debug + ForkSource> ReadStorage for &ForkStorage<S> {
     fn read_value(&mut self, key: &StorageKey) -> zksync_types::StorageValue {
         self.read_value_internal(key)
     }
@@ -176,7 +169,7 @@ impl ReadStorage for &ForkStorage {
     }
 }
 
-impl ForkStorage {
+impl<S> ForkStorage<S> {
     pub fn set_value(&mut self, key: StorageKey, value: zksync_types::StorageValue) {
         let mut mutator = self.inner.write().unwrap();
         mutator.raw_storage.set_value(key, value)
@@ -193,12 +186,7 @@ impl ForkStorage {
 
 pub trait ForkSource {
     /// Returns the Storage value at a given index for given address.
-    fn get_storage_at(
-        &self,
-        address: Address,
-        idx: U256,
-        block: Option<BlockIdVariant>,
-    ) -> H256;
+    fn get_storage_at(&self, address: Address, idx: U256, block: Option<BlockIdVariant>) -> H256;
 
     fn get_bytecode_by_hash(&self, hash: H256) -> Option<Vec<u8>>;
     fn get_transaction_by_hash(&self, hash: H256) -> Option<Transaction>;
@@ -210,10 +198,11 @@ pub trait ForkSource {
 }
 
 /// Holds the information about the original chain.
+/// "S" is the impmenetation of the ForkSource.
 #[derive(Debug, Clone)]
-pub struct ForkDetails {
-    // URL to the server.
-    pub fork_url: String,
+pub struct ForkDetails<S> {
+    // Source of the fork data (for example HTTPForkSoruce)
+    pub fork_source: S,
     // Block number at which we forked (the next block to create is l1_block + 1)
     pub l1_block: L1BatchNumber,
     pub l2_miniblock: u64,
@@ -222,7 +211,7 @@ pub struct ForkDetails {
     pub l1_gas_price: u64,
 }
 
-impl ForkDetails {
+impl ForkDetails<HttpForkSource> {
     pub async fn from_url_and_miniblock_and_chain(
         url: &str,
         client: HttpClient,
@@ -243,7 +232,9 @@ impl ForkDetails {
         );
 
         ForkDetails {
-            fork_url: url.to_owned(),
+            fork_source: HttpForkSource {
+                fork_url: url.to_owned(),
+            },
             l1_block: l1_batch_number,
             block_timestamp: block_details.timestamp,
             l2_miniblock: miniblock,
@@ -251,7 +242,6 @@ impl ForkDetails {
             l1_gas_price: block_details.l1_gas_price,
         }
     }
-
     /// Create a fork from a given network at a given height.
     pub async fn from_network(fork: &str, fork_at: Option<u64>) -> Self {
         let (url, client) = Self::fork_to_url_and_client(fork);
@@ -275,7 +265,9 @@ impl ForkDetails {
 
         Self::from_url_and_miniblock_and_chain(url, client, l2_miniblock, overwrite_chain_id).await
     }
+}
 
+impl<S: ForkSource> ForkDetails<S> {
     /// Return URL and HTTP client for a given fork name.
     pub fn fork_to_url_and_client(fork: &str) -> (&str, HttpClient) {
         let url = match fork {
@@ -293,18 +285,12 @@ impl ForkDetails {
 
     /// Returns transactions that are in the same L2 miniblock as replay_tx, but were executed before it.
     pub async fn get_earlier_transactions_in_same_block(&self, replay_tx: H256) -> Vec<L2Tx> {
-        let client = self.create_client();
-
-        let tx_details = client
-            .get_transaction_by_hash(replay_tx)
-            .await
-            .unwrap()
-            .unwrap();
+        let tx_details = self.fork_source.get_transaction_by_hash(replay_tx).unwrap();
         let miniblock = MiniblockNumber(tx_details.block_number.unwrap().as_u32());
 
         // And we're fetching all the transactions from this miniblock.
-        let block_transactions: Vec<zksync_types::Transaction> =
-            client.get_raw_block_transactions(miniblock).await.unwrap();
+        let block_transactions = self.fork_source.get_raw_block_transactions(miniblock);
+
         let mut tx_to_apply = Vec::new();
 
         for tx in block_transactions {
@@ -320,11 +306,5 @@ impl ForkDetails {
             "Cound not find tx {:?} in miniblock: {:?}",
             replay_tx, miniblock
         );
-    }
-
-    pub fn create_client(&self) -> HttpClient {
-        HttpClientBuilder::default()
-            .build(self.fork_url.clone())
-            .expect("Unable to create a client for fork")
     }
 }

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -183,14 +183,14 @@ impl<S> ForkStorage<S> {
 /// Trait that provides necessary data when
 /// forking a remote chain.
 /// The method signatures are similar to methods from ETHNamespace and ZKNamespace.
-
 pub trait ForkSource {
     /// Returns the Storage value at a given index for given address.
     fn get_storage_at(&self, address: Address, idx: U256, block: Option<BlockIdVariant>) -> H256;
 
     fn get_bytecode_by_hash(&self, hash: H256) -> Option<Vec<u8>>;
     fn get_transaction_by_hash(&self, hash: H256) -> Option<Transaction>;
-    // Gets all transactions that belong to a given miniblock.
+
+    /// Gets all transactions that belong to a given miniblock.
     fn get_raw_block_transactions(
         &self,
         block_number: MiniblockNumber,
@@ -198,7 +198,7 @@ pub trait ForkSource {
 }
 
 /// Holds the information about the original chain.
-/// "S" is the impmenetation of the ForkSource.
+/// "S" is the implementation of the ForkSource.
 #[derive(Debug, Clone)]
 pub struct ForkDetails<S> {
     // Source of the fork data (for example HTTPForkSoruce)

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -104,13 +104,16 @@ impl<S: ForkSource> ForkStorage<S> {
             let l2_miniblock = fork.l2_miniblock;
             let key_ = *key;
 
-            let result = fork.fork_source.get_storage_at(
-                *key_.account().address(),
-                h256_to_u256(*key_.key()),
-                Some(BlockIdVariant::BlockNumber(BlockNumber::Number(U64::from(
-                    l2_miniblock,
-                )))),
-            );
+            let result = fork
+                .fork_source
+                .get_storage_at(
+                    *key_.account().address(),
+                    h256_to_u256(*key_.key()),
+                    Some(BlockIdVariant::BlockNumber(BlockNumber::Number(U64::from(
+                        l2_miniblock,
+                    )))),
+                )
+                .unwrap();
 
             mutator.value_read_cache.insert(*key, result);
             result
@@ -130,7 +133,7 @@ impl<S: ForkSource> ForkStorage<S> {
                 return value.clone();
             }
 
-            let result = fork.fork_source.get_bytecode_by_hash(hash);
+            let result = fork.fork_source.get_bytecode_by_hash(hash).unwrap();
             mutator.factory_dep_cache.insert(hash, result.clone());
             result
         } else {
@@ -185,18 +188,23 @@ impl<S> ForkStorage<S> {
 /// The method signatures are similar to methods from ETHNamespace and ZKNamespace.
 pub trait ForkSource {
     /// Returns the Storage value at a given index for given address.
-    fn get_storage_at(&self, address: Address, idx: U256, block: Option<BlockIdVariant>) -> H256;
+    fn get_storage_at(
+        &self,
+        address: Address,
+        idx: U256,
+        block: Option<BlockIdVariant>,
+    ) -> eyre::Result<H256>;
 
     /// Returns the bytecode stored under this hash (if available).
-    fn get_bytecode_by_hash(&self, hash: H256) -> Option<Vec<u8>>;
+    fn get_bytecode_by_hash(&self, hash: H256) -> eyre::Result<Option<Vec<u8>>>;
     /// Returns the transaction for a given hash.
-    fn get_transaction_by_hash(&self, hash: H256) -> Option<Transaction>;
+    fn get_transaction_by_hash(&self, hash: H256) -> eyre::Result<Option<Transaction>>;
 
     /// Gets all transactions that belong to a given miniblock.
     fn get_raw_block_transactions(
         &self,
         block_number: MiniblockNumber,
-    ) -> Vec<zksync_types::Transaction>;
+    ) -> eyre::Result<Vec<zksync_types::Transaction>>;
 }
 
 /// Holds the information about the original chain.
@@ -287,11 +295,18 @@ impl<S: ForkSource> ForkDetails<S> {
 
     /// Returns transactions that are in the same L2 miniblock as replay_tx, but were executed before it.
     pub async fn get_earlier_transactions_in_same_block(&self, replay_tx: H256) -> Vec<L2Tx> {
-        let tx_details = self.fork_source.get_transaction_by_hash(replay_tx).unwrap();
+        let tx_details = self
+            .fork_source
+            .get_transaction_by_hash(replay_tx)
+            .unwrap()
+            .unwrap();
         let miniblock = MiniblockNumber(tx_details.block_number.unwrap().as_u32());
 
         // And we're fetching all the transactions from this miniblock.
-        let block_transactions = self.fork_source.get_raw_block_transactions(miniblock);
+        let block_transactions = self
+            .fork_source
+            .get_raw_block_transactions(miniblock)
+            .unwrap();
 
         let mut tx_to_apply = Vec::new();
 

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -11,10 +11,10 @@ use std::{
 };
 
 use tokio::runtime::Builder;
-use zksync_basic_types::{L1BatchNumber, L2ChainId, MiniblockNumber, H256, U64};
+use zksync_basic_types::{L1BatchNumber, L2ChainId, MiniblockNumber, H256, U64, Address, U256};
 
 use zksync_types::{
-    api::{BlockIdVariant, BlockNumber},
+    api::{BlockIdVariant, BlockNumber, Transaction},
     l2::L2Tx,
     StorageKey,
 };
@@ -185,6 +185,28 @@ impl ForkStorage {
         let mut mutator = self.inner.write().unwrap();
         mutator.raw_storage.store_factory_dep(hash, bytecode)
     }
+}
+
+/// Trait that provides necessary data when
+/// forking a remote chain.
+/// The method signatures are similar to methods from ETHNamespace and ZKNamespace.
+
+pub trait ForkSource {
+    /// Returns the Storage value at a given index for given address.
+    fn get_storage_at(
+        &self,
+        address: Address,
+        idx: U256,
+        block: Option<BlockIdVariant>,
+    ) -> H256;
+
+    fn get_bytecode_by_hash(&self, hash: H256) -> Option<Vec<u8>>;
+    fn get_transaction_by_hash(&self, hash: H256) -> Option<Transaction>;
+    // Gets all transactions that belong to a given miniblock.
+    fn get_raw_block_transactions(
+        &self,
+        block_number: MiniblockNumber,
+    ) -> Vec<zksync_types::Transaction>;
 }
 
 /// Holds the information about the original chain.

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -8,6 +8,7 @@ use crate::fork::{block_on, ForkSource};
 #[derive(Debug)]
 /// Fork source that gets the data via HTTP requests.
 pub struct HttpForkSource {
+    /// URL for the network to fork.
     pub fork_url: String,
 }
 
@@ -15,7 +16,10 @@ impl HttpForkSource {
     pub fn create_client(&self) -> HttpClient {
         HttpClientBuilder::default()
             .build(self.fork_url.clone())
-            .expect("Unable to create a client for fork")
+            .expect(&format!(
+                "Unable to create a client for fork: {}",
+                self.fork_url
+            ))
     }
 }
 

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -5,6 +5,7 @@ use zksync_web3_decl::{
 
 use crate::fork::{block_on, ForkSource};
 
+#[derive(Debug)]
 /// Fork source that gets the data via HTTP requests.
 pub struct HttpForkSource {
     pub fork_url: String,

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -1,3 +1,4 @@
+use eyre::Context;
 use zksync_web3_decl::{
     jsonrpsee::http_client::{HttpClient, HttpClientBuilder},
     namespaces::{EthNamespaceClient, ZksNamespaceClient},
@@ -29,29 +30,36 @@ impl ForkSource for HttpForkSource {
         address: zksync_basic_types::Address,
         idx: zksync_basic_types::U256,
         block: Option<zksync_types::api::BlockIdVariant>,
-    ) -> zksync_basic_types::H256 {
+    ) -> eyre::Result<zksync_basic_types::H256> {
         let client = self.create_client();
-        block_on(async move { client.get_storage_at(address, idx, block).await }).unwrap()
+        block_on(async move { client.get_storage_at(address, idx, block).await })
+            .wrap_err("fork http client failed")
     }
 
-    fn get_bytecode_by_hash(&self, hash: zksync_basic_types::H256) -> Option<Vec<u8>> {
+    fn get_bytecode_by_hash(
+        &self,
+        hash: zksync_basic_types::H256,
+    ) -> eyre::Result<Option<Vec<u8>>> {
         let client = self.create_client();
-        block_on(async move { client.get_bytecode_by_hash(hash).await }).unwrap()
+        block_on(async move { client.get_bytecode_by_hash(hash).await })
+            .wrap_err("fork http client failed")
     }
 
     fn get_transaction_by_hash(
         &self,
         hash: zksync_basic_types::H256,
-    ) -> Option<zksync_types::api::Transaction> {
+    ) -> eyre::Result<Option<zksync_types::api::Transaction>> {
         let client = self.create_client();
-        block_on(async move { client.get_transaction_by_hash(hash).await }).unwrap()
+        block_on(async move { client.get_transaction_by_hash(hash).await })
+            .wrap_err("fork http client failed")
     }
 
     fn get_raw_block_transactions(
         &self,
         block_number: zksync_basic_types::MiniblockNumber,
-    ) -> Vec<zksync_types::Transaction> {
+    ) -> eyre::Result<Vec<zksync_types::Transaction>> {
         let client = self.create_client();
-        block_on(async move { client.get_raw_block_transactions(block_number).await }).unwrap()
+        block_on(async move { client.get_raw_block_transactions(block_number).await })
+            .wrap_err("fork http client failed")
     }
 }

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -17,11 +17,7 @@ impl HttpForkSource {
     pub fn create_client(&self) -> HttpClient {
         HttpClientBuilder::default()
             .build(self.fork_url.clone())
-             .unwrap_or_else(|_| panic!("Unable to create a client for fork: {}",
-                 self.fork_url))
-                "Unable to create a client for fork: {}",
-                self.fork_url
-            ))
+            .unwrap_or_else(|_| panic!("Unable to create a client for fork: {}", self.fork_url))
     }
 }
 

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -1,0 +1,52 @@
+use zksync_web3_decl::{
+    jsonrpsee::http_client::{HttpClient, HttpClientBuilder},
+    namespaces::{EthNamespaceClient, ZksNamespaceClient},
+};
+
+use crate::fork::{block_on, ForkSource};
+
+/// Fork source that gets the data via HTTP requests.
+pub struct HttpForkSource {
+    pub fork_url: String,
+}
+
+impl HttpForkSource {
+    pub fn create_client(&self) -> HttpClient {
+        HttpClientBuilder::default()
+            .build(self.fork_url.clone())
+            .expect("Unable to create a client for fork")
+    }
+}
+
+impl ForkSource for HttpForkSource {
+    fn get_storage_at(
+        &self,
+        address: zksync_basic_types::Address,
+        idx: zksync_basic_types::U256,
+        block: Option<zksync_types::api::BlockIdVariant>,
+    ) -> zksync_basic_types::H256 {
+        let client = self.create_client();
+        block_on(async move { client.get_storage_at(address, idx, block).await }).unwrap()
+    }
+
+    fn get_bytecode_by_hash(&self, hash: zksync_basic_types::H256) -> Option<Vec<u8>> {
+        let client = self.create_client();
+        block_on(async move { client.get_bytecode_by_hash(hash).await }).unwrap()
+    }
+
+    fn get_transaction_by_hash(
+        &self,
+        hash: zksync_basic_types::H256,
+    ) -> Option<zksync_types::api::Transaction> {
+        let client = self.create_client();
+        block_on(async move { client.get_transaction_by_hash(hash).await }).unwrap()
+    }
+
+    fn get_raw_block_transactions(
+        &self,
+        block_number: zksync_basic_types::MiniblockNumber,
+    ) -> Vec<zksync_types::Transaction> {
+        let client = self.create_client();
+        block_on(async move { client.get_raw_block_transactions(block_number).await }).unwrap()
+    }
+}

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -17,7 +17,8 @@ impl HttpForkSource {
     pub fn create_client(&self) -> HttpClient {
         HttpClientBuilder::default()
             .build(self.fork_url.clone())
-            .expect(&format!(
+             .unwrap_or_else(|_| panic!("Unable to create a client for fork: {}",
+                 self.fork_url))
                 "Unable to create a client for fork: {}",
                 self.fork_url
             ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod console_log;
 pub mod deps;
 pub mod fork;
 pub mod formatter;
+pub mod http_fork_source;
 pub mod node;
 pub mod resolver;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@
 
 use clap::{Parser, Subcommand};
 use configuration_api::ConfigurationApiNamespaceT;
-use fork::ForkDetails;
+use fork::{ForkDetails, ForkSource};
 use zks::ZkMockNamespaceImpl;
 
 mod configuration_api;
@@ -52,11 +52,11 @@ mod console_log;
 mod deps;
 mod fork;
 mod formatter;
+mod http_fork_source;
 mod node;
 mod resolver;
 mod utils;
 mod zks;
-mod http_fork_source;
 
 use core::fmt::Display;
 use node::InMemoryNode;
@@ -128,12 +128,14 @@ pub const RICH_WALLETS: [(&str, &str); 10] = [
     ),
 ];
 
-async fn build_json_http(
+async fn build_json_http<
+    S: std::marker::Sync + std::marker::Send + 'static + ForkSource + std::fmt::Debug,
+>(
     addr: SocketAddr,
-    node: InMemoryNode,
+    node: InMemoryNode<S>,
     net: NetNamespace,
-    config_api: ConfigurationApiNamespace,
-    zks: ZkMockNamespaceImpl,
+    config_api: ConfigurationApiNamespace<S>,
+    zks: ZkMockNamespaceImpl<S>,
 ) -> tokio::task::JoinHandle<()> {
     let (sender, recv) = oneshot::channel::<()>();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ mod node;
 mod resolver;
 mod utils;
 mod zks;
+mod http_fork_source;
 
 use core::fmt::Display;
 use node::InMemoryNode;

--- a/src/node.rs
+++ b/src/node.rs
@@ -543,20 +543,7 @@ fn contract_address_from_tx_result(execution_result: &VmTxExecutionResult) -> Op
     None
 }
 
-impl Default for InMemoryNode {
-    fn default() -> Self {
-        InMemoryNode::new(
-            None,
-            crate::ShowCalls::None,
-            crate::ShowStorageLogs::None,
-            crate::ShowVMDetails::None,
-            false,
-            false,
-        )
-    }
-}
-
-impl Default for InMemoryNode {
+impl<S: ForkSource + std::fmt::Debug> Default for InMemoryNode<S> {
     fn default() -> Self {
         InMemoryNode::new(
             None,

--- a/src/zks.rs
+++ b/src/zks.rs
@@ -9,17 +9,17 @@ use zksync_core::api_server::web3::backend_jsonrpc::{
 use zksync_types::{api::BridgeAddresses, fee::Fee};
 use zksync_web3_decl::error::Web3Error;
 
-use crate::{node::InMemoryNodeInner, utils::IntoBoxedFuture};
+use crate::{fork::ForkSource, node::InMemoryNodeInner, utils::IntoBoxedFuture};
 use colored::Colorize;
 
 /// Mock implementation of ZksNamespace - used only in the test node.
-pub struct ZkMockNamespaceImpl {
-    node: Arc<RwLock<InMemoryNodeInner>>,
+pub struct ZkMockNamespaceImpl<S> {
+    node: Arc<RwLock<InMemoryNodeInner<S>>>,
 }
 
-impl ZkMockNamespaceImpl {
+impl<S> ZkMockNamespaceImpl<S> {
     /// Creates a new `Zks` instance with the given `node`.
-    pub fn new(node: Arc<RwLock<InMemoryNodeInner>>) -> Self {
+    pub fn new(node: Arc<RwLock<InMemoryNodeInner<S>>>) -> Self {
         Self { node }
     }
 }
@@ -29,7 +29,9 @@ macro_rules! not_implemented {
         Box::pin(async move { Err(jsonrpc_core::Error::method_not_found()) })
     };
 }
-impl ZksNamespaceT for ZkMockNamespaceImpl {
+impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> ZksNamespaceT
+    for ZkMockNamespaceImpl<S>
+{
     /// Estimates the gas fee data required for a given call request.
     ///
     /// # Arguments
@@ -235,7 +237,7 @@ impl ZksNamespaceT for ZkMockNamespaceImpl {
 mod tests {
     use std::str::FromStr;
 
-    use crate::node::InMemoryNode;
+    use crate::{http_fork_source::HttpForkSource, node::InMemoryNode};
 
     use super::*;
     use zksync_basic_types::Address;
@@ -243,7 +245,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_estimate_fee() {
-        let node = InMemoryNode::new(None, crate::ShowCalls::None, false, false);
+        let node = InMemoryNode::<HttpForkSource>::new(None, crate::ShowCalls::None, false, false);
         let namespace = ZkMockNamespaceImpl::new(node.get_inner());
 
         let mock_request = CallRequest {
@@ -280,7 +282,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_token_price_given_eth_should_return_price() {
         // Arrange
-        let node = InMemoryNode::new(None, crate::ShowCalls::None, false, false);
+        let node = InMemoryNode::<HttpForkSource>::new(None, crate::ShowCalls::None, false, false);
         let namespace = ZkMockNamespaceImpl::new(node.get_inner());
 
         let mock_address = Address::from_str("0x0000000000000000000000000000000000000000")
@@ -296,7 +298,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_token_price_given_capitalized_link_address_should_return_price() {
         // Arrange
-        let node = InMemoryNode::new(None, crate::ShowCalls::None, false, false);
+        let node = InMemoryNode::<HttpForkSource>::new(None, crate::ShowCalls::None, false, false);
         let namespace = ZkMockNamespaceImpl::new(node.get_inner());
 
         let mock_address = Address::from_str("0x40609141Db628BeEE3BfAB8034Fc2D8278D0Cc78")
@@ -312,7 +314,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_token_price_given_unknown_address_should_return_error() {
         // Arrange
-        let node = InMemoryNode::new(None, crate::ShowCalls::None, false, false);
+        let node = InMemoryNode::<HttpForkSource>::new(None, crate::ShowCalls::None, false, false);
         let namespace = ZkMockNamespaceImpl::new(node.get_inner());
 
         let mock_address = Address::from_str("0x0000000000000000000000000000000000000042")

--- a/src/zks.rs
+++ b/src/zks.rs
@@ -246,7 +246,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_estimate_fee() {
-        let node = InMemoryNode::default();
+        let node = InMemoryNode::<HttpForkSource>::default();
         let namespace = ZkMockNamespaceImpl::new(node.get_inner());
 
         let mock_request = CallRequest {
@@ -283,7 +283,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_token_price_given_eth_should_return_price() {
         // Arrange
-        let node = InMemoryNode::default();
+        let node = InMemoryNode::<HttpForkSource>::default();
         let namespace = ZkMockNamespaceImpl::new(node.get_inner());
 
         let mock_address = Address::from_str("0x0000000000000000000000000000000000000000")
@@ -299,7 +299,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_token_price_given_capitalized_link_address_should_return_price() {
         // Arrange
-        let node = InMemoryNode::new(
+        let node = InMemoryNode::<HttpForkSource>::new(
             None,
             ShowCalls::None,
             crate::node::ShowStorageLogs::None,
@@ -322,7 +322,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_token_price_given_unknown_address_should_return_error() {
         // Arrange
-        let node = InMemoryNode::default();
+        let node = InMemoryNode::<HttpForkSource>::default();
         let namespace = ZkMockNamespaceImpl::new(node.get_inner());
 
         let mock_address = Address::from_str("0x0000000000000000000000000000000000000042")


### PR DESCRIPTION
# What :computer: 
* Adding ForkSource trait that hides the code responsible for querying the original repository data
* Currently there is only one implementation for this ForkSource -- the HttpForkSource that fetches data over internet.

# Why :hand:
* This allows more flexibility when era-test-node is used as a library - for example for Forge, we'll be able to implement the ForkSource that uses REVM database instead.

# Evidence :camera:

<img width="650" alt="image" src="https://github.com/matter-labs/era-test-node/assets/128217157/94cfa570-6760-4ac2-86aa-33570fae4926">