### PR TITLE
chore: enforce conventional commits on main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 
 # These users are the default owners for everything in the repo.
 # They will be requested for review when someone opens a pull request.
-* @MexicanAce @uF4No @dutterbutter @mm-zk
+* @matter-labs/devxp
 
 # You can also specify code owners for specific directories or files.
 # For example:

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,18 @@
+name: Check PR title
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - uses: aslafy-z/conventional-pr-title-action@v3
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -31,7 +31,7 @@ The `status` options are:
 | `ETH` | `eth_feeHistory` | `NOT IMPLEMENTED` | Returns a collection of historical block gas data |
 | [`ETH`](#eth-namespace) | [`eth_gasPrice`](#eth_gasprice) | `SUPPORTED` | Returns the current price per gas in wei <br />_(hardcoded to `250_000_000`)_ |
 | [`ETH`](#eth-namespace) | [`eth_getBalance`](#eth_getbalance) | `SUPPORTED` | Returns the balance of the account of given address |
-| [`ETH`](#eth-namespace) | `eth_getBlockByHash`(#eth_getblockbyhash) | `SUPPORTED` | Returns information about a block by block hash |
+| [`ETH`](#eth-namespace) | [`eth_getBlockByHash`](#eth_getblockbyhash) | `SUPPORTED` | Returns information about a block by block hash |
 | [`ETH`](#eth-namespace) | [`eth_getBlockByNumber`](#eth_getblockbynumber) | `SUPPORTED` | Returns information about a block by block number |
 | `ETH` | `eth_getBlockTransactionCountByHash` | `NOT IMPLEMENTED`<br />[GitHub Issue #44](https://github.com/matter-labs/era-test-node/issues/44) | Number of transactions in a block from a block matching the given block hash |
 | `ETH` | `eth_getBlockTransactionCountByNumber` | `NOT IMPLEMENTED`<br />[GitHub Issue #43](https://github.com/matter-labs/era-test-node/issues/43) | Number of transactions in a block from a block matching the given block number |


### PR DESCRIPTION
# What :computer: 
* Enforce conventional commits on PRs (merges to `main` branch)
* Update `CODEOWNERS` to be entire team
* Fix broken link in `SUPPORTED_APIS.md`

# Why :hand:
* Standardized and automated release notes
* To keep the list of engineers more open as the team changes over time
* Link was malformed

# Evidence :camera:
TBD (I'm unable to validate with the current run criteria, so will merge and validate in subsequent PR to ensure permissions are correct)

# Notes :memo:
* This works as a level of enforcement because we only allow squash merging of PRs
* See [Conventional Commits Spec](https://www.conventionalcommits.org/en/v1.0.0/) for more information
