### PR TITLE
fix: bind server to 0.0.0.0 for external access

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -335,7 +335,7 @@ async fn main() -> anyhow::Result<()> {
     let hardhat = HardhatNamespaceImpl::new(node.get_inner());
 
     let threads = build_json_http(
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), opt.port),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), opt.port),
         node,
         net,
         config_api,


### PR DESCRIPTION
# What :computer:
* Updated RPC server binding address from `127.0.0.1` to `0.0.0.0`

# Why :hand:
* To allow access to the in-memory node both via `http://localhost:8011` and `http://127.0.0.1:8011`
* To ensure compatibility with Docker containerization

# Evidence :camera:
<img width="708" alt="image" src="https://github.com/matter-labs/era-test-node/assets/47187316/eae6afc1-d587-46fe-a670-e250f4039f9b">

# Notes :memo:
* Previously it wasn't possible to access in memory node on `http://localhost:8011` from the browser.
