### PR TITLE
fix: resolves #90 | fixes release executable and headers issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,13 @@ jobs:
       # ==============================
       #       Builds
       # ==============================
+
+      - name: Install cross from source
+        run: |
+          cargo install --git https://github.com/cross-rs/cross cross --branch main
+
       - name: Build era-test-node for ${{ matrix.arch }}
         run: |
-          cargo install cross
           make build-${{ matrix.arch }}
     
       - name: Rename and move binary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a
 zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
 zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
 zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
+openssl-sys = { version = "0.9", features = ["vendored"] }
 
 anyhow = "1.0"
 tokio = { version = "1", features = ["time", "rt"] }

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,6 +1,13 @@
 # Cross.toml
 
-[build]
+[target.x86_64-unknown-linux-gnu]
 pre-build = [
-    "apt-get update && apt-get install --assume-yes apt-utils --no-install-recommends pkg-config libssl-dev libsasl2-dev llvm-dev libclang-6.0-dev clang-6.0"
+    "export DEBIAN_FRONTEND=noninteractive",
+    "export TZ=Etc/UTC",
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt update -q",
+    "apt upgrade -yq",
+    "add-apt-repository -y ppa:savoury1/virtualisation",
+    "apt-get upgrade -yq",
+    "apt update -q && apt install --assume-yes --no-install-recommends libclang-10-dev clang-10 cmake build-essential pkg-config libssl-dev:$CROSS_DEB_ARCH libsasl2-dev llvm-dev curl gnutls-bin"
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -5,9 +5,5 @@ pre-build = [
     "export DEBIAN_FRONTEND=noninteractive",
     "export TZ=Etc/UTC",
     "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt update -q",
-    "apt upgrade -yq",
-    "add-apt-repository -y ppa:savoury1/virtualisation",
-    "apt-get upgrade -yq",
-    "apt update -q && apt install --assume-yes --no-install-recommends libclang-10-dev clang-10 cmake build-essential pkg-config libssl-dev:$CROSS_DEB_ARCH libsasl2-dev llvm-dev curl gnutls-bin"
+    "apt update -q && apt upgrade -yq && apt install --assume-yes --no-install-recommends libclang-10-dev clang-10 cmake build-essential pkg-config libssl-dev:$CROSS_DEB_ARCH libsasl2-dev llvm-dev gnutls-bin"
 ]


### PR DESCRIPTION
# What :computer: 
* Installs cross from source
* Adds req deps to `Cross.toml` and `Cargo.toml`

# Why :hand:
* Installing cross from source provides newest image for `x86_64-unknown-linux-gnu`
* Updated `Cross.toml` to include new required deps from rocksdb version update to `0.21.0` 
* Adds `openssl-sys` vendored copy so binary can be distributed with openssl so it can be executable without installing additional deps

# Evidence :camera:

**Release pipeline succeeding from fork:**
<img width="972" alt="CleanShot 2023-09-05 at 17 08 32@2x" src="https://github.com/matter-labs/era-test-node/assets/29983536/253edd71-6f55-44cc-b254-3aef2f21bd47">

**x86_64-unknown-linux-gnu libraries available:**
<img width="767" alt="CleanShot 2023-09-05 at 17 08 52@2x" src="https://github.com/matter-labs/era-test-node/assets/29983536/155ed4ab-12bd-475c-a13b-599a79434b0b">

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
Closes #90 
