### PR TITLE
feat: Add caching to HttpForkSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ etc/**/*.zbin
 !.vscode/tasks.json
 
 *.log
+.cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,6 +1795,7 @@ dependencies = [
  "once_cell",
  "openssl-sys",
  "reqwest",
+ "rustc-hash",
  "serde",
  "serde_json",
  "simplelog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,6 +1799,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
+ "tempdir",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5050,6 +5051,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6142,6 +6152,16 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ ethabi = "16.0.0"
 itertools = "0.10.5"
 log = "0.4.20"
 simplelog = "0.12.1"
+rustc-hash = "1.1.0"
 
 [dev-dependencies]
 httptest = "0.15.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,4 @@ rustc-hash = "1.1.0"
 
 [dev-dependencies]
 httptest = "0.15.4"
+tempdir = "0.3.7"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ Additionally, the file path can be provided via the `--log-file-path` option (de
 era_test_node --log=error --log-file-path=run.log run
 ```
 
+## 📃 Caching
+
+The node will cache certain network request by default to disk in the `.cache` directory. Alternatively the caching can be disabled tor set to in-memory only
+via the `--cache=none|memory|disk` parameter. 
+
+```bash
+era_test_node --cache=none run
+```
+
+```bash
+era_test_node --cache=memory run
+```
+
+Additionally when using `--cache=disk`, the cache directory may be specified via `--cache-dir` and the cache may
+be reset on startup via `--reset-cache` parameters.
+```bash
+era_test_node --cache=disk --cache-dir=/tmp/foo --reset-cache run
+```
+
 ## 🌐 Network Details
 
 - L2 RPC: http://localhost:8011

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ era_test_node --log=error --log-file-path=run.log run
 
 ## 📃 Caching
 
-The node will cache certain network request by default to disk in the `.cache` directory. Alternatively the caching can be disabled tor set to in-memory only
+The node will cache certain network request by default to disk in the `.cache` directory. Alternatively the caching can be disabled or set to in-memory only
 via the `--cache=none|memory|disk` parameter. 
 
 ```bash

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -16,7 +16,7 @@ const CACHE_TYPE_BLOCK_RAW_TRANSACTIONS: &'static str = "block_raw_transactions"
 const CACHE_TYPE_TRANSACTIONS: &'static str = "transactions";
 
 /// Cache configuration. Can be one of:
-/// 
+///
 /// None    : Caching is disabled
 /// Memory  : Caching is provided in-memory and not persisted across runs
 /// Disk    : Caching is persisted on disk in the provided directory and can be reset

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -20,17 +20,15 @@ const CACHE_TYPE_TRANSACTIONS: &str = "transactions";
 /// None    : Caching is disabled
 /// Memory  : Caching is provided in-memory and not persisted across runs
 /// Disk    : Caching is persisted on disk in the provided directory and can be reset
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub enum CacheConfig {
+    #[default]
     None,
     Memory,
-    Disk { dir: String, reset: bool },
-}
-
-impl std::default::Default for CacheConfig {
-    fn default() -> Self {
-        CacheConfig::None
-    }
+    Disk {
+        dir: String,
+        reset: bool,
+    },
 }
 
 /// A general purpose cache.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,20 +1,70 @@
+use eyre::Result;
+use rustc_hash::FxHashMap;
+use serde::Serialize;
 use zksync_basic_types::H256;
 use zksync_types::api::{Block, Transaction, TransactionVariant};
 use zksync_types::Transaction as RawTransaction;
-use rustc_hash::FxHashMap;
 
+const CACHE_DIR: &'static str = ".cache";
 
 #[derive(Default, Debug, Clone)]
 pub(crate) struct Cache {
-    pub(crate) block_hashes: FxHashMap<u64, H256>, 
+    pub(crate) block_hashes: FxHashMap<u64, H256>,
     pub(crate) blocks_full: FxHashMap<H256, Block<TransactionVariant>>,
     pub(crate) blocks_min: FxHashMap<H256, Block<TransactionVariant>>,
-    pub(crate) raw_block_transactions: FxHashMap<H256, Vec<RawTransaction>>,
+    pub(crate) block_raw_transactions: FxHashMap<H256, Vec<RawTransaction>>,
     pub(crate) transactions: FxHashMap<H256, Transaction>,
 }
 
 impl Cache {
-    pub (crate) fn new() -> Self { 
+    pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    pub(crate) fn get_block(
+        &self,
+        hash: &H256,
+        full_transactions: bool,
+    ) -> Option<&Block<TransactionVariant>> {
+        if full_transactions {
+            self.blocks_full.get(hash)
+        } else {
+            self.blocks_min.get(hash)
+        }
+    }
+
+    pub(crate) fn insert_block(
+        &self,
+        hash: H256,
+        full_transactions: bool,
+        block: Block<TransactionVariant>,
+    ) {
+        if full_transactions {
+            self.blocks_full.insert(hash, block);
+        } else {
+            self.blocks_min.insert(hash, block);
+        }
+    }
+
+    pub(crate) fn get_block_hash(&self, number: u64) -> Option<&H256> {
+        self.block_hashes.get(&number)
+    }
+
+    pub(crate) fn insert_block_hash(&self, number: u64, hash: H256) {
+        self.block_hashes.insert(number, hash);
+        Self::write(format!("block-hashes/{number}"), serde_json::to_string(&hash).expect("failed encoding value").as_bytes());
+    }
+
+    pub(crate) fn get_block_raw_transactions(&self, hash: &H256) -> Option<&Vec<RawTransaction>> {
+        self.block_raw_transactions.get(&hash)
+    }
+
+    pub(crate) fn insert_block_raw_transactions(&self, hash: H256, transactions: Vec<RawTransaction>) {
+        self.block_raw_transactions.insert(hash, transactions);
+        Self::write(format!("block-raw-transactions/{hash}"), transactions.as_bytes());
+    }
+
+    fn write(key: String, data: &[u8]) {
+
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,31 +1,91 @@
-use eyre::Result;
 use rustc_hash::FxHashMap;
 use serde::Serialize;
+use std::fs;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::path::Path;
+use std::result::Result;
+use std::str::FromStr;
 use zksync_basic_types::H256;
 use zksync_types::api::{Block, Transaction, TransactionVariant};
 use zksync_types::Transaction as RawTransaction;
 
-const CACHE_DIR: &'static str = ".cache";
+const CACHE_TYPE_BLOCKS_FULL: &'static str = "blocks_full";
+const CACHE_TYPE_BLOCKS_MIN: &'static str = "blocks_min";
+const CACHE_TYPE_BLOCK_RAW_TRANSACTIONS: &'static str = "block_raw_transactions";
+const CACHE_TYPE_TRANSACTIONS: &'static str = "transactions";
 
+/// Cache configuration. Can be one of:
+/// 
+/// None    : Caching is disabled
+/// Memory  : Caching is provided in-memory and not persisted across runs
+/// Disk    : Caching is persisted on disk in the provided directory and can be reset
+#[derive(Debug, Clone)]
+pub enum CacheConfig {
+    None,
+    Memory,
+    Disk { dir: String, reset: bool },
+}
+
+impl std::default::Default for CacheConfig {
+    fn default() -> Self {
+        CacheConfig::None
+    }
+}
+
+/// A general purpose cache.
 #[derive(Default, Debug, Clone)]
 pub(crate) struct Cache {
-    pub(crate) block_hashes: FxHashMap<u64, H256>,
-    pub(crate) blocks_full: FxHashMap<H256, Block<TransactionVariant>>,
-    pub(crate) blocks_min: FxHashMap<H256, Block<TransactionVariant>>,
-    pub(crate) block_raw_transactions: FxHashMap<H256, Vec<RawTransaction>>,
-    pub(crate) transactions: FxHashMap<H256, Transaction>,
+    config: CacheConfig,
+    block_hashes: FxHashMap<u64, H256>,
+    blocks_full: FxHashMap<H256, Block<TransactionVariant>>,
+    blocks_min: FxHashMap<H256, Block<TransactionVariant>>,
+    block_raw_transactions: FxHashMap<u64, Vec<RawTransaction>>,
+    transactions: FxHashMap<H256, Transaction>,
 }
 
 impl Cache {
-    pub(crate) fn new() -> Self {
-        Self::default()
+    /// Creates a new cache with the provided config.
+    pub(crate) fn new(config: CacheConfig) -> Self {
+        let mut cache = Cache {
+            config: config.clone(),
+            ..Default::default()
+        };
+
+        if let CacheConfig::Disk { dir, reset } = &config {
+            if *reset {
+                fs::remove_dir_all(Path::new(dir))
+                    .unwrap_or_else(|err| eprintln!("failed removing cache from disk: {:?}", err));
+            }
+
+            for cache_type in [
+                CACHE_TYPE_BLOCKS_FULL,
+                CACHE_TYPE_BLOCKS_MIN,
+                CACHE_TYPE_BLOCK_RAW_TRANSACTIONS,
+                CACHE_TYPE_TRANSACTIONS,
+            ] {
+                fs::create_dir_all(Path::new(dir).join(cache_type)).unwrap_or_else(|err| {
+                    panic!("failed creating directory {}: {:?}", cache_type, err)
+                });
+            }
+            cache
+                .read_all_from_disk(&dir)
+                .unwrap_or_else(|err| eprintln!("failed reading cache from disk: {:?}", err));
+        }
+
+        cache
     }
 
+    /// Returns the cached full/minimal block for the provided hash.
     pub(crate) fn get_block(
         &self,
         hash: &H256,
         full_transactions: bool,
     ) -> Option<&Block<TransactionVariant>> {
+        if matches!(self.config, CacheConfig::None) {
+            return None;
+        }
+
         if full_transactions {
             self.blocks_full.get(hash)
         } else {
@@ -33,38 +93,415 @@ impl Cache {
         }
     }
 
+    /// Cache a full/minimal block for the provided hash.
     pub(crate) fn insert_block(
-        &self,
+        &mut self,
         hash: H256,
         full_transactions: bool,
         block: Block<TransactionVariant>,
     ) {
+        if matches!(self.config, CacheConfig::None) {
+            return;
+        }
+
+        self.block_hashes.insert(block.number.as_u64(), block.hash);
         if full_transactions {
+            self.write_to_disk(CACHE_TYPE_BLOCKS_FULL, format!("{:#x}", hash), &block);
             self.blocks_full.insert(hash, block);
         } else {
+            self.write_to_disk(CACHE_TYPE_BLOCKS_MIN, format!("{:#x}", hash), &block);
             self.blocks_min.insert(hash, block);
         }
     }
 
-    pub(crate) fn get_block_hash(&self, number: u64) -> Option<&H256> {
+    /// Returns the cached full/minimal block for the provided hash.
+    pub(crate) fn get_block_hash(&self, number: &u64) -> Option<&H256> {
+        if matches!(self.config, CacheConfig::None) {
+            return None;
+        }
+
         self.block_hashes.get(&number)
     }
 
-    pub(crate) fn insert_block_hash(&self, number: u64, hash: H256) {
-        self.block_hashes.insert(number, hash);
-        Self::write(format!("block-hashes/{number}"), serde_json::to_string(&hash).expect("failed encoding value").as_bytes());
+    /// Returns the cached raw transactions for the provided block number.
+    pub(crate) fn get_block_raw_transactions(&self, number: &u64) -> Option<&Vec<RawTransaction>> {
+        if matches!(self.config, CacheConfig::None) {
+            return None;
+        }
+
+        self.block_raw_transactions.get(number)
     }
 
-    pub(crate) fn get_block_raw_transactions(&self, hash: &H256) -> Option<&Vec<RawTransaction>> {
-        self.block_raw_transactions.get(&hash)
+    /// Cache the raw transactions for the provided block number.
+    pub(crate) fn insert_block_raw_transactions(
+        &mut self,
+        number: u64,
+        transactions: Vec<RawTransaction>,
+    ) {
+        if matches!(self.config, CacheConfig::None) {
+            return;
+        }
+
+        self.write_to_disk(
+            CACHE_TYPE_BLOCK_RAW_TRANSACTIONS,
+            format!("{}", number),
+            &transactions,
+        );
+        self.block_raw_transactions.insert(number, transactions);
     }
 
-    pub(crate) fn insert_block_raw_transactions(&self, hash: H256, transactions: Vec<RawTransaction>) {
-        self.block_raw_transactions.insert(hash, transactions);
-        Self::write(format!("block-raw-transactions/{hash}"), transactions.as_bytes());
+    /// Returns the cached transaction for the provided hash.
+    pub(crate) fn get_transaction(&self, hash: &H256) -> Option<&Transaction> {
+        if matches!(self.config, CacheConfig::None) {
+            return None;
+        }
+
+        self.transactions.get(&hash)
     }
 
-    fn write(key: String, data: &[u8]) {
+    /// Cache a transaction for the provided hash.
+    pub(crate) fn insert_transaction(&mut self, hash: H256, transaction: Transaction) {
+        if matches!(self.config, CacheConfig::None) {
+            return;
+        }
 
+        self.write_to_disk(
+            CACHE_TYPE_TRANSACTIONS,
+            format!("{:#x}", hash),
+            &transaction,
+        );
+        self.transactions.insert(hash, transaction);
+    }
+
+    /// Reads the cache contents from the disk, if available.
+    fn read_all_from_disk(&mut self, dir: &str) -> Result<(), String> {
+        for cache_type in [
+            CACHE_TYPE_BLOCKS_FULL,
+            CACHE_TYPE_BLOCKS_MIN,
+            CACHE_TYPE_BLOCK_RAW_TRANSACTIONS,
+            CACHE_TYPE_TRANSACTIONS,
+        ] {
+            let cache_dir = Path::new(dir).join(cache_type);
+            let dir_listing = fs::read_dir(cache_dir.clone())
+                .map_err(|err| format!("failed reading dir '{:?}': {:?}", cache_dir, err))?;
+            for file in dir_listing {
+                if let Ok(file) = file {
+                    let key = file
+                        .file_name()
+                        .to_str()
+                        .ok_or_else(|| String::from("failed converting filename to string"))?
+                        .to_string();
+
+                    let cache_file = File::open(file.path()).map_err(|err| {
+                        format!("failed reading file: '{:?}': {:?}", file.path(), err)
+                    })?;
+                    let reader = BufReader::new(cache_file);
+                    match cache_type {
+                        CACHE_TYPE_BLOCKS_FULL => {
+                            let key = H256::from_str(&key).map_err(|err| {
+                                format!("invalid key for cache file '{:?}': {:?}", key, err)
+                            })?;
+                            let block: Block<TransactionVariant> = serde_json::from_reader(reader)
+                                .map_err(|err| {
+                                    format!(
+                                        "failed parsing json for cache file '{:?}': {:?}",
+                                        key, err
+                                    )
+                                })?;
+                            self.block_hashes.insert(block.number.as_u64(), block.hash);
+                            self.blocks_full.insert(key, block);
+                        }
+                        CACHE_TYPE_BLOCKS_MIN => {
+                            let key = H256::from_str(&key).map_err(|err| {
+                                format!("invalid key for cache file '{:?}': {:?}", key, err)
+                            })?;
+                            let block: Block<TransactionVariant> = serde_json::from_reader(reader)
+                                .map_err(|err| {
+                                    format!(
+                                        "failed parsing json for cache file '{:?}': {:?}",
+                                        key, err
+                                    )
+                                })?;
+                            self.block_hashes.insert(block.number.as_u64(), block.hash);
+                            self.blocks_min.insert(key, block);
+                        }
+                        CACHE_TYPE_BLOCK_RAW_TRANSACTIONS => {
+                            let key = key.parse::<u64>().map_err(|err| {
+                                format!("invalid key for cache file '{:?}': {:?}", key, err)
+                            })?;
+                            let transactions: Vec<RawTransaction> = serde_json::from_reader(reader)
+                                .map_err(|err| {
+                                    format!(
+                                        "failed parsing json for cache file '{:?}': {:?}",
+                                        key, err
+                                    )
+                                })?;
+                            self.block_raw_transactions.insert(key, transactions);
+                        }
+                        CACHE_TYPE_TRANSACTIONS => {
+                            let key = H256::from_str(&key).map_err(|err| {
+                                format!("invalid key for cache file '{:?}': {:?}", key, err)
+                            })?;
+                            let transaction: Transaction = serde_json::from_reader(reader)
+                                .map_err(|err| {
+                                    format!(
+                                        "failed parsing json for cache file '{:?}': {:?}",
+                                        key, err
+                                    )
+                                })?;
+                            self.transactions.insert(key, transaction);
+                        }
+                        _ => return Err(format!("invalid cache_type {}", cache_type)),
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Writes the cache contents to disk, if supported.
+    fn write_to_disk<T: Serialize>(&self, cache_type: &'static str, key: String, data: &T) {
+        if let CacheConfig::Disk { dir, .. } = &self.config {
+            let file = Path::new(&dir).join(cache_type).join(key);
+
+            println!("writing cache {:?}", file);
+            match File::create(file.clone()) {
+                Ok(cache_file) => {
+                    let writer = BufWriter::new(cache_file);
+                    if let Err(err) = serde_json::to_writer(writer, data) {
+                        eprintln!("failed writing to cache '{:?}': {:?}", file, err);
+                    }
+                }
+                Err(err) => eprintln!("failed creating file: '{:?}': {:?}", file, err),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempdir::TempDir;
+    use zksync_basic_types::U64;
+    use zksync_types::{Execute, ExecuteTransactionCommon};
+
+    use super::*;
+
+    #[test]
+    fn test_cache_config_none_disables_cache() {
+        let mut cache = Cache::new(CacheConfig::None);
+
+        cache.insert_block(H256::zero(), true, Default::default());
+        assert_eq!(None, cache.get_block(&H256::zero(), true));
+        assert_eq!(None, cache.get_block_hash(&0));
+
+        cache.insert_block(H256::zero(), false, Default::default());
+        assert_eq!(None, cache.get_block(&H256::zero(), false));
+        assert_eq!(None, cache.get_block_hash(&0));
+
+        cache.insert_block_raw_transactions(0, Default::default());
+        assert_eq!(None, cache.get_block_raw_transactions(&0));
+
+        cache.insert_transaction(H256::zero(), Default::default());
+        assert_eq!(None, cache.get_transaction(&H256::zero()));
+    }
+
+    #[test]
+    fn test_cache_config_memory_enables_cache() {
+        let block_full = Block::<TransactionVariant> {
+            hash: H256::repeat_byte(0x1),
+            number: U64::from(1),
+            ..Default::default()
+        };
+        let block_min = Block::<TransactionVariant> {
+            hash: H256::repeat_byte(0x2),
+            number: U64::from(2),
+            ..Default::default()
+        };
+        let transaction = Transaction::default();
+        let raw_transactions = vec![RawTransaction {
+            common_data: ExecuteTransactionCommon::L1(Default::default()),
+            execute: Execute {
+                calldata: Default::default(),
+                contract_address: Default::default(),
+                factory_deps: None,
+                value: Default::default(),
+            },
+            received_timestamp_ms: 0,
+        }];
+
+        let mut cache = Cache::new(CacheConfig::Memory);
+
+        cache.insert_block(block_full.hash, true, block_full.clone());
+        assert_eq!(
+            Some(&block_full),
+            cache.get_block(&H256::repeat_byte(0x1), true)
+        );
+        assert_eq!(Some(&H256::repeat_byte(0x1)), cache.get_block_hash(&1));
+
+        cache.insert_block(block_min.hash, false, block_min.clone());
+        assert_eq!(
+            Some(&block_min),
+            cache.get_block(&H256::repeat_byte(0x2), false)
+        );
+        assert_eq!(Some(&H256::repeat_byte(0x2)), cache.get_block_hash(&2));
+
+        cache.insert_block_raw_transactions(0, raw_transactions.clone());
+        assert_eq!(
+            Some(&raw_transactions),
+            cache.get_block_raw_transactions(&0)
+        );
+
+        cache.insert_transaction(H256::zero(), transaction.clone());
+        assert_eq!(Some(&transaction), cache.get_transaction(&H256::zero()));
+    }
+
+    #[test]
+    fn test_cache_config_disk_enables_cache_and_preserves_it_to_disk() {
+        let block_full = Block::<TransactionVariant> {
+            hash: H256::repeat_byte(0x1),
+            number: U64::from(1),
+            ..Default::default()
+        };
+        let block_min = Block::<TransactionVariant> {
+            hash: H256::repeat_byte(0x2),
+            number: U64::from(2),
+            ..Default::default()
+        };
+        let transaction = Transaction::default();
+        let raw_transactions = vec![RawTransaction {
+            common_data: ExecuteTransactionCommon::L1(Default::default()),
+            execute: Execute {
+                calldata: Default::default(),
+                contract_address: Default::default(),
+                factory_deps: None,
+                value: Default::default(),
+            },
+            received_timestamp_ms: 0,
+        }];
+
+        let cache_dir = TempDir::new("cache-test").expect("failed creating temporary dir");
+        let cache_dir_path = cache_dir
+            .path()
+            .to_str()
+            .expect("invalid dir name")
+            .to_string();
+        let mut cache = Cache::new(CacheConfig::Disk {
+            dir: cache_dir_path.clone(),
+            reset: true,
+        });
+
+        cache.insert_block(block_full.hash, true, block_full.clone());
+        assert_eq!(
+            Some(&block_full),
+            cache.get_block(&H256::repeat_byte(0x1), true)
+        );
+        assert_eq!(Some(&H256::repeat_byte(0x1)), cache.get_block_hash(&1));
+
+        cache.insert_block(block_min.hash, false, block_min.clone());
+        assert_eq!(
+            Some(&block_min),
+            cache.get_block(&H256::repeat_byte(0x2), false)
+        );
+        assert_eq!(Some(&H256::repeat_byte(0x2)), cache.get_block_hash(&2));
+
+        cache.insert_block_raw_transactions(0, raw_transactions.clone());
+        assert_eq!(
+            Some(&raw_transactions),
+            cache.get_block_raw_transactions(&0)
+        );
+
+        cache.insert_transaction(H256::zero(), transaction.clone());
+        assert_eq!(Some(&transaction), cache.get_transaction(&H256::zero()));
+
+        let new_cache = Cache::new(CacheConfig::Disk {
+            dir: cache_dir_path,
+            reset: false,
+        });
+        assert_eq!(
+            Some(&block_full),
+            new_cache.get_block(&H256::repeat_byte(0x1), true)
+        );
+        assert_eq!(Some(&H256::repeat_byte(0x1)), new_cache.get_block_hash(&1));
+        assert_eq!(
+            Some(&block_min),
+            new_cache.get_block(&H256::repeat_byte(0x2), false)
+        );
+        assert_eq!(Some(&H256::repeat_byte(0x2)), new_cache.get_block_hash(&2));
+        assert_eq!(
+            Some(&raw_transactions),
+            new_cache.get_block_raw_transactions(&0)
+        );
+        assert_eq!(Some(&transaction), new_cache.get_transaction(&H256::zero()));
+    }
+
+    #[test]
+    fn test_cache_config_disk_enables_cache_and_can_reset_data_on_disk() {
+        let block_full = Block::<TransactionVariant> {
+            hash: H256::repeat_byte(0x1),
+            number: U64::from(1),
+            ..Default::default()
+        };
+        let block_min = Block::<TransactionVariant> {
+            hash: H256::repeat_byte(0x2),
+            number: U64::from(2),
+            ..Default::default()
+        };
+        let transaction = Transaction::default();
+        let raw_transactions = vec![RawTransaction {
+            common_data: ExecuteTransactionCommon::L1(Default::default()),
+            execute: Execute {
+                calldata: Default::default(),
+                contract_address: Default::default(),
+                factory_deps: None,
+                value: Default::default(),
+            },
+            received_timestamp_ms: 0,
+        }];
+
+        let cache_dir = TempDir::new("cache-test").expect("failed creating temporary dir");
+        let cache_dir_path = cache_dir
+            .path()
+            .to_str()
+            .expect("invalid dir name")
+            .to_string();
+        let mut cache = Cache::new(CacheConfig::Disk {
+            dir: cache_dir_path.clone(),
+            reset: true,
+        });
+
+        cache.insert_block(block_full.hash, true, block_full.clone());
+        assert_eq!(
+            Some(&block_full),
+            cache.get_block(&H256::repeat_byte(0x1), true)
+        );
+        assert_eq!(Some(&H256::repeat_byte(0x1)), cache.get_block_hash(&1));
+
+        cache.insert_block(block_min.hash, false, block_min.clone());
+        assert_eq!(
+            Some(&block_min),
+            cache.get_block(&H256::repeat_byte(0x2), false)
+        );
+        assert_eq!(Some(&H256::repeat_byte(0x2)), cache.get_block_hash(&2));
+
+        cache.insert_block_raw_transactions(0, raw_transactions.clone());
+        assert_eq!(
+            Some(&raw_transactions),
+            cache.get_block_raw_transactions(&0)
+        );
+
+        cache.insert_transaction(H256::zero(), transaction.clone());
+        assert_eq!(Some(&transaction), cache.get_transaction(&H256::zero()));
+
+        let new_cache = Cache::new(CacheConfig::Disk {
+            dir: cache_dir_path,
+            reset: true,
+        });
+        assert_eq!(None, new_cache.get_block(&H256::zero(), true));
+        assert_eq!(None, new_cache.get_block_hash(&1));
+        assert_eq!(None, new_cache.get_block(&H256::zero(), false));
+        assert_eq!(None, new_cache.get_block_hash(&2));
+        assert_eq!(None, new_cache.get_block_raw_transactions(&0));
+        assert_eq!(None, new_cache.get_transaction(&H256::zero()));
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -61,7 +61,11 @@ impl Cache {
                     CACHE_TYPE_TRANSACTIONS,
                 ] {
                     fs::remove_dir_all(Path::new(dir).join(cache_type)).unwrap_or_else(|err| {
-                        log::warn!("failed removing directory {:?}: {:?}", Path::new(dir).join(cache_type), err)
+                        log::warn!(
+                            "failed removing directory {:?}: {:?}",
+                            Path::new(dir).join(cache_type),
+                            err
+                        )
                     });
                 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -54,8 +54,9 @@ impl Cache {
 
         if let CacheConfig::Disk { dir, reset } = &config {
             if *reset {
-                fs::remove_dir_all(Path::new(dir))
-                    .unwrap_or_else(|err| eprintln!("failed removing cache from disk: {:?}", err));
+                fs::remove_dir_all(Path::new(dir)).unwrap_or_else(|err| {
+                    log::error!("failed removing cache from disk: {:?}", err)
+                });
             }
 
             for cache_type in [
@@ -70,7 +71,7 @@ impl Cache {
             }
             cache
                 .read_all_from_disk(&dir)
-                .unwrap_or_else(|err| eprintln!("failed reading cache from disk: {:?}", err));
+                .unwrap_or_else(|err| log::error!("failed reading cache from disk: {:?}", err));
         }
 
         cache
@@ -265,15 +266,15 @@ impl Cache {
         if let CacheConfig::Disk { dir, .. } = &self.config {
             let file = Path::new(&dir).join(cache_type).join(key);
 
-            println!("writing cache {:?}", file);
+            log::debug!("writing cache {:?}", file);
             match File::create(file.clone()) {
                 Ok(cache_file) => {
                     let writer = BufWriter::new(cache_file);
                     if let Err(err) = serde_json::to_writer(writer, data) {
-                        eprintln!("failed writing to cache '{:?}': {:?}", file, err);
+                        log::error!("failed writing to cache '{:?}': {:?}", file, err);
                     }
                 }
-                Err(err) => eprintln!("failed creating file: '{:?}': {:?}", file, err),
+                Err(err) => log::error!("failed creating file: '{:?}': {:?}", file, err),
             }
         }
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,20 @@
+use zksync_basic_types::H256;
+use zksync_types::api::{Block, Transaction, TransactionVariant};
+use zksync_types::Transaction as RawTransaction;
+use rustc_hash::FxHashMap;
+
+
+#[derive(Default, Debug, Clone)]
+pub(crate) struct Cache {
+    pub(crate) block_hashes: FxHashMap<u64, H256>, 
+    pub(crate) blocks_full: FxHashMap<H256, Block<TransactionVariant>>,
+    pub(crate) blocks_min: FxHashMap<H256, Block<TransactionVariant>>,
+    pub(crate) raw_block_transactions: FxHashMap<H256, Vec<RawTransaction>>,
+    pub(crate) transactions: FxHashMap<H256, Transaction>,
+}
+
+impl Cache {
+    pub (crate) fn new() -> Self { 
+        Self::default()
+    }
+}

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -25,10 +25,7 @@ use zksync_utils::{bytecode::hash_bytecode, h256_to_u256};
 use zksync_web3_decl::{jsonrpsee::http_client::HttpClient, namespaces::EthNamespaceClient};
 use zksync_web3_decl::{jsonrpsee::http_client::HttpClientBuilder, namespaces::ZksNamespaceClient};
 
-use crate::{
-    cache::CacheConfig,
-    node::TEST_NODE_NETWORK_ID,
-};
+use crate::{cache::CacheConfig, node::TEST_NODE_NETWORK_ID};
 use crate::{deps::InMemoryStorage, http_fork_source::HttpForkSource};
 use crate::{deps::ReadStorage as RS, system_contracts};
 

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -25,7 +25,10 @@ use zksync_utils::{bytecode::hash_bytecode, h256_to_u256};
 use zksync_web3_decl::{jsonrpsee::http_client::HttpClient, namespaces::EthNamespaceClient};
 use zksync_web3_decl::{jsonrpsee::http_client::HttpClientBuilder, namespaces::ZksNamespaceClient};
 
-use crate::node::TEST_NODE_NETWORK_ID;
+use crate::{
+    cache::CacheConfig,
+    node::TEST_NODE_NETWORK_ID,
+};
 use crate::{deps::InMemoryStorage, http_fork_source::HttpForkSource};
 use crate::{deps::ReadStorage as RS, system_contracts};
 
@@ -247,6 +250,7 @@ impl ForkDetails<HttpForkSource> {
         client: HttpClient,
         miniblock: u64,
         chain_id: Option<L2ChainId>,
+        cache_config: CacheConfig,
     ) -> Self {
         let block_details = client
             .get_block_details(MiniblockNumber(miniblock as u32))
@@ -277,9 +281,7 @@ impl ForkDetails<HttpForkSource> {
         );
 
         ForkDetails {
-            fork_source: HttpForkSource {
-                fork_url: url.to_owned(),
-            },
+            fork_source: HttpForkSource::new(url.to_owned(), cache_config),
             l1_block: l1_batch_number,
             l2_block: block,
             block_timestamp: block_details.base.timestamp,
@@ -290,19 +292,19 @@ impl ForkDetails<HttpForkSource> {
         }
     }
     /// Create a fork from a given network at a given height.
-    pub async fn from_network(fork: &str, fork_at: Option<u64>) -> Self {
+    pub async fn from_network(fork: &str, fork_at: Option<u64>, cache_config: CacheConfig) -> Self {
         let (url, client) = Self::fork_to_url_and_client(fork);
         let l2_miniblock = if let Some(fork_at) = fork_at {
             fork_at
         } else {
             client.get_block_number().await.unwrap().as_u64()
         };
-        Self::from_url_and_miniblock_and_chain(url, client, l2_miniblock, None).await
+        Self::from_url_and_miniblock_and_chain(url, client, l2_miniblock, None, cache_config).await
     }
 
     /// Create a fork from a given network, at a height BEFORE a transaction.
     /// This will allow us to apply this transaction locally on top of this fork.
-    pub async fn from_network_tx(fork: &str, tx: H256) -> Self {
+    pub async fn from_network_tx(fork: &str, tx: H256, cache_config: CacheConfig) -> Self {
         let (url, client) = Self::fork_to_url_and_client(fork);
         let tx_details = client.get_transaction_by_hash(tx).await.unwrap().unwrap();
         let overwrite_chain_id = Some(L2ChainId(tx_details.chain_id.as_u32() as u16));
@@ -310,7 +312,14 @@ impl ForkDetails<HttpForkSource> {
         // We have to sync to the one-miniblock before the one where transaction is.
         let l2_miniblock = miniblock_number.saturating_sub(1) as u64;
 
-        Self::from_url_and_miniblock_and_chain(url, client, l2_miniblock, overwrite_chain_id).await
+        Self::from_url_and_miniblock_and_chain(
+            url,
+            client,
+            l2_miniblock,
+            overwrite_chain_id,
+            cache_config,
+        )
+        .await
     }
 }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -141,11 +141,11 @@ pub fn print_call(call: &Call, padding: usize, show_calls: &ShowCalls, resolve_h
             call.revert_reason
                 .as_ref()
                 .map(|s| format!("Revert: {}", s))
-                .unwrap_or_else(|| "".to_string()),
+                .unwrap_or_default(),
             call.error
                 .as_ref()
                 .map(|s| format!("Error: {}", s))
-                .unwrap_or_else(|| "".to_string()),
+                .unwrap_or_default(),
             call.gas
         );
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -141,11 +141,11 @@ pub fn print_call(call: &Call, padding: usize, show_calls: &ShowCalls, resolve_h
             call.revert_reason
                 .as_ref()
                 .map(|s| format!("Revert: {}", s))
-                .unwrap_or("".to_string()),
+                .unwrap_or_else(|| "".to_string()),
             call.error
                 .as_ref()
                 .map(|s| format!("Error: {}", s))
-                .unwrap_or("".to_string()),
+                .unwrap_or_else(|| "".to_string()),
             call.gas
         );
 

--- a/src/hardhat.rs
+++ b/src/hardhat.rs
@@ -71,7 +71,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> HardhatNamespaceT
                     inner_guard
                         .fork_storage
                         .set_value(balance_key, u256_to_h256(balance));
-                    log::debug!(
+                    log::info!(
                         "👷 Balance for address {:?} has been manually set to {} Wei",
                         address,
                         balance
@@ -114,7 +114,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> HardhatNamespaceT
                     }
                     deployment_nonce = nonce;
                     let enforced_full_nonce = nonces_to_full_nonce(account_nonce, deployment_nonce);
-                    log::debug!(
+                    log::info!(
                         "👷 Nonces for address {:?} have been set to {}",
                         address,
                         nonce

--- a/src/hardhat.rs
+++ b/src/hardhat.rs
@@ -73,7 +73,8 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> HardhatNamespaceT
                         .set_value(balance_key, u256_to_h256(balance));
                     log::debug!(
                         "👷 Balance for address {:?} has been manually set to {} Wei",
-                        address, balance
+                        address,
+                        balance
                     );
                     Ok(true)
                 }
@@ -115,7 +116,8 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> HardhatNamespaceT
                     let enforced_full_nonce = nonces_to_full_nonce(account_nonce, deployment_nonce);
                     log::debug!(
                         "👷 Nonces for address {:?} have been set to {}",
-                        address, nonce
+                        address,
+                        nonce
                     );
                     inner_guard
                         .fork_storage

--- a/src/hardhat.rs
+++ b/src/hardhat.rs
@@ -71,7 +71,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> HardhatNamespaceT
                     inner_guard
                         .fork_storage
                         .set_value(balance_key, u256_to_h256(balance));
-                    println!(
+                    log::debug!(
                         "👷 Balance for address {:?} has been manually set to {} Wei",
                         address, balance
                     );
@@ -113,7 +113,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> HardhatNamespaceT
                     }
                     deployment_nonce = nonce;
                     let enforced_full_nonce = nonces_to_full_nonce(account_nonce, deployment_nonce);
-                    println!(
+                    log::debug!(
                         "👷 Nonces for address {:?} have been set to {}",
                         address, nonce
                     );

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -4,13 +4,17 @@ use zksync_web3_decl::{
     namespaces::{EthNamespaceClient, ZksNamespaceClient},
 };
 
-use crate::fork::{block_on, ForkSource};
+use crate::{
+    cache::Cache,
+    fork::{block_on, ForkSource},
+};
 
 #[derive(Debug)]
 /// Fork source that gets the data via HTTP requests.
 pub struct HttpForkSource {
     /// URL for the network to fork.
     pub fork_url: String,
+    cache: Cache,
 }
 
 impl HttpForkSource {
@@ -46,18 +50,58 @@ impl ForkSource for HttpForkSource {
         &self,
         hash: zksync_basic_types::H256,
     ) -> eyre::Result<Option<zksync_types::api::Transaction>> {
-        let client = self.create_client();
-        block_on(async move { client.get_transaction_by_hash(hash).await })
-            .wrap_err("fork http client failed")
+        self.cache
+            .transactions
+            .get(&hash)
+            .cloned()
+            .map(|value| Ok(Some(value)))
+            .unwrap_or_else(|| {
+                let client = self.create_client();
+                block_on(async move { client.get_transaction_by_hash(hash).await })
+                    .wrap_err("fork http client failed")
+                    .and_then(|result| {
+                        if let Some(transaction) = &result {
+                            self.cache.transactions.insert(hash, transaction.clone());
+                        }
+                        Ok(result)
+                    })
+            })
     }
 
     fn get_raw_block_transactions(
         &self,
         block_number: zksync_basic_types::MiniblockNumber,
     ) -> eyre::Result<Vec<zksync_types::Transaction>> {
-        let client = self.create_client();
-        block_on(async move { client.get_raw_block_transactions(block_number).await })
-            .wrap_err("fork http client failed")
+        let mut block_hash = zksync_basic_types::H256::zero();
+        let mut block_number_mapped = false;
+
+        self.cache
+            .block_hashes
+            .get(&(block_number.0 as u64))
+            .and_then(|hash| {
+                block_number_mapped = true;
+                block_hash = *hash;
+                self.cache.raw_block_transactions.get(hash)
+            })
+            .cloned()
+            .map(|value| Ok(value))
+            .unwrap_or_else(|| {
+                let client = self.create_client();
+                block_on(async move { client.get_raw_block_transactions(block_number).await })
+                    .wrap_err("fork http client failed")
+                    .and_then(|result| {
+                        if !block_number_mapped {
+                            self.cache
+                                .block_hashes
+                                .insert(block_number.0 as u64, block_hash);
+                        }
+
+                        self.cache
+                            .raw_block_transactions
+                            .insert(block_hash, result.clone());
+                        Ok(result)
+                    })
+            })
     }
 
     fn get_block_by_hash(
@@ -65,9 +109,27 @@ impl ForkSource for HttpForkSource {
         hash: zksync_basic_types::H256,
         full_transactions: bool,
     ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
-        let client = self.create_client();
-        block_on(async move { client.get_block_by_hash(hash, full_transactions).await })
-            .wrap_err("fork http client failed")
+        let mut cache = if full_transactions {
+            self.cache.blocks_full
+        } else {
+            self.cache.blocks_min
+        };
+
+        cache
+            .get(&hash)
+            .cloned()
+            .map(|value| Ok(Some(value)))
+            .unwrap_or_else(|| {
+                let client = self.create_client();
+                block_on(async move { client.get_block_by_hash(hash, full_transactions).await })
+                    .wrap_err("fork http client failed")
+                    .and_then(|result| {
+                        if let Some(transaction) = &result {
+                            cache.insert(hash, transaction.clone());
+                        }
+                        Ok(result)
+                    })
+            })
     }
 
     fn get_block_by_number(
@@ -75,12 +137,48 @@ impl ForkSource for HttpForkSource {
         block_number: zksync_types::api::BlockNumber,
         full_transactions: bool,
     ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
-        let client = self.create_client();
-        block_on(async move {
-            client
-                .get_block_by_number(block_number, full_transactions)
-                .await
-        })
-        .wrap_err("fork http client failed")
+        let number = match block_number {
+            zksync_types::api::BlockNumber::Number(block_number) => Some(block_number),
+            _ => None,
+        };
+        let mut cache = if full_transactions {
+            self.cache.blocks_full
+        } else {
+            self.cache.blocks_min
+        };
+
+        let mut block_hash = zksync_basic_types::H256::zero();
+        let mut block_number_mapped = false;
+        number
+            .and_then(|number| {
+                self.cache.block_hashes.get(&number.as_u64()).map(|hash| {
+                    block_number_mapped = true;
+                    block_hash = *hash;
+                    *hash
+                })
+            })
+            .and_then(|hash| cache.get(&hash))
+            .cloned()
+            .map(|value| Ok(Some(value)))
+            .unwrap_or_else(|| {
+                let client = self.create_client();
+                block_on(async move {
+                    client
+                        .get_block_by_number(block_number, full_transactions)
+                        .await
+                })
+                .wrap_err("fork http client failed")
+                .and_then(|result| {
+                    if !block_number_mapped {
+                        if let Some(number) = number {
+                            self.cache.block_hashes.insert(number.as_u64(), block_hash);
+                        }
+                    }
+                    if let Some(block) = &result {
+                        cache.insert(block_hash, block.clone());
+                    }
+                    Ok(result)
+                })
+            })
     }
 }

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -65,6 +65,7 @@ impl ForkSource for HttpForkSource {
             .read()
             .map(|guard| guard.get_transaction(&hash).cloned())
         {
+            log::debug!("using cached transaction for {hash}");
             return Ok(Some(transaction));
         }
 
@@ -97,6 +98,7 @@ impl ForkSource for HttpForkSource {
             .read()
             .map(|guard| guard.get_block_raw_transactions(&number).cloned())
         {
+            log::debug!("using cached raw transactions for block {block_number}");
             return Ok(transaction);
         }
 
@@ -131,6 +133,7 @@ impl ForkSource for HttpForkSource {
             .read()
             .map(|guard| guard.get_block(&hash, full_transactions).cloned())
         {
+            log::debug!("using cached block for {hash}");
             return Ok(Some(block));
         }
 
@@ -167,6 +170,7 @@ impl ForkSource for HttpForkSource {
                     .and_then(|hash| guard.get_block(hash, full_transactions).cloned())
             })
         }) {
+            log::debug!("using cached block for {block_number}");
             return Ok(Some(block));
         }
 

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -81,7 +81,7 @@ impl ForkSource for HttpForkSource {
             .and_then(|hash| {
                 block_number_mapped = true;
                 block_hash = *hash;
-                self.cache.raw_block_transactions.get(hash)
+                self.cache.block_raw_transactions.get(hash)
             })
             .cloned()
             .map(|value| Ok(value))
@@ -97,7 +97,7 @@ impl ForkSource for HttpForkSource {
                         }
 
                         self.cache
-                            .raw_block_transactions
+                            .block_raw_transactions
                             .insert(block_hash, result.clone());
                         Ok(result)
                     })

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -78,7 +78,7 @@ impl ForkSource for HttpForkSource {
                             Ok(guard.insert_transaction(hash, transaction.clone()))
                         })
                         .unwrap_or_else(|err| {
-                            println!(
+                            log::warn!(
                                 "failed writing to cache for 'get_transaction_by_hash': {:?}",
                                 err
                             )
@@ -113,7 +113,7 @@ impl ForkSource for HttpForkSource {
                             Ok(guard.insert_block_raw_transactions(number, transactions.clone()))
                         })
                         .unwrap_or_else(|err| {
-                            println!(
+                            log::warn!(
                                 "failed writing to cache for 'get_raw_block_transactions': {:?}",
                                 err
                             )
@@ -146,7 +146,7 @@ impl ForkSource for HttpForkSource {
                             Ok(guard.insert_block(hash, full_transactions, block.clone()))
                         })
                         .unwrap_or_else(|err| {
-                            println!("failed writing to cache for 'get_block_by_hash': {:?}", err)
+                            log::warn!("failed writing to cache for 'get_block_by_hash': {:?}", err)
                         });
                 }
                 Ok(block)
@@ -188,7 +188,7 @@ impl ForkSource for HttpForkSource {
                         Ok(guard.insert_block(block.hash, full_transactions, block.clone()))
                     })
                     .unwrap_or_else(|err| {
-                        println!(
+                        log::warn!(
                             "failed writing to cache for 'get_block_by_number': {:?}",
                             err
                         )

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -1,3 +1,5 @@
+use std::sync::RwLock;
+
 use eyre::Context;
 use zksync_web3_decl::{
     jsonrpsee::http_client::{HttpClient, HttpClientBuilder},
@@ -5,7 +7,7 @@ use zksync_web3_decl::{
 };
 
 use crate::{
-    cache::Cache,
+    cache::{Cache, CacheConfig},
     fork::{block_on, ForkSource},
 };
 
@@ -14,10 +16,18 @@ use crate::{
 pub struct HttpForkSource {
     /// URL for the network to fork.
     pub fork_url: String,
-    cache: Cache,
+    /// Cache for network data.
+    pub(crate) cache: RwLock<Cache>,
 }
 
 impl HttpForkSource {
+    pub fn new(fork_url: String, cache_config: CacheConfig) -> Self {
+        Self {
+            fork_url,
+            cache: RwLock::new(Cache::new(cache_config)),
+        }
+    }
+
     pub fn create_client(&self) -> HttpClient {
         HttpClientBuilder::default()
             .build(self.fork_url.clone())
@@ -50,57 +60,66 @@ impl ForkSource for HttpForkSource {
         &self,
         hash: zksync_basic_types::H256,
     ) -> eyre::Result<Option<zksync_types::api::Transaction>> {
-        self.cache
-            .transactions
-            .get(&hash)
-            .cloned()
-            .map(|value| Ok(Some(value)))
-            .unwrap_or_else(|| {
-                let client = self.create_client();
-                block_on(async move { client.get_transaction_by_hash(hash).await })
-                    .wrap_err("fork http client failed")
-                    .and_then(|result| {
-                        if let Some(transaction) = &result {
-                            self.cache.transactions.insert(hash, transaction.clone());
-                        }
-                        Ok(result)
-                    })
+        if let Ok(Some(transaction)) = self
+            .cache
+            .read()
+            .and_then(|guard| Ok(guard.get_transaction(&hash).cloned()))
+        {
+            return Ok(Some(transaction));
+        }
+
+        let client = self.create_client();
+        block_on(async move { client.get_transaction_by_hash(hash).await })
+            .and_then(|maybe_transaction| {
+                if let Some(transaction) = &maybe_transaction {
+                    self.cache
+                        .write()
+                        .and_then(|mut guard| {
+                            Ok(guard.insert_transaction(hash, transaction.clone()))
+                        })
+                        .unwrap_or_else(|err| {
+                            println!(
+                                "failed writing to cache for 'get_transaction_by_hash': {:?}",
+                                err
+                            )
+                        });
+                }
+                Ok(maybe_transaction)
             })
+            .wrap_err("fork http client failed")
     }
 
     fn get_raw_block_transactions(
         &self,
         block_number: zksync_basic_types::MiniblockNumber,
     ) -> eyre::Result<Vec<zksync_types::Transaction>> {
-        let mut block_hash = zksync_basic_types::H256::zero();
-        let mut block_number_mapped = false;
+        let number = block_number.0 as u64;
+        if let Ok(Some(transaction)) = self
+            .cache
+            .read()
+            .and_then(|guard| Ok(guard.get_block_raw_transactions(&number).cloned()))
+        {
+            return Ok(transaction);
+        }
 
-        self.cache
-            .block_hashes
-            .get(&(block_number.0 as u64))
-            .and_then(|hash| {
-                block_number_mapped = true;
-                block_hash = *hash;
-                self.cache.block_raw_transactions.get(hash)
-            })
-            .cloned()
-            .map(|value| Ok(value))
-            .unwrap_or_else(|| {
-                let client = self.create_client();
-                block_on(async move { client.get_raw_block_transactions(block_number).await })
-                    .wrap_err("fork http client failed")
-                    .and_then(|result| {
-                        if !block_number_mapped {
-                            self.cache
-                                .block_hashes
-                                .insert(block_number.0 as u64, block_hash);
-                        }
-
-                        self.cache
-                            .block_raw_transactions
-                            .insert(block_hash, result.clone());
-                        Ok(result)
-                    })
+        let client = self.create_client();
+        block_on(async move { client.get_raw_block_transactions(block_number).await })
+            .wrap_err("fork http client failed")
+            .and_then(|transactions| {
+                if !transactions.is_empty() {
+                    self.cache
+                        .write()
+                        .and_then(|mut guard| {
+                            Ok(guard.insert_block_raw_transactions(number, transactions.clone()))
+                        })
+                        .unwrap_or_else(|err| {
+                            println!(
+                                "failed writing to cache for 'get_raw_block_transactions': {:?}",
+                                err
+                            )
+                        });
+                }
+                Ok(transactions)
             })
     }
 
@@ -109,27 +128,30 @@ impl ForkSource for HttpForkSource {
         hash: zksync_basic_types::H256,
         full_transactions: bool,
     ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
-        let mut cache = if full_transactions {
-            self.cache.blocks_full
-        } else {
-            self.cache.blocks_min
-        };
+        if let Ok(Some(block)) = self
+            .cache
+            .read()
+            .and_then(|guard| Ok(guard.get_block(&hash, full_transactions).cloned()))
+        {
+            return Ok(Some(block));
+        }
 
-        cache
-            .get(&hash)
-            .cloned()
-            .map(|value| Ok(Some(value)))
-            .unwrap_or_else(|| {
-                let client = self.create_client();
-                block_on(async move { client.get_block_by_hash(hash, full_transactions).await })
-                    .wrap_err("fork http client failed")
-                    .and_then(|result| {
-                        if let Some(transaction) = &result {
-                            cache.insert(hash, transaction.clone());
-                        }
-                        Ok(result)
-                    })
+        let client = self.create_client();
+        block_on(async move { client.get_block_by_hash(hash, full_transactions).await })
+            .and_then(|block| {
+                if let Some(block) = &block {
+                    self.cache
+                        .write()
+                        .and_then(|mut guard| {
+                            Ok(guard.insert_block(hash, full_transactions, block.clone()))
+                        })
+                        .unwrap_or_else(|err| {
+                            println!("failed writing to cache for 'get_block_by_hash': {:?}", err)
+                        });
+                }
+                Ok(block)
             })
+            .wrap_err("fork http client failed")
     }
 
     fn get_block_by_number(
@@ -137,48 +159,289 @@ impl ForkSource for HttpForkSource {
         block_number: zksync_types::api::BlockNumber,
         full_transactions: bool,
     ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
-        let number = match block_number {
+        let maybe_number = match block_number {
             zksync_types::api::BlockNumber::Number(block_number) => Some(block_number),
             _ => None,
         };
-        let mut cache = if full_transactions {
-            self.cache.blocks_full
-        } else {
-            self.cache.blocks_min
-        };
 
-        let mut block_hash = zksync_basic_types::H256::zero();
-        let mut block_number_mapped = false;
-        number
-            .and_then(|number| {
-                self.cache.block_hashes.get(&number.as_u64()).map(|hash| {
-                    block_number_mapped = true;
-                    block_hash = *hash;
-                    *hash
-                })
+        if let Some(block) = maybe_number.and_then(|number| {
+            self.cache.read().ok().and_then(|guard| {
+                guard
+                    .get_block_hash(&number.as_u64())
+                    .and_then(|hash| guard.get_block(hash, full_transactions).cloned())
             })
-            .and_then(|hash| cache.get(&hash))
-            .cloned()
-            .map(|value| Ok(Some(value)))
-            .unwrap_or_else(|| {
-                let client = self.create_client();
-                block_on(async move {
-                    client
-                        .get_block_by_number(block_number, full_transactions)
-                        .await
-                })
-                .wrap_err("fork http client failed")
-                .and_then(|result| {
-                    if !block_number_mapped {
-                        if let Some(number) = number {
-                            self.cache.block_hashes.insert(number.as_u64(), block_hash);
-                        }
-                    }
-                    if let Some(block) = &result {
-                        cache.insert(block_hash, block.clone());
-                    }
-                    Ok(result)
-                })
-            })
+        }) {
+            return Ok(Some(block));
+        }
+
+        let client = self.create_client();
+        block_on(async move {
+            client
+                .get_block_by_number(block_number, full_transactions)
+                .await
+        })
+        .and_then(|block| {
+            if let Some(block) = &block {
+                self.cache
+                    .write()
+                    .and_then(|mut guard| {
+                        Ok(guard.insert_block(block.hash, full_transactions, block.clone()))
+                    })
+                    .unwrap_or_else(|err| {
+                        println!(
+                            "failed writing to cache for 'get_block_by_number': {:?}",
+                            err
+                        )
+                    });
+            }
+            Ok(block)
+        })
+        .wrap_err("fork http client failed")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zksync_basic_types::{MiniblockNumber, H256, U64};
+    use zksync_types::api::BlockNumber;
+
+    use crate::testing;
+
+    use super::*;
+
+    #[test]
+    fn test_get_block_by_hash_full_is_cached() {
+        let input_block_hash = H256::repeat_byte(0x01);
+        let input_block_number = 8;
+
+        let mock_server = testing::MockServer::run();
+        mock_server.expect(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "eth_getBlockByHash",
+                "params": [
+                    format!("{input_block_hash:#x}"),
+                    true
+                ],
+            }),
+            testing::BlockResponseBuilder::new()
+                .set_hash(input_block_hash)
+                .set_number(input_block_number)
+                .build(),
+        );
+
+        let fork_source = HttpForkSource::new(mock_server.url(), CacheConfig::Memory);
+
+        let actual_block = fork_source
+            .get_block_by_hash(input_block_hash, true)
+            .expect("failed fetching block by hash")
+            .expect("no block");
+
+        assert_eq!(input_block_hash, actual_block.hash);
+        assert_eq!(U64::from(input_block_number), actual_block.number);
+
+        let actual_block = fork_source
+            .get_block_by_hash(input_block_hash, true)
+            .expect("failed fetching cached block by hash")
+            .expect("no block");
+
+        assert_eq!(input_block_hash, actual_block.hash);
+        assert_eq!(U64::from(input_block_number), actual_block.number);
+    }
+
+    #[test]
+    fn test_get_block_by_hash_minimal_is_cached() {
+        let input_block_hash = H256::repeat_byte(0x01);
+        let input_block_number = 8;
+
+        let mock_server = testing::MockServer::run();
+        mock_server.expect(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "eth_getBlockByHash",
+                "params": [
+                    format!("{input_block_hash:#x}"),
+                    false
+                ],
+            }),
+            testing::BlockResponseBuilder::new()
+                .set_hash(input_block_hash)
+                .set_number(input_block_number)
+                .build(),
+        );
+
+        let fork_source = HttpForkSource::new(mock_server.url(), CacheConfig::Memory);
+
+        let actual_block = fork_source
+            .get_block_by_hash(input_block_hash, false)
+            .expect("failed fetching block by hash")
+            .expect("no block");
+
+        assert_eq!(input_block_hash, actual_block.hash);
+        assert_eq!(U64::from(input_block_number), actual_block.number);
+
+        let actual_block = fork_source
+            .get_block_by_hash(input_block_hash, false)
+            .expect("failed fetching cached block by hash")
+            .expect("no block");
+
+        assert_eq!(input_block_hash, actual_block.hash);
+        assert_eq!(U64::from(input_block_number), actual_block.number);
+    }
+
+    #[test]
+    fn test_get_block_by_number_full_is_cached() {
+        let input_block_hash = H256::repeat_byte(0x01);
+        let input_block_number = 8;
+
+        let mock_server = testing::MockServer::run();
+        mock_server.expect(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "eth_getBlockByNumber",
+                "params": [
+                    format!("{input_block_number:#x}"),
+                    true
+                ],
+            }),
+            testing::BlockResponseBuilder::new()
+                .set_hash(input_block_hash)
+                .set_number(input_block_number)
+                .build(),
+        );
+
+        let fork_source = HttpForkSource::new(mock_server.url(), CacheConfig::Memory);
+
+        let actual_block = fork_source
+            .get_block_by_number(
+                zksync_types::api::BlockNumber::Number(U64::from(input_block_number)),
+                true,
+            )
+            .expect("failed fetching block by number")
+            .expect("no block");
+
+        assert_eq!(input_block_hash, actual_block.hash);
+        assert_eq!(U64::from(input_block_number), actual_block.number);
+
+        let actual_block = fork_source
+            .get_block_by_number(
+                zksync_types::api::BlockNumber::Number(U64::from(input_block_number)),
+                true,
+            )
+            .expect("failed fetching cached block by number")
+            .expect("no block");
+
+        assert_eq!(input_block_hash, actual_block.hash);
+        assert_eq!(U64::from(input_block_number), actual_block.number);
+    }
+
+    #[test]
+    fn test_get_block_by_number_minimal_is_cached() {
+        let input_block_hash = H256::repeat_byte(0x01);
+        let input_block_number = 8;
+
+        let mock_server = testing::MockServer::run();
+        mock_server.expect(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "eth_getBlockByNumber",
+                "params": [
+                    format!("{input_block_number:#x}"),
+                    false
+                ],
+            }),
+            testing::BlockResponseBuilder::new()
+                .set_hash(input_block_hash)
+                .set_number(input_block_number)
+                .build(),
+        );
+
+        let fork_source = HttpForkSource::new(mock_server.url(), CacheConfig::Memory);
+
+        let actual_block = fork_source
+            .get_block_by_number(BlockNumber::Number(U64::from(input_block_number)), false)
+            .expect("failed fetching block by number")
+            .expect("no block");
+
+        assert_eq!(input_block_hash, actual_block.hash);
+        assert_eq!(U64::from(input_block_number), actual_block.number);
+
+        let actual_block = fork_source
+            .get_block_by_number(BlockNumber::Number(U64::from(input_block_number)), false)
+            .expect("failed fetching cached block by number")
+            .expect("no block");
+
+        assert_eq!(input_block_hash, actual_block.hash);
+        assert_eq!(U64::from(input_block_number), actual_block.number);
+    }
+
+    #[test]
+    fn test_get_raw_block_transactions_is_cached() {
+        let input_block_number = 8u32;
+
+        let mock_server = testing::MockServer::run();
+        mock_server.expect(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "zks_getRawBlockTransactions",
+                "params": [
+                    input_block_number,
+                ],
+            }),
+            testing::RawTransactionsResponseBuilder::new()
+                .add(1)
+                .build(),
+        );
+
+        let fork_source = HttpForkSource::new(mock_server.url(), CacheConfig::Memory);
+
+        let actual_raw_transactions = fork_source
+            .get_raw_block_transactions(MiniblockNumber(input_block_number))
+            .expect("failed fetching block raw transactions");
+        assert_eq!(1, actual_raw_transactions.len());
+
+        let actual_raw_transactions = fork_source
+            .get_raw_block_transactions(MiniblockNumber(input_block_number))
+            .expect("failed fetching cached block raw transactions");
+        assert_eq!(1, actual_raw_transactions.len());
+    }
+
+    #[test]
+    fn test_get_transactions_is_cached() {
+        let input_tx_hash = H256::repeat_byte(0x01);
+
+        let mock_server = testing::MockServer::run();
+        mock_server.expect(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "eth_getTransactionByHash",
+                "params": [
+                    input_tx_hash,
+                ],
+            }),
+            testing::TransactionResponseBuilder::new()
+                .set_hash(input_tx_hash)
+                .build(),
+        );
+
+        let fork_source = HttpForkSource::new(mock_server.url(), CacheConfig::Memory);
+
+        let actual_transaction = fork_source
+            .get_transaction_by_hash(input_tx_hash)
+            .expect("failed fetching transaction")
+            .expect("no transaction");
+        assert_eq!(input_tx_hash, actual_transaction.hash);
+
+        let actual_transaction = fork_source
+            .get_transaction_by_hash(input_tx_hash)
+            .expect("failed fetching cached transaction")
+            .expect("no transaction");
+        assert_eq!(input_tx_hash, actual_transaction.hash);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,5 +54,5 @@ pub mod system_contracts;
 pub mod utils;
 pub mod zks;
 
-mod testing;
 mod cache;
+mod testing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,3 +55,4 @@ pub mod utils;
 pub mod zks;
 
 mod testing;
+mod cache;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1078,7 +1078,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
             timestamp: U256::from(block_context.block_timestamp),
             l1_batch_number: Some(U64::from(block_context.block_number)),
             transactions: vec![TransactionVariant::Full(
-                zksync_types::api::Transaction::from(l2_tx.clone()),
+                zksync_types::api::Transaction::from(l2_tx),
             )],
             gas_used,
             gas_limit,


### PR DESCRIPTION
# What :computer: 
* Adds a caching layer to the http fork source.
* Adds `--cache` command line parameter to either:
  * `none` - disable caching
  * `memory` - in-memory caching
  * `disk` - persisted on-disk caching
* Adds `--cache-dir` & `--reset-cache` options to disk caching to select the cache location and whether to purge cache on startup, respectively

# Why :hand:
* During testing it is quite often intended to run similar requests multiple times. Having a cache reduces the required number of network calls to be made.

# Evidence :camera:
![image](https://github.com/matter-labs/era-test-node/assets/1564843/027480cc-d590-431d-b8dc-1cebce647177)

# Notes :memo:
* Fixes #106
