### PR TITLE
feat: add logs for incoming API requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,7 +1774,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "era_test_node"
-version = "0.1.0"
+version = "0.1.0-alpha.3"
 dependencies = [
  "anyhow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "0.1.0"
+version = "0.1.0-alpha.3"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"

--- a/src/hardhat.rs
+++ b/src/hardhat.rs
@@ -239,7 +239,7 @@ mod tests {
             .hardhat_mine(None, None)
             .await
             .expect("hardhat_mine");
-        assert_eq!(result, true);
+        assert!(result);
 
         let current_block = node
             .get_block_by_number(zksync_types::api::BlockNumber::Latest, false)
@@ -253,7 +253,7 @@ mod tests {
             .hardhat_mine(None, None)
             .await
             .expect("hardhat_mine");
-        assert_eq!(result, true);
+        assert!(result);
 
         let current_block = node
             .get_block_by_number(zksync_types::api::BlockNumber::Latest, false)
@@ -284,7 +284,7 @@ mod tests {
             .hardhat_mine(Some(U64::from(num_blocks)), Some(U64::from(interval)))
             .await
             .expect("hardhat_mine");
-        assert_eq!(result, true);
+        assert!(result);
 
         for i in 0..num_blocks {
             let current_block = node

--- a/src/logging_middleware.rs
+++ b/src/logging_middleware.rs
@@ -1,0 +1,99 @@
+use colored::Colorize;
+use itertools::Itertools;
+use jsonrpc_core::{Middleware, Metadata, Request, Response, middleware, FutureResponse, Call, Params};
+use futures::future::Either;
+use futures::Future;
+use log::LevelFilter;
+
+#[derive(Clone, Debug, Default)]
+pub struct Meta();
+impl Metadata for Meta {}
+
+pub struct LoggingMiddleware {
+    log_level_filter: LevelFilter,
+}
+
+impl LoggingMiddleware {
+    pub fn new(log_level_filter: LevelFilter) -> Self {
+        Self { log_level_filter }
+    }
+}
+
+/// Logging Middleware for all in-bound requests
+/// Logs out incoming requests and their parameters
+/// Useful for debugging applications that are pointed at this service
+impl Middleware<Meta> for LoggingMiddleware {
+	type Future = FutureResponse;
+	type CallFuture = middleware::NoopCallFuture;
+
+	fn on_request<F, X>(&self, request: Request, meta: Meta, next: F) -> Either<Self::Future, X>
+	where
+		F: FnOnce(Request, Meta) -> X + Send,
+		X: Future<Output = Option<Response>> + Send + 'static,
+	{
+        match &request {
+            Request::Single(call) => {
+                match call {
+                    Call::MethodCall(method_call) => {
+                        match self.log_level_filter {
+                            LevelFilter::Debug => {
+                                let full_params = match &method_call.params {
+                                    Params::Array(values) => {
+                                        if values.len() == 0 {
+                                            String::default()
+                                        } else {
+                                            format!("with [{}]", values.iter().join(", "))
+                                        }
+
+                                    },
+                                    _ => String::default()
+                                };
+
+                                log::debug!(
+                                    "{} was called {}",
+                                    method_call.method.cyan(),
+                                    full_params);
+                            },
+                            _ => {
+                                // Generate truncated params for requests with massive payloads
+                                let truncated_params = match &method_call.params {
+                                    Params::Array(values) => {
+                                        if values.len() == 0 {
+                                            String::default()
+                                        } else {
+                                            format!("with [{}]",
+                                                values
+                                                    .iter()
+                                                    .map(|s| {
+                                                        let s_str = s.to_string();
+                                                        if s_str.len() > 70 {
+                                                            format!("{:.67}...", s_str)
+                                                        } else {
+                                                            s_str
+                                                        }
+                                                    })
+                                                    .collect::<Vec<String>>()
+                                                    .join(", ")
+                                            )
+                                        }
+
+                                    },
+                                    _ => String::default()
+                                };
+
+                                log::info!(
+                                    "{} was called {}",
+                                    method_call.method.cyan(),
+                                    truncated_params);
+                            }
+                        }
+                    },
+                    _ => {}
+                }
+            },
+            _ => {}
+        };
+
+		Either::Left(Box::pin(next(request, meta)))
+	}
+}

--- a/src/logging_middleware.rs
+++ b/src/logging_middleware.rs
@@ -1,6 +1,6 @@
 use colored::Colorize;
-use futures::{future::Either, FutureExt};
 use futures::Future;
+use futures::{future::Either, FutureExt};
 use itertools::Itertools;
 use jsonrpc_core::{
     middleware, Call, FutureResponse, Metadata, Middleware, Params, Request, Response,
@@ -86,8 +86,8 @@ impl Middleware<Meta> for LoggingMiddleware {
         };
 
         Either::Left(Box::pin(next(request, meta).map(move |res| {
-			log::trace!("API response => {:?}", res);
-			res
-		})))
+            log::trace!("API response => {:?}", res);
+            res
+        })))
     }
 }

