### PR TITLE
feature: display the revert reason when calls or gas estimations fail

### DIFF
--- a/e2e-tests/contracts/Greeter.sol
+++ b/e2e-tests/contracts/Greeter.sol
@@ -1,9 +1,10 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "hardhat/console.sol";
 
-contract Greeter {
+contract Greeter is Ownable {
     string private greeting;
 
     constructor(string memory _greeting) {
@@ -14,7 +15,7 @@ contract Greeter {
         return greeting;
     }
 
-    function setGreeting(string memory _greeting) public {
+    function setGreeting(string memory _greeting) public onlyOwner {
         console.log("setGreeting called");
         console.log(_greeting);
         require(

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -8,6 +8,7 @@
     "@matterlabs/hardhat-zksync-deploy": "^0.6.3",
     "@matterlabs/hardhat-zksync-solc": "^0.4.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
+    "@openzeppelin/contracts": "^4.9.3",
     "@types/chai": "^4.3.4",
     "@types/mocha": "^10.0.1",
     "chai": "^4.3.7",

--- a/e2e-tests/test/main.test.ts
+++ b/e2e-tests/test/main.test.ts
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
-import { Wallet, Contract } from 'zksync-web3';
+import { Wallet, Contract, Provider } from 'zksync-web3';
 import * as hre from 'hardhat';
 import { Deployer } from '@matterlabs/hardhat-zksync-deploy';
+import { ethers } from 'ethers';
 
 const RICH_WALLET_PK =
   '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110';
@@ -9,6 +10,19 @@ const RICH_WALLET_PK =
 async function deployGreeter(deployer: Deployer): Promise<Contract> {
   const artifact = await deployer.loadArtifact('Greeter');
   return await deployer.deploy(artifact, ['Hi']);
+}
+
+async function fundAccount(
+  wallet: ethers.Wallet,
+  address: string,
+  amount: string,
+) {
+  await (
+    await wallet.sendTransaction({
+      to: address,
+      value: ethers.utils.parseEther(amount),
+    })
+  ).wait();
 }
 
 describe('Greeter', function () {
@@ -25,5 +39,31 @@ describe('Greeter', function () {
     await setGreetingTx.wait();
 
     expect(await greeter.greet()).to.equal('Hola, mundo!');
+  });
+
+  it("should prevent non-owners from setting greeting", async function () {
+    let errorThrown = false;
+    try {
+        const provider = new Provider("http://127.0.0.1:8011");
+        const wallet = new Wallet(RICH_WALLET_PK, provider);
+        const deployer = new Deployer(hre, wallet);
+
+        // setup user wallet
+        const userWallet = Wallet.createRandom().connect(provider);
+        await fundAccount(wallet, userWallet.address, "3");
+        
+        // deploy Greeter contract
+        const artifact = await deployer.loadArtifact('Greeter');
+        const greeter = await deployer.deploy(artifact, ["Hello, world!"]);
+        
+        // should revert
+        const tx = await greeter.connect(userWallet).setGreeting("Hola, mundo!");
+        await tx.wait();
+    } catch (e) {
+      expect(e.message).to.include("Ownable: caller is not the owner");
+      errorThrown = true;
+    }
+
+    expect(errorThrown).to.be.true;
   });
 });

--- a/e2e-tests/yarn.lock
+++ b/e2e-tests/yarn.lock
@@ -674,6 +674,11 @@
     table "^6.8.0"
     undici "^5.14.0"
 
+"@openzeppelin/contracts@^4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.3.tgz#00d7a8cf35a475b160b3f0293a6403c511099364"
+  integrity sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg==
+
 "@scure/base@~1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"

--- a/src/node.rs
+++ b/src/node.rs
@@ -430,17 +430,19 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
                 );
                 println!("{}", format!("\tOverhead: {}", overhead).red());
                 let message = tx_revert_reason.to_string();
+                let pretty_message = format!(
+                    "execution reverted{}{}",
+                    if message.is_empty() { "" } else { ": " },
+                    message
+                );
                 let data = match tx_revert_reason {
                     TxRevertReason::EthCall(vm_revert_reason) => vm_revert_reason.encoded_data(),
                     TxRevertReason::TxReverted(vm_revert_reason) => vm_revert_reason.encoded_data(),
                     _ => vec![],
                 };
+                println!("{}", pretty_message.on_red());
                 Err(into_jsrpc_error(Web3Error::SubmitTransactionError(
-                    format!(
-                        "execution reverted{}{}",
-                        if message.is_empty() { "" } else { ": " },
-                        message
-                    ),
+                    pretty_message,
                     data,
                 )))
             }
@@ -1199,6 +1201,11 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
                     Ok(vm_block_result) => match vm_block_result.full_result.revert_reason {
                         Some(revert) => {
                             let message = revert.revert_reason.to_string();
+                            let pretty_message = format!(
+                                "execution reverted{}{}",
+                                if message.is_empty() { "" } else { ": " },
+                                message
+                            );
                             let data = match revert.revert_reason {
                                 TxRevertReason::EthCall(vm_revert_reason) => {
                                     vm_revert_reason.encoded_data()
@@ -1208,12 +1215,9 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
                                 }
                                 _ => vec![],
                             };
+                            println!("{}", pretty_message.on_red());
                             Err(into_jsrpc_error(Web3Error::SubmitTransactionError(
-                                format!(
-                                    "execution reverted{}{}",
-                                    if message.is_empty() { "" } else { ": " },
-                                    message
-                                ),
+                                pretty_message,
                                 data,
                             )))
                             .into_boxed_future()


### PR DESCRIPTION
# What :computer: 
* Display the revert reason when calls or gas estimations fail
* Added negative e2e test

# Why :hand:
* This data provides a lot of clarity for reverts that could appear to just be gas estimation failures
* Need to validate the node can correctly handle expected failures for negative testing
  * NOTE: This will probably be one of the final e2e tests as we want to invest more into unit/integration tests for the immediate future. We just needed to validate that we've unblocked negative testing for hardhat.

# Evidence :camera:
Results of added e2e test:
![image](https://github.com/matter-labs/era-test-node/assets/1890113/be3fbc8b-5ab0-488c-9c12-f540bed3fe02)

![image](https://github.com/matter-labs/era-test-node/assets/1890113/99754069-6f69-4875-9b54-2d2ba97681f2)

