### PR TITLE
chore: add contributors to draft release template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,9 @@ jobs:
         run: rustup target add ${{ matrix.arch }}
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-on-failure: true
+          cache-on-failure: false
+      - name: Run cargo clean
+        run: cargo clean
 
       # ==============================
       #       Builds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,13 @@ jobs:
           echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
           echo "$(git log --pretty=format:"- %s" $(git describe --tags --abbrev=0 ${{ env.VERSION }}^)..${{ env.VERSION }})" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+      
+      - name: Generate list of contributors
+        id: contributors
+        run: |
+          echo "CONTRIBUTORS<<EOF" >> $GITHUB_OUTPUT
+          echo "$(git log --pretty=format:"- %aN (%aE)" $(git describe --tags --abbrev=0 ${{ env.VERSION }}^)..${{ env.VERSION }} | sort | uniq)" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create release draft
         env:
@@ -131,17 +138,26 @@ jobs:
         # The formatting here is borrowed from reth which borrowed it from Lighthouse (which is borrowed from OpenEthereum): https://github.com/openethereum/openethereum/blob/main/.github/workflows/build.yml
         run: |
           body=$(cat <<- "ENDBODY"
-          # Release: <Release Name>
+          Release: ${{ env.VERSION }}
           
           ## 📋 Summary
           
-          🐛 **Bug Fixes:** 
-          ✨ **New Features:** 
+          🐛 **Bug Fixes:**
+          - TBD
+          
+          ✨ **New Features:**
+          - TBD
+          
           ⚠️ **Breaking Changes:**
+          - TBD
           
           ## 📜 All Changes
           
           ${{ steps.changelog.outputs.CHANGELOG }}
+          
+          ## ⭐ Contributors
+          
+          ${{ steps.contributors.outputs.CONTRIBUTORS }}
           
           ## 📥 Binaries
           


### PR DESCRIPTION
# What :computer: 
* Add Contributors section to Releases
* Slight revisions to Release default format
* Include this commit [f68093cfbe4c4c2e8ea2c0c67ff172e2e0be7289](https://github.com/matter-labs/era-test-node/commit/f68093cfbe4c4c2e8ea2c0c67ff172e2e0be7289)

# Why :hand:
* To ensure credit is given to all contributors of releases
* This better matches the latest release notes we've published (leading to fewer manual changes for us from draft to release)
* It was necessary for the previous release, but was never merged into `main`

# Evidence :camera:
For tag `v0.1.0-alpha.2`:
```bash
$ git log --pretty=format:"- %aN (%aE)" $(git describe --tags --abbrev=0 v0.1.0-alpha.2^)..v0.1.0-alpha.2 | sort | uniq
- Dustin Brickwood (dustinbrickwood204@gmail.com)
- Marcin M (128217157+mm-zk@users.noreply.github.com)
- Nicolas Villanueva (nicolasvillanueva@msn.com)
```

I created a new tag based off the head of `main`:
```bash
$ git log --pretty=format:"- %aN (%aE)" $(git describe --tags --abbrev=0 v0.1.0-alpha.3^)..v0.1.0-alpha.3 | sort | uniq
- Dustin Brickwood (dustinbrickwood204@gmail.com)
- George W (140627974+grw-ms@users.noreply.github.com)
- Marcin M (128217157+mm-zk@users.noreply.github.com)
- Nicolas Villanueva (nicolasvillanueva@msn.com)
- Nisheeth Barthwal (nbaztec@gmail.com)
- Nisheeth Barthwal (nisheeth.barthwal@gmail.com)
```

Ran a fake release on my fork -> https://github.com/MexicanAce/era-test-node/releases/tag/untagged-cbd41d6befcf7f217deb
<img width="839" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/7fc79990-c359-4550-b49a-562df9591726">

