### PR TITLE
feat: impl `evm_mine` and `hardhat_mine`

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -93,7 +93,7 @@ The `status` options are:
 | `HARDHAT` | `hardhat_impersonateAccount` | `NOT IMPLEMENTED`<br />[GitHub Issue #73](https://github.com/matter-labs/era-test-node/issues/73) | Impersonate an account |
 | `HARDHAT` | `hardhat_getAutomine` | `NOT IMPLEMENTED` | Returns `true` if automatic mining is enabled, and `false` otherwise |
 | `HARDHAT` | `hardhat_metadata` | `NOT IMPLEMENTED` | Returns the metadata of the current network |
-| `HARDHAT` | `hardhat_mine` | `NOT IMPLEMENTED`<br />[GitHub Issue #75](https://github.com/matter-labs/era-test-node/issues/75) | Mine any number of blocks at once, in constant time |
+| [`HARDHAT`](#hardhat-namespace) | [`hardhat_mine`](#hardhat_mine) | Mine any number of blocks at once, in constant time |
 | `HARDHAT` | `hardhat_reset` | `NOT IMPLEMENTED` | Resets the state of the network |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setBalance`](#hardhat_setbalance) | `SUPPORTED` | Modifies the balance of an account |
 | `HARDHAT` | `hardhat_setCode` | `NOT IMPLEMENTED` | Sets the bytecode of a given account |
@@ -798,6 +798,36 @@ curl --request POST \
         "0x1337"
       ]
   }'
+```
+
+### `hardhat_mine`
+
+[source](src/hardhat.rs)
+
+Sometimes you may want to advance the latest block number of the network by a large number of blocks.
+One way to do this would be to call the evm_mine RPC method multiple times, but this is too slow if you want to mine thousands of blocks.
+The hardhat_mine method can mine any number of blocks at once, in constant time. (It exhibits the same performance no matter how many blocks are mined.)
+
+#### Arguments
+
++ `num_blocks: U64` - The number of blocks to mine. (Optional: defaults to 1)
++ `interval: U646` - The interval between the timestamps of each block, in seconds. (Optional: defaults to 1)
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "hardhat_mine",
+    "params": [
+        "0xaa",
+        "0x100"
+    ]
+}'
 ```
 
 ## `EVM NAMESPACE`

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -75,7 +75,7 @@ The `status` options are:
 | `ETH` | `eth_unsubscribe` | `NOT IMPLEMENTED` | Cancel a subscription to a particular event |
 | `EVM` | `evm_addAccount` | `NOT IMPLEMENTED` | Adds any arbitrary account |
 | [`EVM`](#evm-namespace) | [`evm_increaseTime`](#evm_increasetime) | `SUPPORTED` | Jump forward in time by the given amount of time, in seconds |
-| `EVM` | `evm_mine` | `NOT IMPLEMENTED`<br />[GitHub Issue #67](https://github.com/matter-labs/era-test-node/issues/67) | Force a single block to be mined |
+| [`EVM`](#evm-namespace) | [`evm_mine`](#evm_mine) | `SUPPORTED` | Force a single block to be mined |
 | `EVM` | `evm_removeAccount` | `NOT IMPLEMENTED` | Removes an account |
 | `EVM` | `evm_revert` | `NOT IMPLEMENTED`<br />[GitHub Issue #70](https://github.com/matter-labs/era-test-node/issues/70) | Revert the state of the blockchain to a previous snapshot |
 | `EVM` | `evm_setAccountBalance` | `NOT IMPLEMENTED` | Sets the given account's balance to the specified WEI value |
@@ -801,6 +801,26 @@ curl --request POST \
 ```
 
 ## `EVM NAMESPACE`
+
+### `evm_mine`
+
+[source](src/evm.rs)
+
+Mines an empty block
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{"jsonrpc": "2.0","id": "1","method": "evm_mine","params": []
+}'
+```
 
 ### `evm_increaseTime`
 

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -125,7 +125,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EvmNamespaceT
             match inner.write() {
                 Ok(mut inner) => {
                     mine_empty_blocks(&mut inner, 1, 1000);
-                    println!("👷 Mined block #{}", inner.current_miniblock);
+                    log::info!("👷 Mined block #{}", inner.current_miniblock);
                     Ok("0x0".to_string())
                 }
                 Err(_) => Err(into_jsrpc_error(Web3Error::InternalError)),

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -3,7 +3,17 @@ use std::sync::{Arc, RwLock};
 use crate::{fork::ForkSource, node::InMemoryNodeInner};
 use jsonrpc_core::{BoxFuture, Result};
 use jsonrpc_derive::rpc;
+use vm::{
+    utils::BLOCK_GAS_LIMIT,
+    vm_with_bootloader::{init_vm_inner, BlockContextMode, BootloaderJobType, TxExecutionMode},
+    HistoryEnabled, OracleTools,
+};
+use zksync_basic_types::H256;
 use zksync_core::api_server::web3::backend_jsonrpc::error::into_jsrpc_error;
+use zksync_state::StorageView;
+use zksync_state::WriteStorage;
+use zksync_types::api::Block;
+use zksync_utils::u256_to_h256;
 use zksync_web3_decl::error::Web3Error;
 
 /// Implementation of EvmNamespace
@@ -29,6 +39,15 @@ pub trait EvmNamespaceT {
     /// The applied time delta to `current_timestamp` value for the InMemoryNodeInner.
     #[rpc(name = "evm_increaseTime")]
     fn increase_time(&self, time_delta_seconds: u64) -> BoxFuture<Result<u64>>;
+
+    /// Force a single block to be mined.
+    ///
+    /// Will mine an empty block (containing zero transactions)
+    ///
+    /// # Returns
+    /// The string "0x0".
+    #[rpc(name = "evm_mine")]
+    fn evm_mine(&self) -> BoxFuture<Result<String>>;
 
     /// Set the current timestamp for the node. The timestamp must be in future.
     ///
@@ -109,11 +128,90 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EvmNamespaceT
             }
         })
     }
+
+    fn evm_mine(&self) -> BoxFuture<Result<String>> {
+        let inner = Arc::clone(&self.node);
+        Box::pin(async move {
+            match inner.write() {
+                Ok(mut inner) => {
+                    let (keys, block, bytecodes) = {
+                        let mut storage_view = StorageView::new(&inner.fork_storage);
+                        let mut oracle_tools = OracleTools::new(&mut storage_view, HistoryEnabled);
+
+                        let bootloader_code = &inner.system_contracts.baseline_contracts;
+                        let block_context = inner.create_block_context();
+                        let block_properties =
+                            InMemoryNodeInner::<S>::create_block_properties(bootloader_code);
+
+                        let block = Block {
+                            hash: H256::random(),
+                            number: inner.current_miniblock.saturating_add(1).into(),
+                            timestamp: block_context.block_timestamp.into(),
+                            l1_batch_number: Some(block_context.block_number.into()),
+                            ..Default::default()
+                        };
+
+                        // init vm
+                        let mut vm = init_vm_inner(
+                            &mut oracle_tools,
+                            BlockContextMode::NewBlock(block_context.into(), Default::default()),
+                            &block_properties,
+                            BLOCK_GAS_LIMIT,
+                            bootloader_code,
+                            TxExecutionMode::VerifyExecute,
+                        );
+
+                        vm.execute_till_block_end(BootloaderJobType::BlockPostprocessing);
+
+                        let bytecodes = vm
+                            .state
+                            .decommittment_processor
+                            .known_bytecodes
+                            .inner()
+                            .clone();
+
+                        let modified_keys = storage_view.modified_storage_keys().clone();
+                        (modified_keys, block, bytecodes)
+                    };
+
+                    for (key, value) in keys.iter() {
+                        inner.fork_storage.set_value(*key, *value);
+                    }
+
+                    // Write all the factory deps.
+                    for (hash, code) in bytecodes.iter() {
+                        inner.fork_storage.store_factory_dep(
+                            u256_to_h256(*hash),
+                            code.iter()
+                                .flat_map(|entry| {
+                                    let mut bytes = vec![0u8; 32];
+                                    entry.to_big_endian(&mut bytes);
+                                    bytes.to_vec()
+                                })
+                                .collect(),
+                        )
+                    }
+                    println!("👷 Mined block #{}", block.number.as_u64());
+
+                    // update node state
+                    inner.block_hashes.insert(block.number.as_u64(), block.hash);
+                    inner.blocks.insert(block.hash, block);
+                    inner.current_timestamp += 1;
+                    inner.current_batch += 1;
+                    inner.current_miniblock += 1;
+
+                    Ok("0x0".to_string())
+                }
+                Err(_) => Err(into_jsrpc_error(Web3Error::InternalError)),
+            }
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{http_fork_source::HttpForkSource, node::InMemoryNode};
+    use zksync_core::api_server::web3::backend_jsonrpc::namespaces::eth::EthNamespaceT;
 
     use super::*;
 
@@ -420,5 +518,27 @@ mod tests {
                 "case {new_time}: timestamp was not set correctly",
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_evm_mine() {
+        let node = InMemoryNode::<HttpForkSource>::default();
+        let evm = EvmNamespaceImpl::new(node.get_inner());
+
+        let start_block = node
+            .get_block_by_number(zksync_types::api::BlockNumber::Latest, true)
+            .await
+            .unwrap()
+            .expect("block exists");
+
+        let result = evm.evm_mine().await.expect("evm_mine");
+        assert_eq!(&result, "0x0");
+
+        let current_block = node
+            .get_block_by_number(zksync_types::api::BlockNumber::Latest, true)
+            .await
+            .unwrap()
+            .expect("block exists");
+        assert_eq!(start_block.number + 1, current_block.number);
     }
 }

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -1,19 +1,9 @@
 use std::sync::{Arc, RwLock};
 
-use crate::{fork::ForkSource, node::InMemoryNodeInner};
+use crate::{fork::ForkSource, node::InMemoryNodeInner, utils::mine_empty_blocks};
 use jsonrpc_core::{BoxFuture, Result};
 use jsonrpc_derive::rpc;
-use vm::{
-    utils::BLOCK_GAS_LIMIT,
-    vm_with_bootloader::{init_vm_inner, BlockContextMode, BootloaderJobType, TxExecutionMode},
-    HistoryEnabled, OracleTools,
-};
-use zksync_basic_types::H256;
 use zksync_core::api_server::web3::backend_jsonrpc::error::into_jsrpc_error;
-use zksync_state::StorageView;
-use zksync_state::WriteStorage;
-use zksync_types::api::Block;
-use zksync_utils::u256_to_h256;
 use zksync_web3_decl::error::Web3Error;
 
 /// Implementation of EvmNamespace
@@ -134,72 +124,8 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EvmNamespaceT
         Box::pin(async move {
             match inner.write() {
                 Ok(mut inner) => {
-                    let (keys, block, bytecodes) = {
-                        let mut storage_view = StorageView::new(&inner.fork_storage);
-                        let mut oracle_tools = OracleTools::new(&mut storage_view, HistoryEnabled);
-
-                        let bootloader_code = &inner.system_contracts.baseline_contracts;
-                        let block_context = inner.create_block_context();
-                        let block_properties =
-                            InMemoryNodeInner::<S>::create_block_properties(bootloader_code);
-
-                        let block = Block {
-                            hash: H256::random(),
-                            number: inner.current_miniblock.saturating_add(1).into(),
-                            timestamp: block_context.block_timestamp.into(),
-                            l1_batch_number: Some(block_context.block_number.into()),
-                            ..Default::default()
-                        };
-
-                        // init vm
-                        let mut vm = init_vm_inner(
-                            &mut oracle_tools,
-                            BlockContextMode::NewBlock(block_context.into(), Default::default()),
-                            &block_properties,
-                            BLOCK_GAS_LIMIT,
-                            bootloader_code,
-                            TxExecutionMode::VerifyExecute,
-                        );
-
-                        vm.execute_till_block_end(BootloaderJobType::BlockPostprocessing);
-
-                        let bytecodes = vm
-                            .state
-                            .decommittment_processor
-                            .known_bytecodes
-                            .inner()
-                            .clone();
-
-                        let modified_keys = storage_view.modified_storage_keys().clone();
-                        (modified_keys, block, bytecodes)
-                    };
-
-                    for (key, value) in keys.iter() {
-                        inner.fork_storage.set_value(*key, *value);
-                    }
-
-                    // Write all the factory deps.
-                    for (hash, code) in bytecodes.iter() {
-                        inner.fork_storage.store_factory_dep(
-                            u256_to_h256(*hash),
-                            code.iter()
-                                .flat_map(|entry| {
-                                    let mut bytes = vec![0u8; 32];
-                                    entry.to_big_endian(&mut bytes);
-                                    bytes.to_vec()
-                                })
-                                .collect(),
-                        )
-                    }
-                    log::info!("👷 Mined block #{}", block.number.as_u64());
-
-                    // update node state
-                    inner.block_hashes.insert(block.number.as_u64(), block.hash);
-                    inner.blocks.insert(block.hash, block);
-                    inner.current_timestamp += 1;
-                    inner.current_batch += 1;
-                    inner.current_miniblock += 1;
-
+                    mine_empty_blocks(&mut inner, 1, 1000);
+                    println!("👷 Mined block #{}", inner.current_miniblock);
                     Ok("0x0".to_string())
                 }
                 Err(_) => Err(into_jsrpc_error(Web3Error::InternalError)),
@@ -526,19 +452,32 @@ mod tests {
         let evm = EvmNamespaceImpl::new(node.get_inner());
 
         let start_block = node
-            .get_block_by_number(zksync_types::api::BlockNumber::Latest, true)
+            .get_block_by_number(zksync_types::api::BlockNumber::Latest, false)
             .await
             .unwrap()
             .expect("block exists");
+        let result = evm.evm_mine().await.expect("evm_mine");
+        assert_eq!(&result, "0x0");
+
+        let current_block = node
+            .get_block_by_number(zksync_types::api::BlockNumber::Latest, false)
+            .await
+            .unwrap()
+            .expect("block exists");
+
+        assert_eq!(start_block.number + 1, current_block.number);
+        assert_eq!(start_block.timestamp + 1000, current_block.timestamp);
 
         let result = evm.evm_mine().await.expect("evm_mine");
         assert_eq!(&result, "0x0");
 
         let current_block = node
-            .get_block_by_number(zksync_types::api::BlockNumber::Latest, true)
+            .get_block_by_number(zksync_types::api::BlockNumber::Latest, false)
             .await
             .unwrap()
             .expect("block exists");
-        assert_eq!(start_block.number + 1, current_block.number);
+
+        assert_eq!(start_block.number + 2, current_block.number);
+        assert_eq!(start_block.timestamp + 2000, current_block.timestamp);
     }
 }

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -191,7 +191,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EvmNamespaceT
                                 .collect(),
                         )
                     }
-                    println!("👷 Mined block #{}", block.number.as_u64());
+                    log::info!("👷 Mined block #{}", block.number.as_u64());
 
                     // update node state
                     inner.block_hashes.insert(block.number.as_u64(), block.hash);

--- a/src/hardhat.rs
+++ b/src/hardhat.rs
@@ -167,7 +167,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> HardhatNamespaceT
                         ));
                     }
                     mine_empty_blocks(&mut inner, num_blocks.as_u64(), interval_ms.as_u64());
-                    println!("👷 Mined {} blocks", num_blocks);
+                    log::info!("👷 Mined {} blocks", num_blocks);
                     Ok(true)
                 }
                 Err(_) => Err(into_jsrpc_error(Web3Error::InternalError)),
@@ -232,7 +232,6 @@ mod tests {
             .await
             .unwrap()
             .expect("block exists");
-        println!("start_block: {:?}", start_block);
 
         // test with defaults
         let result = hardhat
@@ -241,13 +240,11 @@ mod tests {
             .expect("hardhat_mine");
         assert_eq!(result, true);
 
-        println!("mined default");
         let current_block = node
             .get_block_by_number(zksync_types::api::BlockNumber::Latest, false)
             .await
             .unwrap()
             .expect("block exists");
-        println!("current_block: {:?}", current_block);
 
         assert_eq!(start_block.number + 1, current_block.number);
         assert_eq!(start_block.timestamp + 1000, current_block.timestamp);
@@ -257,13 +254,11 @@ mod tests {
             .expect("hardhat_mine");
         assert_eq!(result, true);
 
-        println!("mined default");
         let current_block = node
             .get_block_by_number(zksync_types::api::BlockNumber::Latest, false)
             .await
             .unwrap()
             .expect("block exists");
-        println!("current_block: {:?}", current_block);
 
         assert_eq!(start_block.number + 2, current_block.number);
         assert_eq!(start_block.timestamp + 2000, current_block.timestamp);
@@ -279,7 +274,6 @@ mod tests {
             .await
             .unwrap()
             .expect("block exists");
-        println!("start_block: {:?}", start_block);
 
         // test with custom values
         let result = hardhat
@@ -287,6 +281,5 @@ mod tests {
             .await
             .expect("hardhat_mine");
         assert_eq!(result, true);
-        println!("mined twice");
     }
 }

--- a/src/hardhat.rs
+++ b/src/hardhat.rs
@@ -1,9 +1,9 @@
 use std::sync::{Arc, RwLock};
 
-use crate::{fork::ForkSource, node::InMemoryNodeInner};
+use crate::{fork::ForkSource, node::InMemoryNodeInner, utils::mine_empty_blocks};
 use jsonrpc_core::{BoxFuture, Result};
 use jsonrpc_derive::rpc;
-use zksync_basic_types::{Address, U256};
+use zksync_basic_types::{Address, U256, U64};
 use zksync_core::api_server::web3::backend_jsonrpc::error::into_jsrpc_error;
 use zksync_state::ReadStorage;
 use zksync_types::{
@@ -52,6 +52,25 @@ pub trait HardhatNamespaceT {
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "hardhat_setNonce")]
     fn set_nonce(&self, address: Address, balance: U256) -> BoxFuture<Result<bool>>;
+
+    /// Sometimes you may want to advance the latest block number of the network by a large number of blocks.
+    /// One way to do this would be to call the evm_mine RPC method multiple times, but this is too slow if you want to mine thousands of blocks.
+    /// The hardhat_mine method can mine any number of blocks at once, in constant time. (It exhibits the same performance no matter how many blocks are mined.)
+    ///
+    /// # Arguments
+    ///
+    /// * `num_blocks` - The number of blocks to mine, defaults to 1
+    /// * `interval` - The interval between the timestamps of each block, in seconds, and it also defaults to 1
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
+    #[rpc(name = "hardhat_mine")]
+    fn hardhat_mine(
+        &self,
+        num_blocks: Option<U64>,
+        interval: Option<U64>,
+    ) -> BoxFuture<Result<bool>>;
 }
 
 impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> HardhatNamespaceT
@@ -128,6 +147,33 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> HardhatNamespaceT
             }
         })
     }
+
+    fn hardhat_mine(
+        &self,
+        num_blocks: Option<U64>,
+        interval: Option<U64>,
+    ) -> BoxFuture<Result<bool>> {
+        let inner = Arc::clone(&self.node);
+        Box::pin(async move {
+            match inner.write() {
+                Ok(mut inner) => {
+                    let num_blocks = num_blocks.unwrap_or(U64::from(1));
+                    let interval_ms = interval
+                        .unwrap_or(U64::from(1))
+                        .saturating_mul(1_000.into());
+                    if num_blocks.is_zero() {
+                        return Err(jsonrpc_core::Error::invalid_params(
+                            "Number of blocks must be greater than 0".to_string(),
+                        ));
+                    }
+                    mine_empty_blocks(&mut inner, num_blocks.as_u64(), interval_ms.as_u64());
+                    println!("👷 Mined {} blocks", num_blocks);
+                    Ok(true)
+                }
+                Err(_) => Err(into_jsrpc_error(Web3Error::InternalError)),
+            }
+        })
+    }
 }
 
 #[cfg(test)]
@@ -174,5 +220,73 @@ mod tests {
         // setting nonce lower than the current one should fail
         let result = hardhat.set_nonce(address, U256::from(1336)).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_hardhat_mine_default() {
+        let node = InMemoryNode::<HttpForkSource>::default();
+        let hardhat = HardhatNamespaceImpl::new(node.get_inner());
+
+        let start_block = node
+            .get_block_by_number(zksync_types::api::BlockNumber::Latest, false)
+            .await
+            .unwrap()
+            .expect("block exists");
+        println!("start_block: {:?}", start_block);
+
+        // test with defaults
+        let result = hardhat
+            .hardhat_mine(None, None)
+            .await
+            .expect("hardhat_mine");
+        assert_eq!(result, true);
+
+        println!("mined default");
+        let current_block = node
+            .get_block_by_number(zksync_types::api::BlockNumber::Latest, false)
+            .await
+            .unwrap()
+            .expect("block exists");
+        println!("current_block: {:?}", current_block);
+
+        assert_eq!(start_block.number + 1, current_block.number);
+        assert_eq!(start_block.timestamp + 1000, current_block.timestamp);
+        let result = hardhat
+            .hardhat_mine(None, None)
+            .await
+            .expect("hardhat_mine");
+        assert_eq!(result, true);
+
+        println!("mined default");
+        let current_block = node
+            .get_block_by_number(zksync_types::api::BlockNumber::Latest, false)
+            .await
+            .unwrap()
+            .expect("block exists");
+        println!("current_block: {:?}", current_block);
+
+        assert_eq!(start_block.number + 2, current_block.number);
+        assert_eq!(start_block.timestamp + 2000, current_block.timestamp);
+    }
+
+    #[tokio::test]
+    async fn test_hardhat_mine_custom() {
+        let node = InMemoryNode::<HttpForkSource>::default();
+        let hardhat = HardhatNamespaceImpl::new(node.get_inner());
+
+        let start_block = node
+            .get_block_by_number(zksync_types::api::BlockNumber::Latest, false)
+            .await
+            .unwrap()
+            .expect("block exists");
+        println!("start_block: {:?}", start_block);
+
+        // test with custom values
+        let result = hardhat
+            .hardhat_mine(Some(U64::from(5)), Some(U64::from(10)))
+            .await
+            .expect("hardhat_mine");
+        assert_eq!(result, true);
+        println!("mined twice");
     }
 }

--- a/src/hardhat.rs
+++ b/src/hardhat.rs
@@ -277,9 +277,17 @@ mod tests {
 
         // test with custom values
         let result = hardhat
-            .hardhat_mine(Some(U64::from(5)), Some(U64::from(10)))
+            .hardhat_mine(Some(U64::from(2)), Some(U64::from(10)))
             .await
             .expect("hardhat_mine");
         assert_eq!(result, true);
+
+        let current_block = node
+            .get_block_by_number(zksync_types::api::BlockNumber::Latest, false)
+            .await
+            .unwrap()
+            .expect("block exists");
+        assert_eq!(start_block.number + 5, current_block.number);
+        assert_eq!(start_block.timestamp + 50_000, current_block.timestamp);
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -253,7 +253,7 @@ type L2TxResult = (
 );
 
 impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
-    fn create_block_context(&self) -> BlockContext {
+    pub fn create_block_context(&self) -> BlockContext {
         BlockContext {
             block_number: self.current_batch,
             block_timestamp: self.current_timestamp,
@@ -263,7 +263,7 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
         }
     }
 
-    fn create_block_properties(contracts: &BaseSystemContracts) -> BlockProperties {
+    pub fn create_block_properties(contracts: &BaseSystemContracts) -> BlockProperties {
         BlockProperties {
             default_aa_code_hash: h256_to_u256(contracts.default_aa.hash),
             zkporter_is_available: false,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -189,9 +189,9 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
         let mut storage_view: StorageView<&ForkStorage<S>> = StorageView::new(&node.fork_storage);
         let mut oracle_tools = OracleTools::new(&mut storage_view, HistoryEnabled);
 
-        let bootloader_code = node
-            .system_contracts
-            .contracts(TxExecutionMode::VerifyExecute);
+        // system_contract.contacts_for_l2_call() will give playground contracts
+        // we need these to use the unsafeOverrideBlock method in SystemContext.sol
+        let bootloader_code = node.system_contracts.contacts_for_l2_call();
         let block_context = BlockContext {
             block_number: node.current_miniblock as u32,
             block_timestamp: node.current_timestamp,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,13 +1,27 @@
 use std::pin::Pin;
 
 use futures::Future;
-use vm::vm_with_bootloader::{
-    derive_base_fee_and_gas_per_pubdata, BLOCK_OVERHEAD_GAS, BLOCK_OVERHEAD_PUBDATA,
-    BOOTLOADER_TX_ENCODING_SPACE,
+use vm::{
+    utils::BLOCK_GAS_LIMIT,
+    vm_with_bootloader::{
+        derive_base_fee_and_gas_per_pubdata, init_vm_inner, BlockContext, BlockContextMode,
+        BootloaderJobType, TxExecutionMode, BLOCK_OVERHEAD_GAS, BLOCK_OVERHEAD_PUBDATA,
+        BOOTLOADER_TX_ENCODING_SPACE,
+    },
+    HistoryEnabled, OracleTools,
 };
-use zksync_basic_types::U256;
-use zksync_types::{zk_evm::zkevm_opcode_defs::system_params::MAX_TX_ERGS_LIMIT, MAX_TXS_IN_BLOCK};
-use zksync_utils::ceil_div_u256;
+use zksync_basic_types::{H256, U256};
+use zksync_state::StorageView;
+use zksync_state::WriteStorage;
+use zksync_types::{
+    api::Block, zk_evm::zkevm_opcode_defs::system_params::MAX_TX_ERGS_LIMIT, MAX_TXS_IN_BLOCK,
+};
+use zksync_utils::{ceil_div_u256, u256_to_h256};
+
+use crate::{
+    fork::{ForkSource, ForkStorage},
+    node::{compute_hash, InMemoryNodeInner},
+};
 
 pub(crate) trait IntoBoxedFuture: Sized + Send + 'static {
     fn into_boxed_future(self) -> Pin<Box<dyn Future<Output = Self> + Send>> {
@@ -141,6 +155,90 @@ pub fn to_human_size(input: U256) -> String {
         })
         .collect();
     tmp.iter().rev().collect()
+}
+
+/// Creates and inserts a given number of empty blocks into the node, with a given interval between them.
+/// The blocks will be empty (contain no transactions).
+/// The test system contracts will be used to force overwriting the block number and timestamp in VM state,
+/// otherwise the VM will reject subsequent blocks as invalid.
+pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
+    node: &mut InMemoryNodeInner<S>,
+    num_blocks: u64,
+    interval_ms: u64,
+) {
+    // build and insert new blocks
+    for _ in 0..num_blocks {
+        node.current_miniblock = node.current_miniblock.saturating_add(1);
+
+        let block = Block {
+            hash: compute_hash(node.current_miniblock as u32, H256::zero()),
+            number: node.current_batch.into(),
+            timestamp: node.current_timestamp.into(),
+            ..Default::default()
+        };
+
+        node.block_hashes.insert(node.current_miniblock, block.hash);
+        node.blocks.insert(block.hash, block);
+
+        // leave node state ready for next interaction
+        node.current_timestamp = node.current_timestamp.saturating_add(interval_ms);
+        node.current_batch = node.current_batch.saturating_add(1);
+    }
+
+    // roll the vm
+    let (keys, bytecodes) = {
+        let mut storage_view: StorageView<&ForkStorage<S>> = StorageView::new(&node.fork_storage);
+        let mut oracle_tools = OracleTools::new(&mut storage_view, HistoryEnabled);
+
+        let bootloader_code = &node.system_contracts.playground_contracts;
+
+        let block_context = BlockContext {
+            block_number: node.current_batch - 1,
+            block_timestamp: node.current_timestamp,
+            ..node.create_block_context()
+        };
+        let block_properties = InMemoryNodeInner::<S>::create_block_properties(bootloader_code);
+
+        // init vm
+        let mut vm = init_vm_inner(
+            &mut oracle_tools,
+            BlockContextMode::OverrideCurrent(block_context.into()),
+            &block_properties,
+            BLOCK_GAS_LIMIT,
+            bootloader_code,
+            TxExecutionMode::VerifyExecute,
+        );
+
+        vm.execute_till_block_end(BootloaderJobType::BlockPostprocessing);
+
+        let bytecodes = vm
+            .state
+            .decommittment_processor
+            .known_bytecodes
+            .inner()
+            .clone();
+
+        let modified_keys = storage_view.modified_storage_keys().clone();
+        (modified_keys, bytecodes)
+    };
+
+    for (key, value) in keys.iter() {
+        node.fork_storage.set_value(*key, *value);
+    }
+
+    // Write all the factory deps.
+    for (hash, code) in bytecodes.iter() {
+        node.fork_storage.store_factory_dep(
+            u256_to_h256(*hash),
+            code.iter()
+                .flat_map(|entry| {
+                    let mut bytes = vec![0u8; 32];
+                    entry.to_big_endian(&mut bytes);
+                    bytes.to_vec()
+                })
+                .collect(),
+        )
+    }
 }
 
 #[cfg(test)]

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -311,6 +311,17 @@ content-type: application/json
 
 {
     "jsonrpc": "2.0",
+    "id": "1",
+    "method": "evm_mine",
+    "params": []
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
     "id": "2",
     "method": "eth_getBlockByHash",
     "params": ["0x371c9871792d89fea30e6b947ca45e9798e4f577dcdddb79269a93450f52b459", true]

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -395,6 +395,20 @@ content-type: application/json
 
 {
     "jsonrpc": "2.0",
+    "id": "2",
+    "method": "hardhat_mine",
+    "params": [
+        "0xaa",
+        "0x100"
+    ]
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
     "id": "1",
     "method": "zks_getTokenPrice",
     "params": ["0x0000000000000000000000000000000000000000"]


### PR DESCRIPTION
# What :computer: 
* Adds `evm_mine` as supported RPC method
* Adds `hardhat_mine` as supported RPC method
* Adds tests/docs

# Why :hand:
* Allows user to manually trigger a new block(s) to be mined

# Evidence :camera:
![image](https://github.com/matter-labs/era-test-node/assets/140627974/a6429b2a-bb0f-4f84-905e-6a438ad9f9a8)
![image](https://github.com/matter-labs/era-test-node/assets/140627974/c369cc8a-b215-45ad-9acb-febc948caa7c)
![image](https://github.com/matter-labs/era-test-node/assets/140627974/b1377123-cedd-4e1b-982b-2f0a8bdfd13f)
![image](https://github.com/matter-labs/era-test-node/assets/140627974/9e799f8b-79c4-4e49-88e1-e8011410fdcc)

# Notes :memo:
* Seems quite a lot of setup for rolling new block