### PR TITLE
chore: fix permissions for e2e test results

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,11 @@ name: Testing era_test_node using e2e
 on:
   workflow_call:
 
+permissions:
+  statuses: write
+  checks: write
+  actions: write
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# What :computer: 
* Fix permissions for e2e test results

# Why :hand:
* E2E tests are failing with `Error: HttpError: Resource not accessible by integration`

# Evidence :camera:
See checks for this PR
