### PR TITLE
chore: remove e2e test reports

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,13 +2,6 @@ name: Testing era_test_node using e2e
 on:
   workflow_call:
 
-permissions:
-  statuses: write
-  checks: write
-  contents: write
-  pull-requests: write
-  actions: write
-
 jobs:
   e2e:
     runs-on: ubuntu-latest
@@ -45,11 +38,3 @@ jobs:
         run: |
           cat era_test_node_ouput.log
           kill $PID
-
-      - name: Publish Test Results
-        uses: dorny/test-reporter@v1
-        if: always()
-        with:
-          path: ./e2e-tests/test-results.json
-          name: E2E Test Results
-          reporter: 'mocha-json'

--- a/e2e-tests/test/main.test.ts
+++ b/e2e-tests/test/main.test.ts
@@ -24,6 +24,6 @@ describe('Greeter', function () {
     // wait until the transaction is mined
     await setGreetingTx.wait();
 
-    expect(await greeter.greet()).to.equal('Hola, mundo2!');
+    expect(await greeter.greet()).to.equal('Hola, mundo!');
   });
 });

--- a/e2e-tests/test/main.test.ts
+++ b/e2e-tests/test/main.test.ts
@@ -24,6 +24,6 @@ describe('Greeter', function () {
     // wait until the transaction is mined
     await setGreetingTx.wait();
 
-    expect(await greeter.greet()).to.equal('Hola, mundo!');
+    expect(await greeter.greet()).to.equal('Hola, mundo2!');
   });
 });

--- a/scripts/execute-e2e-tests.sh
+++ b/scripts/execute-e2e-tests.sh
@@ -55,4 +55,4 @@ echo ""
 echo "================="
 echo "Running e2e tests"
 echo "================="
-yarn test || true # Absorb exit codes in-case of test failures
+yarn test


### PR DESCRIPTION
# What :computer: 
* Remove e2e test reports

# Why :hand:
* They provide little value as they pass 99% of the time, and print out failures/results to the console

# Evidence :camera:
Verified that when e2e tests fail, the job fails and still prints out the output of the `era_test_node` binary
![image](https://github.com/matter-labs/era-test-node/assets/1890113/9823d76a-f1b3-489e-85c5-a9d709591afa)


# Notes :memo:
* The original commit contains a failed test to validate that the logs of the `era_test_node` binary will still be output as expected