--- a/src/logging_middleware.rs
+++ b/src/logging_middleware.rs
@@ -1,5 +1,5 @@
 use colored::Colorize;
-use futures::future::Either;
+use futures::{future::Either, FutureExt};
 use futures::Future;
 use itertools::Itertools;
 use jsonrpc_core::{
@@ -85,6 +85,9 @@ impl Middleware<Meta> for LoggingMiddleware {
             }
         };
 
-        Either::Left(Box::pin(next(request, meta)))
+        Either::Left(Box::pin(next(request, meta).map(move |res| {
+			log::trace!("API response => {:?}", res);
+			res
+		})))
     }
 }

--- a/src/logging_middleware.rs
+++ b/src/logging_middleware.rs
@@ -35,7 +35,7 @@ impl Middleware<Meta> for LoggingMiddleware {
     {
         if let Request::Single(Call::MethodCall(method_call)) = &request {
             match self.log_level_filter {
-                LevelFilter::Debug => {
+                LevelFilter::Trace => {
                     let full_params = match &method_call.params {
                         Params::Array(values) => {
                             if values.is_empty() {
@@ -47,7 +47,7 @@ impl Middleware<Meta> for LoggingMiddleware {
                         _ => String::default(),
                     };
 
-                    log::debug!("{} was called {}", method_call.method.cyan(), full_params);
+                    log::trace!("{} was called {}", method_call.method.cyan(), full_params);
                 }
                 _ => {
                     // Generate truncated params for requests with massive payloads

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,7 +338,7 @@ async fn main() -> anyhow::Result<()> {
     let hardhat = HardhatNamespaceImpl::new(node.get_inner());
 
     let threads = build_json_http(
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), opt.port),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), opt.port),
         log_level_filter,
         node,
         net,

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,7 @@ pub const RICH_WALLETS: [(&str, &str); 10] = [
     ),
 ];
 
+#[allow(clippy::too_many_arguments)]
 async fn build_json_http<
     S: std::marker::Sync + std::marker::Send + 'static + ForkSource + std::fmt::Debug,
 >(

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,7 @@ async fn build_json_http<
 /// Log filter level for the node.
 #[derive(Debug, Clone, ValueEnum)]
 enum LogLevel {
+    Trace,
     Debug,
     Info,
     Warn,
@@ -158,6 +159,7 @@ enum LogLevel {
 impl From<LogLevel> for LevelFilter {
     fn from(value: LogLevel) -> Self {
         match value {
+            LogLevel::Trace => LevelFilter::Trace,
             LogLevel::Debug => LevelFilter::Debug,
             LogLevel::Info => LevelFilter::Info,
             LogLevel::Warn => LevelFilter::Warn,

--- a/src/node.rs
+++ b/src/node.rs
@@ -2120,31 +2120,7 @@ mod tests {
     async fn test_get_fee_history_with_multiple_blocks() {
         // Arrange
         let node = InMemoryNode::<HttpForkSource>::default();
-
-        let private_key = H256::random();
-        let from_account = PackedEthSignature::address_from_private_key(&private_key)
-            .expect("failed generating address");
-        node.set_rich_account(from_account);
-        let mut tx = L2Tx::new_signed(
-            Address::random(),
-            vec![],
-            Nonce(0),
-            Fee {
-                gas_limit: U256::from(1_000_000),
-                max_fee_per_gas: U256::from(250_000_000),
-                max_priority_fee_per_gas: U256::from(250_000_000),
-                gas_per_pubdata_limit: U256::from(20000),
-            },
-            U256::from(1),
-            L2ChainId(260),
-            &private_key,
-            None,
-            Default::default(),
-        )
-        .unwrap();
-        tx.set_input(vec![], H256::repeat_byte(0x01));
-
-        node.apply_txs(vec![tx]).expect("failed applying tx");
+        testing::apply_tx(&node, H256::repeat_byte(0x01));
 
         // Act
         let fee_history = node

--- a/src/node.rs
+++ b/src/node.rs
@@ -559,7 +559,7 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
 fn not_implemented<T: Send + 'static>(
     method_name: &str,
 ) -> jsonrpc_core::BoxFuture<Result<T, jsonrpc_core::Error>> {
-    log::info!("Method {} is not implemented", method_name);
+    log::info!("{}", format!("Method {} is not implemented", method_name).yellow());
     Err(jsonrpc_core::Error {
         data: None,
         code: jsonrpc_core::ErrorCode::MethodNotFound,

--- a/src/node.rs
+++ b/src/node.rs
@@ -1994,7 +1994,7 @@ mod tests {
         .unwrap();
         tx.set_input(vec![], H256::repeat_byte(0x01));
 
-        node.apply_txs(vec![tx.into()]).expect("failed applying tx");
+        node.apply_txs(vec![tx]).expect("failed applying tx");
 
         let expected_block_hash =
             H256::from_str("0x89c0aa770eba1f187235bdad80de9c01fe81bca415d442ca892f087da56fa109")
@@ -2120,7 +2120,7 @@ mod tests {
         .unwrap();
         tx.set_input(vec![], H256::repeat_byte(0x01));
 
-        node.apply_txs(vec![tx.into()]).expect("failed applying tx");
+        node.apply_txs(vec![tx]).expect("failed applying tx");
 
         let expected_block_number = 1;
         let actual_block = node
@@ -2197,7 +2197,7 @@ mod tests {
         .unwrap();
         tx.set_input(vec![], H256::repeat_byte(0x01));
 
-        node.apply_txs(vec![tx.into()]).expect("failed applying tx");
+        node.apply_txs(vec![tx]).expect("failed applying tx");
 
         let latest_block_number = 1;
         let actual_block = node

--- a/src/node.rs
+++ b/src/node.rs
@@ -559,7 +559,7 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
 fn not_implemented<T: Send + 'static>(
     method_name: &str,
 ) -> jsonrpc_core::BoxFuture<Result<T, jsonrpc_core::Error>> {
-    log::info!("{}", format!("Method {} is not implemented", method_name).yellow());
+    log::warn!("Method {} is not implemented", method_name);
     Err(jsonrpc_core::Error {
         data: None,
         code: jsonrpc_core::ErrorCode::MethodNotFound,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -124,7 +124,6 @@ impl MockServer {
                     "sealFields": [],
                     "uncles": [],
                     "transactions": (0..block_config.transaction_count)
-                        .into_iter()
                         .map(|index| {
                             TransactionResponseBuilder::new()
                                 .set_hash(H256::repeat_byte(index))
@@ -381,7 +380,7 @@ pub fn apply_tx<T: ForkSource + std::fmt::Debug>(node: &InMemoryNode<T>, tx_hash
     )
     .unwrap();
     tx.set_input(vec![], tx_hash);
-    node.apply_txs(vec![tx.into()]).expect("failed applying tx");
+    node.apply_txs(vec![tx]).expect("failed applying tx");
 
     produced_block_hash
 }
@@ -463,7 +462,7 @@ mod test {
             .as_object()
             .and_then(|o| o.get("result").unwrap().as_array())
             .map(|o| {
-                o.into_iter()
+                o.iter()
                     .map(|o| o.get("common_data").unwrap().as_object().unwrap())
                     .map(|o| o.get("L1").unwrap().as_object().unwrap())
                     .map(|entry| entry.get("serialId").unwrap().as_u64().unwrap())


### PR DESCRIPTION
# What :computer: 
* Add logs for incoming API requests
* Update `not_implemented` logs to warnings
* Update version number to match latest release
* Fix unit test

# Why :hand:
* This shows a clearer picture of what's happening against the node. When debugging an interaction with other tools like MetaMask, Portal, Block Explorer, etc. it's VERY useful to know what requests have been made and might be silently failing
* Warning better encapsulated the response now that it's contrasted against the initial request
* This was out of date per the latest release
* Overlooked prior to merge of a refactor when implementing `eth_feeHistory`

# Evidence :camera:
Example of new `not_implemented` logs:
<img width="349" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/62dc0979-b1ca-4739-8784-b846602ef11d">

Output of `make test-e2e` with default logs:
<img width="794" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/26c32c4a-90b4-4c8b-97e6-2bd714ceb570">

Output of `eth_getBlockByNumber` with `trace` log level:
<img width="903" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/04030ae7-4f99-45ad-b635-c910c366f54f">

# Notes :memo:
* I chose to reference the `LevelFilter` in the middleware because I wanted to avoid duplicate log statements for `trace` and `info`. The `info` is meant to be truncated/short/concise, while trace log can be MASSIVE depending on the incoming payload.
