### PR TITLE
feat: add filter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,6 +1792,7 @@ dependencies = [
  "jsonrpc-http-server",
  "lazy_static",
  "log",
+ "maplit",
  "once_cell",
  "openssl-sys",
  "reqwest",
@@ -3453,6 +3454,12 @@ checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "match_cfg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,4 @@ rustc-hash = "1.1.0"
 [dev-dependencies]
 httptest = "0.15.4"
 tempdir = "0.3.7"
+maplit = "1.0.2"

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -42,7 +42,7 @@ The `status` options are:
 | [`ETH`](#eth-namespace) | [`eth_call`](#eth_call) | `SUPPORTED` | Executes a new message call immediately without creating a transaction on the block chain |
 | [`ETH`](#eth-namespace) | [`eth_sendRawTransaction`](#eth_sendrawtransaction) | `SUPPORTED` | Creates new message call transaction or a contract creation for signed transactions |
 | [`ETH`](#eth-namespace) | [`eth_getCode`](#eth_getcode) | `SUPPORTED` | Returns code at a given address |
-| `ETH` | `eth_getFilterChanges` | `NOT IMPLEMENTED`<br />[GitHub Issue #42](https://github.com/matter-labs/era-test-node/issues/42) | Polling method for a filter, which returns an array of logs, block hashes, or transaction hashes, depending on the filter type, which occurred since last poll |
+| [`ETH`](#eth-namespace) | [`eth_getFilterChanges`](#`eth_getFilterChanges) | `SUPPORTED` | Polling method for a filter, which returns an array of logs, block hashes, or transaction hashes, depending on the filter type, which occurred since last poll |
 | `ETH` | `eth_getFilterLogs` | `NOT IMPLEMENTED`<br />[GitHub Issue #41](https://github.com/matter-labs/era-test-node/issues/41) | Returns an array of all logs matching filter with given id |
 | `ETH` | `eth_getLogs` | `NOT IMPLEMENTED`<br />[GitHub Issue #40](https://github.com/matter-labs/era-test-node/issues/40) | Returns an array of all logs matching a given filter object |
 | `ETH` | `eth_getProof` | `NOT IMPLEMENTED` | Returns the details for the account at the specified address and block number, the account's Merkle proof, and the storage values for the specified storage keys with their Merkle-proofs |
@@ -58,9 +58,9 @@ The `status` options are:
 | `ETH` | `eth_hashrate` | `NOT IMPLEMENTED` | Returns the number of hashes per second that the node is mining with |
 | `ETH` | `eth_maxPriorityFeePerGas` | `NOT IMPLEMENTED` | Returns a `maxPriorityFeePerGas` value suitable for quick transaction inclusion |
 | `ETH` | `eth_mining` | `NOT IMPLEMENTED` | Returns `true` if client is actively mining new blocks |
-| `ETH` | `eth_newBlockFilter` | `NOT IMPLEMENTED`<br />[GitHub Issue #37](https://github.com/matter-labs/era-test-node/issues/37) | Creates a filter in the node, to notify when a new block arrives |
-| `ETH` | `eth_newFilter` | `NOT IMPLEMENTED`<br />[GitHub Issue #36](https://github.com/matter-labs/era-test-node/issues/36) | Creates a filter object, based on filter options, to notify when the state changes (logs) |
-| `ETH` | `eth_newPendingTransactionFilter` | `NOT IMPLEMENTED`<br />[GitHub Issue #39](https://github.com/matter-labs/era-test-node/issues/39) | Creates a filter in the node, to notify when new pending transactions arrive |
+| [`ETH`](#eth-namespace) | [`eth_newBlockFilter`](#`eth_newblockfilter) | `SUPPORTED` | Creates a filter in the node, to notify when a new block arrives |
+| [`ETH`](#eth-namespace) | [`eth_newFilter`](#`eth_newfilter) | `SUPPORTED` | Creates a filter object, based on filter options, to notify when the state changes (logs) |
+| [`ETH`](#eth-namespace) | [`eth_newPendingTransactionFilter`](#`eth_newpendingtransactionfilter) | `SUPPORTED` | Creates a filter in the node, to notify when new pending transactions arrive |
 | `ETH` | `eth_protocolVersion` | `NOT IMPLEMENTED`<br />[GitHub Issue #48](https://github.com/matter-labs/era-test-node/issues/48) | Returns the current ethereum protocol version |
 | `ETH` | `eth_sendTransaction` | `NOT IMPLEMENTED` | Creates new message call transaction or a contract creation, if the data field contains code |
 | `ETH` | `eth_sign` | `NOT IMPLEMENTED` | The sign method calculates an Ethereum specific signature with: `sign(keccak256("\x19Ethereum Signed Message:\n" + message.length + message)))` |
@@ -71,7 +71,7 @@ The `status` options are:
 | `ETH` | `eth_submitWork` | `NOT IMPLEMENTED` | Used for submitting a proof-of-work solution |
 | `ETH` | `eth_subscribe` | `NOT IMPLEMENTED` | Starts a subscription to a particular event |
 | [`ETH`](#eth-namespace) | [`eth_syncing`](#eth_syncing) | `SUPPORTED` | Returns an object containing data about the sync status or `false` when not syncing |
-| `ETH` | `eth_uninstallFilter` | `NOT IMPLEMENTED`<br />[GitHub Issue #38](https://github.com/matter-labs/era-test-node/issues/38) | Uninstalls a filter with given id |
+| [`ETH`](#eth-namespace) | [`eth_uninstallFilter`](#`eth_uninstallfilter) | `SUPPORTED` | Uninstalls a filter with given id |
 | `ETH` | `eth_unsubscribe` | `NOT IMPLEMENTED` | Cancel a subscription to a particular event |
 | `EVM` | `evm_addAccount` | `NOT IMPLEMENTED` | Adds any arbitrary account |
 | [`EVM`](#evm-namespace) | [`evm_increaseTime`](#evm_increasetime) | `SUPPORTED` | Jump forward in time by the given amount of time, in seconds |
@@ -565,6 +565,150 @@ curl --request POST \
     "id": "1",
     "method": "eth_getBlockTransactionCountByNumber",
     "params": ["latest"]
+}'
+```
+
+
+### `eth_getFilterChanges`
+
+[source](src/node.rs)
+
+Polling method for a filter, which returns an array of logs, block hashes, or transaction hashes, depending on the filter type, which occurred since last poll
+
+#### Arguments
+
++ `id: U256`
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "eth_getFilterChanges",
+    "params": ["0x1"]
+}'
+```
+
+### `eth_newBlockFilter`
+
+[source](src/node.rs)
+
+Creates a filter in the node, to notify when a new block arrives
+
+#### Arguments
+
++ _NONE__
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "eth_newBlockFilter"
+}'
+```
+
+### `eth_newFilter`
+
+[source](src/node.rs)
+
+Creates a filter object, based on filter options, to notify when the state changes (logs)
+
+#### Arguments
+
++ `filter: Filter`
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "eth_newFilter",
+    "params": [{
+      "fromBlock": "0xa", 
+      "toBlock": "0xff", 
+      "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+      "topics": []
+    }]
+}'
+```
+
+### `eth_newPendingTransactionFilter`
+
+[source](src/node.rs)
+
+Creates a filter in the node, to notify when new pending transactions arrive
+
+#### Arguments
+
++ _NONE__
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "eth_newPendingTransactionFilter"
+}'
+```
+
+### `eth_uninstallFilter`
+
+[source](src/node.rs)
+
+Uninstalls a filter with given id
+
+#### Arguments
+
++ `id: U256`
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "eth_uninstallFilter",
+    "params": ["0x1"]
 }'
 ```
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -269,7 +269,7 @@ mod tests {
         assert_eq!(U256::from(1), id);
         assert_eq!(
             hashmap! {
-                U256::from(1) => FilterType::Log(LogFilter {
+                U256::from(1) => FilterType::Log(Box::new(LogFilter {
                     from_block: BlockNumber::Latest,
                     to_block: BlockNumber::Number(U64::from(10)),
                     addresses: vec![H160::repeat_byte(0x1)],
@@ -280,7 +280,7 @@ mod tests {
                         Some(hashset! {}),
                     ],
                     updates:vec![],
-                })
+                }))
             },
             filters.filters
         );

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1,0 +1,221 @@
+use std::collections::{HashMap, HashSet};
+
+use zksync_basic_types::{H160, H256, U256, U64};
+use zksync_types::api::{BlockNumber, Log};
+use zksync_web3_decl::types::FilterChanges;
+
+#[derive(Debug, Clone)]
+pub enum FilterType {
+    Block(BlockFilter),
+    Log(LogFilter),
+    PendingTransaction(PendingTransactionFilter),
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct BlockFilter {
+    updates: Vec<H256>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LogFilter {
+    from_block: BlockNumber,
+    to_block: BlockNumber,
+    addresses: Vec<H160>,
+    topics: [Option<HashSet<H256>>; 4],
+    updates: Vec<Log>,
+}
+
+impl LogFilter {
+    fn matches(&self, log: &Log, latest_block_number: U64) -> bool {
+        let from = match self.from_block {
+            BlockNumber::Finalized
+            | BlockNumber::Pending
+            | BlockNumber::Committed
+            | BlockNumber::Latest => latest_block_number,
+            BlockNumber::Earliest => U64::zero(),
+            BlockNumber::Number(n) => n,
+        };
+        let to = match self.to_block {
+            BlockNumber::Finalized
+            | BlockNumber::Pending
+            | BlockNumber::Committed
+            | BlockNumber::Latest => latest_block_number,
+            BlockNumber::Earliest => U64::zero(),
+            BlockNumber::Number(n) => n,
+        };
+
+        let n = log.block_number.expect("block number must exist");
+        if n < from || n > to {
+            return false;
+        }
+
+        if !self.addresses.is_empty()
+            && self.addresses.iter().all(|address| address != &log.address)
+        {
+            return false;
+        }
+
+        let mut matched_topic = [true; 4];
+        for (i, topic) in log.topics.iter().take(4).enumerate() {
+            if let Some(topic_set) = &self.topics[i] {
+                if !topic_set.contains(topic) {
+                    matched_topic[i] = false;
+                }
+            }
+        }
+
+        matched_topic.iter().all(|m| *m == true)
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PendingTransactionFilter {
+    updates: Vec<H256>,
+}
+
+type Result<T> = std::result::Result<T, &'static str>;
+
+#[derive(Debug, Default, Clone)]
+pub struct EthFilters {
+    id_counter: U256,
+    filters: HashMap<U256, FilterType>,
+}
+
+impl EthFilters {
+    /// Adds a block filter to keep track of new block hashes. Returns the filter id.
+    pub fn add_block_filter(&mut self) -> Result<U256> {
+        self.id_counter = self
+            .id_counter
+            .checked_add(U256::from(1))
+            .ok_or("overflow")?;
+        self.filters.insert(
+            self.id_counter,
+            FilterType::Block(BlockFilter {
+                updates: Default::default(),
+            }),
+        );
+
+        log::info!("created block filter '{:#x}'", self.id_counter);
+        Ok(self.id_counter)
+    }
+
+    /// Adds a log filter to keep track of new transaction logs. Returns the filter id.
+    pub fn add_log_filter(
+        &mut self,
+        from_block: BlockNumber,
+        to_block: BlockNumber,
+        addresses: Vec<H160>,
+        topics: [Option<HashSet<H256>>; 4],
+    ) -> Result<U256> {
+        self.id_counter = self
+            .id_counter
+            .checked_add(U256::from(1))
+            .ok_or("overflow")?;
+        self.filters.insert(
+            self.id_counter,
+            FilterType::Log(LogFilter {
+                from_block,
+                to_block,
+                addresses,
+                topics,
+                updates: Default::default(),
+            }),
+        );
+
+        log::info!("created log filter '{:#x}'", self.id_counter);
+        Ok(self.id_counter)
+    }
+
+    /// Adds a filter to keep track of new pending transaction hashes. Returns the filter id.
+    pub fn add_pending_transaction_filter(&mut self) -> Result<U256> {
+        self.id_counter = self
+            .id_counter
+            .checked_add(U256::from(1))
+            .ok_or("overflow")?;
+        self.filters.insert(
+            self.id_counter,
+            FilterType::PendingTransaction(PendingTransactionFilter {
+                updates: Default::default(),
+            }),
+        );
+
+        log::info!(
+            "created pending transaction filter '{:#x}'",
+            self.id_counter
+        );
+        Ok(self.id_counter)
+    }
+
+    /// Removes the filter with the given id. Returns true if the filter existed, false otherwise.
+    pub fn remove_filter(&mut self, id: U256) -> bool {
+        log::info!("removing filter '{id:#x}'");
+        self.filters.remove(&id).is_some()
+    }
+
+    /// Retrieves the filter updates with the given id. The updates are reset after this call.
+    pub fn get_new_changes(&mut self, id: U256) -> Result<FilterChanges> {
+        let filter = self.filters.get_mut(&id).ok_or("invalid filter")?;
+        let changes = match filter {
+            FilterType::Block(f) => {
+                if f.updates.is_empty() {
+                    FilterChanges::Empty(Default::default())
+                } else {
+                    let updates = f.updates.clone();
+                    f.updates.clear();
+                    FilterChanges::Hashes(updates)
+                }
+            }
+            FilterType::Log(f) => {
+                if f.updates.is_empty() {
+                    FilterChanges::Empty(Default::default())
+                } else {
+                    let updates = f.updates.clone();
+                    f.updates.clear();
+                    FilterChanges::Logs(updates)
+                }
+            }
+            FilterType::PendingTransaction(f) => {
+                if f.updates.is_empty() {
+                    FilterChanges::Empty(Default::default())
+                } else {
+                    let updates = f.updates.clone();
+                    f.updates.clear();
+                    FilterChanges::Hashes(updates)
+                }
+            }
+        };
+
+        Ok(changes)
+    }
+
+    pub fn notify_new_block(&mut self, hash: H256) {
+        self.filters
+            .iter_mut()
+            .for_each(|(_, filter)| match filter {
+                FilterType::Block(f) => f.updates.push(hash),
+                _ => (),
+            })
+    }
+
+    pub fn notify_new_pending_transaction(&mut self, hash: H256) {
+        self.filters
+            .iter_mut()
+            .for_each(|(_, filter)| match filter {
+                FilterType::PendingTransaction(f) => f.updates.push(hash),
+                _ => (),
+            })
+    }
+
+    pub fn notify_new_log(&mut self, log: &Log, latest_block_number: U64) {
+        self.filters
+            .iter_mut()
+            .for_each(|(_, filter)| match filter {
+                FilterType::Log(f) => {
+                    if f.matches(&log, latest_block_number) {
+                        f.updates.push(log.clone());
+                    }
+                }
+                _ => (),
+            })
+    }
+}

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -4,19 +4,25 @@ use zksync_basic_types::{H160, H256, U256, U64};
 use zksync_types::api::{BlockNumber, Log};
 use zksync_web3_decl::types::FilterChanges;
 
-#[derive(Debug, Clone)]
+/// Specifies a filter type
+#[derive(Debug, Clone, PartialEq)]
 pub enum FilterType {
+    /// A filter for block information
     Block(BlockFilter),
+    /// A filter for log information
     Log(LogFilter),
+    /// A filter for pending transaction information
     PendingTransaction(PendingTransactionFilter),
 }
 
-#[derive(Debug, Default, Clone)]
+/// Specifies a filter that keeps track of new blocks
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct BlockFilter {
     updates: Vec<H256>,
 }
 
-#[derive(Debug, Clone)]
+/// Specifies a filter that keeps track of new logs
+#[derive(Debug, Clone, PartialEq)]
 pub struct LogFilter {
     from_block: BlockNumber,
     to_block: BlockNumber,
@@ -58,7 +64,7 @@ impl LogFilter {
         let mut matched_topic = [true; 4];
         for (i, topic) in log.topics.iter().take(4).enumerate() {
             if let Some(topic_set) = &self.topics[i] {
-                if !topic_set.contains(topic) {
+                if !topic_set.is_empty() && !topic_set.contains(topic) {
                     matched_topic[i] = false;
                 }
             }
@@ -68,13 +74,15 @@ impl LogFilter {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+/// Specifies a filter that keeps track of new pending transactions
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct PendingTransactionFilter {
     updates: Vec<H256>,
 }
 
 type Result<T> = std::result::Result<T, &'static str>;
 
+/// Keeps track of installed filters and their respective updates.
 #[derive(Debug, Default, Clone)]
 pub struct EthFilters {
     id_counter: U256,
@@ -188,6 +196,7 @@ impl EthFilters {
         Ok(changes)
     }
 
+    /// Notify available filters of a newly produced block
     pub fn notify_new_block(&mut self, hash: H256) {
         self.filters
             .iter_mut()
@@ -197,6 +206,7 @@ impl EthFilters {
             })
     }
 
+    /// Notify available filters of a new pending transaction
     pub fn notify_new_pending_transaction(&mut self, hash: H256) {
         self.filters
             .iter_mut()
@@ -206,6 +216,7 @@ impl EthFilters {
             })
     }
 
+    /// Notify available filters of a new transaction log
     pub fn notify_new_log(&mut self, log: &Log, latest_block_number: U64) {
         self.filters
             .iter_mut()
@@ -217,5 +228,892 @@ impl EthFilters {
                 }
                 _ => (),
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::testing::LogBuilder;
+
+    use super::*;
+
+    use maplit::{hashmap, hashset};
+
+    #[test]
+    fn test_add_block_filter() {
+        let mut filters = EthFilters::default();
+        let id = filters.add_block_filter().expect("failed adding filter");
+
+        assert_eq!(U256::from(1), id);
+        assert_eq!(
+            hashmap! {
+                U256::from(1) => FilterType::Block(BlockFilter { updates: vec![] })
+            },
+            filters.filters
+        );
+    }
+
+    #[test]
+    fn test_add_log_filter() {
+        let mut filters = EthFilters::default();
+        let id = filters
+            .add_log_filter(
+                BlockNumber::Latest,
+                BlockNumber::Number(U64::from(10)),
+                vec![H160::repeat_byte(0x1)],
+                [
+                    Some(hashset! { H256::repeat_byte(0x2) }),
+                    Some(hashset! { H256::repeat_byte(0x3), H256::repeat_byte(0x4) }),
+                    None,
+                    Some(hashset! {}),
+                ],
+            )
+            .expect("failed adding filter");
+
+        assert_eq!(U256::from(1), id);
+        assert_eq!(
+            hashmap! {
+                U256::from(1) => FilterType::Log(LogFilter {
+                    from_block: BlockNumber::Latest,
+                    to_block: BlockNumber::Number(U64::from(10)),
+                    addresses: vec![H160::repeat_byte(0x1)],
+                    topics: [
+                        Some(hashset! { H256::repeat_byte(0x2) }),
+                        Some(hashset! { H256::repeat_byte(0x3), H256::repeat_byte(0x4) }),
+                        None,
+                        Some(hashset! {}),
+                    ],
+                    updates:vec![],
+                })
+            },
+            filters.filters
+        );
+    }
+
+    #[test]
+    fn test_add_pending_transaction_filter() {
+        let mut filters = EthFilters::default();
+        let id = filters
+            .add_pending_transaction_filter()
+            .expect("failed adding filter");
+
+        assert_eq!(U256::from(1), id);
+        assert_eq!(
+            hashmap! {
+                U256::from(1) => FilterType::PendingTransaction(PendingTransactionFilter { updates: vec![] })
+            },
+            filters.filters
+        );
+    }
+
+    #[test]
+    fn test_different_filters_share_incremental_identifiers() {
+        let mut filters = EthFilters::default();
+
+        let block_filter_id = filters.add_block_filter().expect("failed adding filter");
+        let log_filter_id = filters
+            .add_log_filter(
+                BlockNumber::Earliest,
+                BlockNumber::Latest,
+                Default::default(),
+                Default::default(),
+            )
+            .expect("failed adding filter");
+        let pending_transaction_filter_id = filters
+            .add_pending_transaction_filter()
+            .expect("failed adding filter");
+
+        assert_eq!(U256::from(1), block_filter_id);
+        assert_eq!(U256::from(2), log_filter_id);
+        assert_eq!(U256::from(3), pending_transaction_filter_id);
+    }
+
+    #[test]
+    fn test_remove_filter() {
+        let mut filters = EthFilters::default();
+        let block_filter_id = filters.add_block_filter().expect("failed adding filter");
+        let log_filter_id = filters
+            .add_log_filter(
+                BlockNumber::Earliest,
+                BlockNumber::Latest,
+                Default::default(),
+                Default::default(),
+            )
+            .expect("failed adding filter");
+        let pending_transaction_filter_id = filters
+            .add_pending_transaction_filter()
+            .expect("failed adding filter");
+
+        filters.remove_filter(log_filter_id);
+
+        assert!(
+            filters.filters.contains_key(&block_filter_id),
+            "filter was erroneously removed"
+        );
+        assert!(
+            filters.filters.contains_key(&pending_transaction_filter_id),
+            "filter was erroneously removed"
+        );
+        assert!(
+            !filters.filters.contains_key(&log_filter_id),
+            "filter was not removed"
+        );
+    }
+
+    #[test]
+    fn test_notify_new_block_appends_updates() {
+        let mut filters = EthFilters::default();
+        let id = filters.add_block_filter().expect("failed adding filter");
+
+        filters.notify_new_block(H256::repeat_byte(0x1));
+
+        match filters.filters.get(&id).unwrap() {
+            FilterType::Block(f) => {
+                assert_eq!(vec![H256::repeat_byte(0x1)], f.updates);
+            }
+            _ => panic!("invalid filter"),
+        }
+    }
+
+    #[test]
+    fn test_notify_new_log_appends_matching_updates() {
+        let mut filters = EthFilters::default();
+        let match_address = H160::repeat_byte(0x1);
+        let id = filters
+            .add_log_filter(
+                BlockNumber::Earliest,
+                BlockNumber::Latest,
+                vec![match_address],
+                Default::default(),
+            )
+            .expect("failed adding filter");
+
+        let log = LogBuilder::new()
+            .set_address(match_address)
+            .set_block(U64::from(1))
+            .build();
+        filters.notify_new_log(&log, U64::from(1));
+
+        match filters.filters.get(&id).unwrap() {
+            FilterType::Log(f) => {
+                assert_eq!(vec![log], f.updates);
+            }
+            _ => panic!("invalid filter"),
+        }
+    }
+
+    #[test]
+    fn test_notify_new_pending_transaction_appends_updates() {
+        let mut filters = EthFilters::default();
+        let id = filters
+            .add_pending_transaction_filter()
+            .expect("failed adding filter");
+
+        filters.notify_new_pending_transaction(H256::repeat_byte(0x1));
+
+        match filters.filters.get(&id).unwrap() {
+            FilterType::PendingTransaction(f) => {
+                assert_eq!(vec![H256::repeat_byte(0x1)], f.updates);
+            }
+            _ => panic!("invalid filter"),
+        }
+    }
+
+    #[test]
+    fn test_get_new_changes_block_returns_updates_and_clears_them() {
+        let mut filters = EthFilters::default();
+        let id = filters.add_block_filter().expect("failed adding filter");
+        filters.notify_new_block(H256::repeat_byte(0x1));
+
+        let changes = filters
+            .get_new_changes(id)
+            .expect("failed retrieving changes");
+
+        match changes {
+            FilterChanges::Hashes(result) => {
+                assert_eq!(vec![H256::repeat_byte(0x1)], result);
+            }
+            _ => panic!("unexpected filter changes {:?}", changes),
+        }
+        match filters.filters.get(&id).unwrap() {
+            FilterType::Block(f) => {
+                assert!(f.updates.is_empty(), "updates were not cleared");
+            }
+            _ => panic!("invalid filter"),
+        }
+    }
+
+    #[test]
+    fn test_get_new_changes_log_appends_mreturng_updates_and_clears_them() {
+        let mut filters = EthFilters::default();
+        let match_address = H160::repeat_byte(0x1);
+        let id = filters
+            .add_log_filter(
+                BlockNumber::Earliest,
+                BlockNumber::Latest,
+                vec![match_address],
+                Default::default(),
+            )
+            .expect("failed adding filter");
+
+        let log = LogBuilder::new()
+            .set_address(match_address)
+            .set_block(U64::from(1))
+            .build();
+        filters.notify_new_log(&log, U64::from(1));
+
+        let changes = filters
+            .get_new_changes(id)
+            .expect("failed retrieving changes");
+
+        match changes {
+            FilterChanges::Logs(result) => {
+                assert_eq!(vec![log], result);
+            }
+            _ => panic!("unexpected filter changes {:?}", changes),
+        }
+        match filters.filters.get(&id).unwrap() {
+            FilterType::Log(f) => {
+                assert!(f.updates.is_empty(), "updates were not cleared");
+            }
+            _ => panic!("invalid filter"),
+        }
+    }
+
+    #[test]
+    fn test_get_new_changes_pending_transaction_returns_updates_and_clears_them() {
+        let mut filters = EthFilters::default();
+        let id = filters
+            .add_pending_transaction_filter()
+            .expect("failed adding filter");
+
+        filters.notify_new_pending_transaction(H256::repeat_byte(0x1));
+
+        let changes = filters
+            .get_new_changes(id)
+            .expect("failed retrieving changes");
+
+        match changes {
+            FilterChanges::Hashes(result) => {
+                assert_eq!(vec![H256::repeat_byte(0x1)], result);
+            }
+            _ => panic!("unexpected filter changes {:?}", changes),
+        }
+        match filters.filters.get(&id).unwrap() {
+            FilterType::PendingTransaction(f) => {
+                assert!(f.updates.is_empty(), "updates were not cleared");
+            }
+            _ => panic!("invalid filter"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod log_filter_tests {
+    use maplit::hashset;
+
+    use crate::testing::LogBuilder;
+
+    use super::*;
+
+    #[test]
+    fn test_filter_from_block_earliest_accepts_all_block_numbers_lte_latest() {
+        let filter = LogFilter {
+            from_block: BlockNumber::Earliest,
+            to_block: BlockNumber::Latest,
+            addresses: Default::default(),
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        let latest_block_number = 2u64;
+        for log_block in 0..=latest_block_number {
+            let matched = filter.matches(
+                &LogBuilder::new().set_block(U64::from(log_block)).build(),
+                U64::from(latest_block_number),
+            );
+            assert!(
+                matched,
+                "failed matching log for block_number {}",
+                log_block
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_from_block_latest_accepts_block_number_eq_latest() {
+        let filter = LogFilter {
+            from_block: BlockNumber::Latest,
+            to_block: BlockNumber::Latest,
+            addresses: Default::default(),
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        let latest_block_number = U64::from(2);
+        let input_block_number = U64::from(2);
+        let matched = filter.matches(
+            &LogBuilder::new().set_block(input_block_number).build(),
+            latest_block_number,
+        );
+        assert!(matched);
+    }
+
+    #[test]
+    fn test_filter_from_block_latest_rejects_block_number_lt_latest() {
+        let filter = LogFilter {
+            from_block: BlockNumber::Latest,
+            to_block: BlockNumber::Latest,
+            addresses: Default::default(),
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        let latest_block_number = U64::from(2);
+        let matched = filter.matches(
+            &LogBuilder::new().set_block(U64::from(1)).build(),
+            latest_block_number,
+        );
+        assert!(!matched);
+    }
+
+    #[test]
+    fn test_filter_from_block_accepts_all_block_numbers_gte_input_number() {
+        let input_block_number = 2u64;
+        let latest_block_number = 100u64;
+        let filter = LogFilter {
+            from_block: BlockNumber::Number(U64::from(input_block_number)),
+            to_block: BlockNumber::Latest,
+            addresses: Default::default(),
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        for log_block in input_block_number..=input_block_number + 1 {
+            let matched = filter.matches(
+                &LogBuilder::new().set_block(U64::from(log_block)).build(),
+                U64::from(latest_block_number),
+            );
+            assert!(
+                matched,
+                "failed matching log for block_number {}",
+                log_block
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_from_block_rejects_block_number_lt_input_number() {
+        let input_block_number = 2u64;
+        let latest_block_number = 100u64;
+        let filter = LogFilter {
+            from_block: BlockNumber::Number(U64::from(input_block_number)),
+            to_block: BlockNumber::Latest,
+            addresses: Default::default(),
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_block(U64::from(input_block_number - 1))
+                .build(),
+            U64::from(latest_block_number),
+        );
+        assert!(!matched);
+    }
+
+    #[test]
+    fn test_filter_to_block_latest_accepts_block_number_lte_latest() {
+        let filter = LogFilter {
+            from_block: BlockNumber::Earliest,
+            to_block: BlockNumber::Latest,
+            addresses: Default::default(),
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        let latest_block_number = 2u32;
+        for log_block in 1..=latest_block_number {
+            let matched = filter.matches(
+                &LogBuilder::new().set_block(U64::from(log_block)).build(),
+                U64::from(latest_block_number),
+            );
+            assert!(
+                matched,
+                "failed matching log for block_number {}",
+                log_block
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_to_block_accepts_all_block_numbers_lte_input_number() {
+        let input_block_number = 2u64;
+        let latest_block_number = 100u64;
+        let filter = LogFilter {
+            from_block: BlockNumber::Earliest,
+            to_block: BlockNumber::Number(U64::from(input_block_number)),
+            addresses: Default::default(),
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        for log_block in input_block_number - 1..=input_block_number {
+            let matched = filter.matches(
+                &LogBuilder::new().set_block(U64::from(log_block)).build(),
+                U64::from(latest_block_number),
+            );
+            assert!(
+                matched,
+                "failed matching log for block_number {}",
+                log_block
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_to_block_rejects_block_number_gt_input_number() {
+        let input_block_number = 2u64;
+        let latest_block_number = 100u64;
+        let filter = LogFilter {
+            from_block: BlockNumber::Earliest,
+            to_block: BlockNumber::Number(U64::from(input_block_number)),
+            addresses: Default::default(),
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_block(U64::from(input_block_number + 1))
+                .build(),
+            U64::from(latest_block_number),
+        );
+        assert!(!matched);
+    }
+
+    #[test]
+    fn test_filter_from_and_to_block_rejects_block_number_left_of_range() {
+        let input_from_block_number = 2u64;
+        let input_to_block_number = 4u64;
+        let latest_block_number = 100u64;
+        let filter = LogFilter {
+            from_block: BlockNumber::Number(U64::from(input_from_block_number)),
+            to_block: BlockNumber::Number(U64::from(input_to_block_number)),
+            addresses: Default::default(),
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_block(U64::from(input_from_block_number - 1))
+                .build(),
+            U64::from(latest_block_number),
+        );
+        assert!(!matched);
+    }
+
+    #[test]
+    fn test_filter_from_and_to_block_rejects_block_number_right_of_range() {
+        let input_from_block_number = 2u64;
+        let input_to_block_number = 4u64;
+        let latest_block_number = 100u64;
+        let filter = LogFilter {
+            from_block: BlockNumber::Number(U64::from(input_from_block_number)),
+            to_block: BlockNumber::Number(U64::from(input_to_block_number)),
+            addresses: Default::default(),
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_block(U64::from(input_to_block_number + 1))
+                .build(),
+            U64::from(latest_block_number),
+        );
+        assert!(!matched);
+    }
+
+    #[test]
+    fn test_filter_from_and_to_block_accepts_block_number_inclusive_of_range() {
+        let input_from_block_number = 2u64;
+        let input_to_block_number = 4u64;
+        let latest_block_number = 100u64;
+        let filter = LogFilter {
+            from_block: BlockNumber::Number(U64::from(input_from_block_number)),
+            to_block: BlockNumber::Number(U64::from(input_to_block_number)),
+            addresses: Default::default(),
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        for log_block in input_from_block_number..=input_to_block_number {
+            let matched = filter.matches(
+                &LogBuilder::new().set_block(U64::from(log_block)).build(),
+                U64::from(latest_block_number),
+            );
+            assert!(
+                matched,
+                "failed matching log for block_number {}",
+                log_block
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_address_rejects_if_address_not_in_set() {
+        let filter = LogFilter {
+            from_block: BlockNumber::Earliest,
+            to_block: BlockNumber::Latest,
+            addresses: vec![H160::repeat_byte(0xa)],
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_address(H160::repeat_byte(0x1))
+                .build(),
+            U64::from(100),
+        );
+        assert!(!matched);
+    }
+
+    #[test]
+    fn test_filter_address_accepts_if_address_in_set() {
+        let filter = LogFilter {
+            from_block: BlockNumber::Earliest,
+            to_block: BlockNumber::Latest,
+            addresses: vec![H160::repeat_byte(0x1)],
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_address(H160::repeat_byte(0x1))
+                .build(),
+            U64::from(100),
+        );
+        assert!(matched);
+    }
+
+    #[test]
+    fn test_filter_address_accepts_if_address_set_empty() {
+        let filter = LogFilter {
+            from_block: BlockNumber::Earliest,
+            to_block: BlockNumber::Latest,
+            addresses: vec![],
+            topics: Default::default(),
+            updates: Default::default(),
+        };
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_address(H160::repeat_byte(0x1))
+                .build(),
+            U64::from(100),
+        );
+        assert!(matched);
+    }
+
+    #[test]
+    fn test_filter_topic_none_accepts_any_topic() {
+        let filter = LogFilter {
+            from_block: BlockNumber::Earliest,
+            to_block: BlockNumber::Latest,
+            addresses: Default::default(),
+            topics: [None, None, None, None],
+            updates: Default::default(),
+        };
+
+        for topic_idx in 0..4 {
+            let mut input_topics = [H256::zero(); 4].to_vec();
+            input_topics[topic_idx] = H256::repeat_byte(0x1);
+
+            let matched = filter.matches(
+                &LogBuilder::new().set_topics(input_topics).build(),
+                U64::from(100),
+            );
+            assert!(matched, "failed matching log for topic index {}", topic_idx);
+        }
+    }
+
+    #[test]
+    fn test_filter_topic_exactly_one_accepts_exact_topic() {
+        for topic_idx in 0..4 {
+            let match_topic = H256::repeat_byte(0x1);
+            let mut topics = [None, None, None, None];
+            topics[topic_idx] = Some(hashset! { match_topic });
+            let filter = LogFilter {
+                from_block: BlockNumber::Earliest,
+                to_block: BlockNumber::Latest,
+                addresses: Default::default(),
+                topics,
+                updates: Default::default(),
+            };
+            let mut input_topics = [H256::zero(); 4].to_vec();
+            input_topics[topic_idx] = match_topic;
+
+            let matched = filter.matches(
+                &LogBuilder::new().set_topics(input_topics).build(),
+                U64::from(100),
+            );
+            assert!(matched, "failed matching log for topic index {}", topic_idx);
+        }
+    }
+
+    #[test]
+    fn test_filter_topic_multiple_accepts_either_topic() {
+        for topic_idx in 0..4 {
+            let match_topic_1 = H256::repeat_byte(0x1);
+            let match_topic_2 = H256::repeat_byte(0x2);
+            let mut topics = [None, None, None, None];
+            topics[topic_idx] = Some(hashset! { match_topic_1, match_topic_2, });
+            let filter = LogFilter {
+                from_block: BlockNumber::Earliest,
+                to_block: BlockNumber::Latest,
+                addresses: Default::default(),
+                topics,
+                updates: Default::default(),
+            };
+
+            let mut input_topics = [H256::zero(); 4].to_vec();
+            input_topics[topic_idx] = match_topic_1;
+            let matched = filter.matches(
+                &LogBuilder::new().set_topics(input_topics).build(),
+                U64::from(100),
+            );
+            assert!(
+                matched,
+                "failed matching log for topic index {} for {}",
+                topic_idx, match_topic_1
+            );
+
+            let mut input_topics = [H256::zero(); 4].to_vec();
+            input_topics[topic_idx] = match_topic_2;
+            let matched = filter.matches(
+                &LogBuilder::new().set_topics(input_topics).build(),
+                U64::from(100),
+            );
+            assert!(
+                matched,
+                "failed matching log for topic index {} for {}",
+                topic_idx, match_topic_2
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_topic_exactly_one_rejects_different_topic() {
+        for topic_idx in 0..4 {
+            let match_topic = H256::repeat_byte(0x1);
+            let mut topics = [None, None, None, None];
+            topics[topic_idx] = Some(hashset! { match_topic });
+            let filter = LogFilter {
+                from_block: BlockNumber::Earliest,
+                to_block: BlockNumber::Latest,
+                addresses: Default::default(),
+                topics,
+                updates: Default::default(),
+            };
+            let mut input_topics = [H256::zero(); 4].to_vec();
+            input_topics[topic_idx] = H256::repeat_byte(0xa);
+
+            let matched = filter.matches(
+                &LogBuilder::new().set_topics(input_topics).build(),
+                U64::from(100),
+            );
+            assert!(
+                !matched,
+                "erroneously matched log for topic index {}",
+                topic_idx
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_topic_multiple_rejects_different_topic() {
+        for topic_idx in 0..4 {
+            let match_topic_1 = H256::repeat_byte(0x1);
+            let match_topic_2 = H256::repeat_byte(0x2);
+            let mut topics = [None, None, None, None];
+            topics[topic_idx] = Some(hashset! { match_topic_1, match_topic_2, });
+            let filter = LogFilter {
+                from_block: BlockNumber::Earliest,
+                to_block: BlockNumber::Latest,
+                addresses: Default::default(),
+                topics,
+                updates: Default::default(),
+            };
+
+            let mut input_topics = [H256::zero(); 4].to_vec();
+            input_topics[topic_idx] = H256::repeat_byte(0xa);
+            let matched = filter.matches(
+                &LogBuilder::new().set_topics(input_topics).build(),
+                U64::from(100),
+            );
+            assert!(
+                !matched,
+                "erroneously matched log for topic index {}",
+                topic_idx
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_topic_combination_accepts_if_all_topics_valid() {
+        let filter = LogFilter {
+            from_block: BlockNumber::Earliest,
+            to_block: BlockNumber::Latest,
+            addresses: Default::default(),
+            topics: [
+                None, // matches anything
+                Some(hashset! { H256::repeat_byte(0x1) }),
+                Some(hashset! { H256::repeat_byte(0x2), H256::repeat_byte(0x3) }),
+                Some(hashset! {}), // matches anything
+            ],
+            updates: Default::default(),
+        };
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_topics(vec![
+                    H256::zero(),
+                    H256::repeat_byte(0x1),
+                    H256::repeat_byte(0x3),
+                    H256::repeat_byte(0xa),
+                ])
+                .build(),
+            U64::from(100),
+        );
+        assert!(matched);
+    }
+
+    #[test]
+    fn test_filter_topic_combination_rejects_if_any_topic_is_invalid() {
+        let filter = LogFilter {
+            from_block: BlockNumber::Earliest,
+            to_block: BlockNumber::Latest,
+            addresses: Default::default(),
+            topics: [
+                None, // matches anything
+                Some(hashset! { H256::repeat_byte(0x1) }),
+                Some(hashset! { H256::repeat_byte(0x2), H256::repeat_byte(0x3) }),
+                Some(hashset! {}), // matches anything
+            ],
+            updates: Default::default(),
+        };
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_topics(vec![
+                    H256::zero(),
+                    H256::repeat_byte(0xf), // invalid
+                    H256::repeat_byte(0x3),
+                    H256::repeat_byte(0xa),
+                ])
+                .build(),
+            U64::from(100),
+        );
+        assert!(!matched, "erroneously matched on invalid topic1");
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_topics(vec![
+                    H256::zero(),
+                    H256::repeat_byte(0x1),
+                    H256::repeat_byte(0xf), // invalid
+                    H256::repeat_byte(0xa),
+                ])
+                .build(),
+            U64::from(100),
+        );
+        assert!(!matched, "erroneously matched on invalid topic2");
+    }
+
+    #[test]
+    fn test_filter_combination_accepts_if_all_criteria_valid() {
+        let filter = LogFilter {
+            from_block: BlockNumber::Number(U64::from(2)),
+            to_block: BlockNumber::Number(U64::from(5)),
+            addresses: vec![H160::repeat_byte(0xab)],
+            topics: [
+                None,
+                Some(hashset! { H256::repeat_byte(0x1) }),
+                Some(hashset! { H256::repeat_byte(0x2), H256::repeat_byte(0x3) }),
+                Some(hashset! {}),
+            ],
+            updates: Default::default(),
+        };
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_block(U64::from(4))
+                .set_address(H160::repeat_byte(0xab))
+                .set_topics(vec![
+                    H256::zero(),
+                    H256::repeat_byte(0x1),
+                    H256::repeat_byte(0x3),
+                    H256::repeat_byte(0xa),
+                ])
+                .build(),
+            U64::from(100),
+        );
+        assert!(matched);
+    }
+
+    #[test]
+    fn test_filter_combination_rejects_if_any_criterion_invalid() {
+        let filter = LogFilter {
+            from_block: BlockNumber::Number(U64::from(2)),
+            to_block: BlockNumber::Number(U64::from(5)),
+            addresses: vec![H160::repeat_byte(0xab)],
+            topics: [Some(hashset! { H256::repeat_byte(0x1) }), None, None, None],
+            updates: Default::default(),
+        };
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_block(U64::from(1)) // invalid
+                .set_address(H160::repeat_byte(0xab))
+                .set_topics(vec![
+                    H256::zero(),
+                    H256::repeat_byte(0x1),
+                    H256::repeat_byte(0x3),
+                    H256::repeat_byte(0xa),
+                ])
+                .build(),
+            U64::from(100),
+        );
+        assert!(!matched, "erroneously matched on invalid block number");
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_block(U64::from(1))
+                .set_address(H160::repeat_byte(0xde)) // invalid
+                .set_topics(vec![
+                    H256::zero(),
+                    H256::repeat_byte(0x1),
+                    H256::repeat_byte(0x3),
+                    H256::repeat_byte(0xa),
+                ])
+                .build(),
+            U64::from(100),
+        );
+        assert!(!matched, "erroneously matched on invalid address");
+
+        let matched = filter.matches(
+            &LogBuilder::new()
+                .set_block(U64::from(1))
+                .set_address(H160::repeat_byte(0xde))
+                .set_topics(vec![H256::zero(), H256::zero(), H256::zero(), H256::zero()]) // invalid
+                .build(),
+            U64::from(100),
+        );
+        assert!(!matched, "erroneously matched on invalid topic");
     }
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -59,15 +59,16 @@ pub fn print_event(event: &VmEvent, resolve_hashes: bool) {
     block_on(async move {
         let mut tt: Vec<String> = vec![];
         if !resolve_hashes {
-            tt = event.indexed_topics.iter().map(|t| format!("{:#x}", t)).collect();
+            tt = event
+                .indexed_topics
+                .iter()
+                .map(|t| format!("{:#x}", t))
+                .collect();
         } else {
             for topic in event.indexed_topics {
-                let selector = resolver::decode_event_selector(&format!(
-                    "{:#x}",
-                    topic
-                ))
-                .await
-                .unwrap();
+                let selector = resolver::decode_event_selector(&format!("{:#x}", topic))
+                    .await
+                    .unwrap();
                 tt.push(selector.unwrap_or(format!("{:#x}", topic)));
             }
         }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -59,16 +59,16 @@ pub fn print_event(event: &VmEvent, resolve_hashes: bool) {
     block_on(async move {
         let mut tt: Vec<String> = vec![];
         if !resolve_hashes {
-            tt = event.indexed_topics.iter().map(|t| t.to_string()).collect();
+            tt = event.indexed_topics.iter().map(|t| format!("{:#x}", t)).collect();
         } else {
             for topic in event.indexed_topics {
                 let selector = resolver::decode_event_selector(&format!(
-                    "0x{}",
-                    hex::encode(topic.as_bytes())
+                    "{:#x}",
+                    topic
                 ))
                 .await
                 .unwrap();
-                tt.push(selector.unwrap_or(format!("{:?}", topic)));
+                tt.push(selector.unwrap_or(format!("{:#x}", topic)));
             }
         }
 

--- a/src/hardhat.rs
+++ b/src/hardhat.rs
@@ -157,9 +157,9 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> HardhatNamespaceT
         Box::pin(async move {
             match inner.write() {
                 Ok(mut inner) => {
-                    let num_blocks = num_blocks.unwrap_or(U64::from(1));
+                    let num_blocks = num_blocks.unwrap_or_else(|| U64::from(1));
                     let interval_ms = interval
-                        .unwrap_or(U64::from(1))
+                        .unwrap_or_else(|| U64::from(1))
                         .saturating_mul(1_000.into());
                     if num_blocks.is_zero() {
                         return Err(jsonrpc_core::Error::invalid_params(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub mod bootloader_debug;
 pub mod configuration_api;
 pub mod console_log;
 pub mod deps;
+pub mod filters;
 pub mod fork;
 pub mod formatter;
 pub mod http_fork_source;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod configuration_api;
 mod console_log;
 mod deps;
 mod evm;
+mod filters;
 mod fork;
 mod formatter;
 mod hardhat;

--- a/src/node.rs
+++ b/src/node.rs
@@ -17,7 +17,7 @@ use futures::FutureExt;
 use jsonrpc_core::BoxFuture;
 use std::{
     cmp::{self},
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     str::FromStr,
     sync::{Arc, RwLock},
 };
@@ -215,6 +215,11 @@ impl Display for ShowGasDetails {
     }
 }
 
+pub struct TransactionResult {
+    info: TxExecutionInfo,
+    receipt: TransactionReceipt,
+}
+
 /// Helper struct for InMemoryNode.
 /// S - is the Source of the Fork.
 pub struct InMemoryNodeInner<S> {
@@ -225,7 +230,7 @@ pub struct InMemoryNodeInner<S> {
     pub current_miniblock: u64,
     pub l1_gas_price: u64,
     // Map from transaction to details about the exeuction
-    pub tx_results: HashMap<H256, TxExecutionInfo>,
+    pub tx_results: HashMap<H256, TransactionResult>,
     // Map from block hash to information about the block.
     pub blocks: HashMap<H256, Block<TransactionVariant>>,
     // Map from block number to a block hash.
@@ -928,7 +933,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
         l2_tx: L2Tx,
         execution_mode: TxExecutionMode,
     ) -> Result<L2TxResult, String> {
-        let mut inner = self
+        let inner = self
             .inner
             .write()
             .map_err(|e| format!("Failed to acquire write lock: {}", e))?;
@@ -1144,19 +1149,80 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
                     .collect(),
             )
         }
+
         let current_miniblock = inner.current_miniblock.saturating_add(1);
-        for event in &result.result.logs.events {
-            inner
-                .filters
-                .notify_new_log(event, U64::from(current_miniblock));
+
+        for (log_idx, event) in result.result.logs.events.iter().enumerate() {
+            inner.filters.notify_new_log(
+                &Log {
+                    address: event.address,
+                    topics: event.indexed_topics.clone(),
+                    data: Bytes(event.value.clone()),
+                    block_hash: Some(block.hash),
+                    block_number: Some(block.number),
+                    l1_batch_number: block.l1_batch_number,
+                    transaction_hash: Some(tx_hash),
+                    transaction_index: Some(U64::zero()),
+                    log_index: Some(U256::from(log_idx)),
+                    transaction_log_index: Some(U256::from(log_idx)),
+                    log_type: None,
+                    removed: None,
+                },
+                U64::from(current_miniblock),
+            );
         }
+        let tx_receipt = TransactionReceipt {
+            transaction_hash: tx_hash,
+            transaction_index: U64::from(0),
+            block_hash: Some(block.hash),
+            block_number: Some(block.number),
+            l1_batch_tx_index: None,
+            l1_batch_number: block.l1_batch_number,
+            from: l2_tx.initiator_account(),
+            to: Some(l2_tx.recipient_account()),
+            cumulative_gas_used: Default::default(),
+            gas_used: Some(l2_tx.common_data.fee.gas_limit - result.gas_refunded),
+            contract_address: contract_address_from_tx_result(&result),
+            logs: result
+                .result
+                .logs
+                .events
+                .iter()
+                .enumerate()
+                .map(|(log_idx, log)| Log {
+                    address: log.address,
+                    topics: log.indexed_topics.clone(),
+                    data: Bytes(log.value.clone()),
+                    block_hash: Some(block.hash),
+                    block_number: Some(block.number),
+                    l1_batch_number: block.l1_batch_number,
+                    transaction_hash: Some(tx_hash),
+                    transaction_index: Some(U64::zero()),
+                    log_index: Some(U256::from(log_idx)),
+                    transaction_log_index: Some(U256::from(log_idx)),
+                    log_type: None,
+                    removed: None,
+                })
+                .collect(),
+            l2_to_l1_logs: vec![],
+            status: Some(if result.status == TxExecutionStatus::Success {
+                U64::from(1)
+            } else {
+                U64::from(0)
+            }),
+            effective_gas_price: Some(L2_GAS_PRICE.into()),
+            ..Default::default()
+        };
         inner.tx_results.insert(
             tx_hash,
-            TxExecutionInfo {
-                tx: l2_tx,
-                batch_number: block.l1_batch_number.unwrap_or_default().as_u32(),
-                miniblock_number: current_miniblock,
-                result,
+            TransactionResult {
+                info: TxExecutionInfo {
+                    tx: l2_tx,
+                    batch_number: block.l1_batch_number.unwrap_or_default().as_u32(),
+                    miniblock_number: current_miniblock,
+                    result,
+                },
+                receipt: tx_receipt,
             },
         );
         let block_hash = block.hash;
@@ -1510,52 +1576,12 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
                 Err(_) => return Err(into_jsrpc_error(Web3Error::InternalError)),
             };
 
-            let tx_result = reader.tx_results.get(&hash);
+            let receipt = reader
+                .tx_results
+                .get(&hash)
+                .map(|info| info.receipt.clone());
 
-            let receipt = tx_result.map(|info| TransactionReceipt {
-                transaction_hash: hash,
-                transaction_index: U64::from(1),
-                block_hash: Some(hash),
-                block_number: Some(U64::from(info.miniblock_number)),
-                l1_batch_tx_index: None,
-                l1_batch_number: Some(U64::from(info.batch_number as u64)),
-                from: Default::default(),
-                to: Some(info.tx.execute.contract_address),
-                cumulative_gas_used: Default::default(),
-                gas_used: Some(info.tx.common_data.fee.gas_limit - info.result.gas_refunded),
-                contract_address: contract_address_from_tx_result(&info.result),
-                logs: info
-                    .result
-                    .result
-                    .logs
-                    .events
-                    .iter()
-                    .map(|log| Log {
-                        address: log.address,
-                        topics: log.indexed_topics.clone(),
-                        data: zksync_types::Bytes(log.value.clone()),
-                        block_hash: Some(hash),
-                        block_number: Some(U64::from(info.miniblock_number)),
-                        l1_batch_number: Some(U64::from(info.batch_number as u64)),
-                        transaction_hash: Some(hash),
-                        transaction_index: Some(U64::from(1)),
-                        log_index: Some(U256::default()),
-                        transaction_log_index: Some(U256::default()),
-                        log_type: None,
-                        removed: None,
-                    })
-                    .collect(),
-                l2_to_l1_logs: vec![],
-                status: Some(if info.result.status == TxExecutionStatus::Success {
-                    U64::from(1)
-                } else {
-                    U64::from(0)
-                }),
-                effective_gas_price: Some(L2_GAS_PRICE.into()),
-                ..Default::default()
-            });
-
-            Ok(receipt).map_err(|_: jsonrpc_core::Error| into_jsrpc_error(Web3Error::InternalError))
+            Ok(receipt)
         })
     }
 
@@ -1716,7 +1742,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
                 .map_err(|_| into_jsrpc_error(Web3Error::InternalError))?;
             let tx_result = reader.tx_results.get(&hash);
 
-            Ok(tx_result.and_then(|info| {
+            Ok(tx_result.and_then(|TransactionResult { info, .. }| {
                 let input_data = info.tx.common_data.input.clone().or(None)?;
 
                 let chain_id = info.tx.extract_chain_id().or(None)?;
@@ -1811,24 +1837,131 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
         Ok(U256::from(fair_l2_gas_price)).into_boxed_future()
     }
 
-    // Methods below are not currently implemented.
+    /// Creates a filter object, based on filter options, to notify when the state changes (logs).
+    /// To check if the state has changed, call `eth_getFilterChanges`.
+    ///
+    /// # Arguments
+    ///
+    /// * `filter`: The filter options -
+    ///     fromBlock: - Integer block number, or the string "latest", "earliest" or "pending".
+    ///     toBlock: - Integer block number, or the string "latest", "earliest" or "pending".
+    ///     address: - Contract address or a list of addresses from which the logs should originate.
+    ///     topics: - [H256] topics. Topics are order-dependent. Each topic can also be an array with "or" options.
+    ///
+    /// If the from `fromBlock` or `toBlock` option are equal to "latest" the filter continually appends logs for newly mined blocks.
+    /// Topics are order-dependent. A transaction with a log with topics [A, B] will be matched by the following topic filters:
+    ///     * [] "anything"
+    ///     * [A] "A in first position (and anything after)"
+    ///     * [null, B] "anything in first position AND B in second position (and anything after)"
+    ///     * [A, B] "A in first position AND B in second position (and anything after)"
+    ///     * [[A, B], [A, B]] "(A OR B) in first position AND (A OR B) in second position (and anything after)"
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `jsonrpc_core::Result` that resolves to an `U256` filter id.
+    fn new_filter(&self, filter: Filter) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<U256>> {
+        let inner = Arc::clone(&self.inner);
+        let mut writer = match inner.write() {
+            Ok(r) => r,
+            Err(_) => {
+                return futures::future::err(into_jsrpc_error(Web3Error::InternalError)).boxed()
+            }
+        };
 
-    fn new_filter(&self, _filter: Filter) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<U256>> {
-        not_implemented("new_filter")
+        let from_block = filter
+            .from_block
+            .unwrap_or(zksync_types::api::BlockNumber::Latest);
+        let to_block = filter
+            .to_block
+            .unwrap_or(zksync_types::api::BlockNumber::Latest);
+        let addresses = filter.address.unwrap_or_default().0;
+        let mut topics: [Option<HashSet<H256>>; 4] = Default::default();
+
+        if let Some(filter_topics) = filter.topics {
+            filter_topics
+                .into_iter()
+                .take(4)
+                .enumerate()
+                .for_each(|(i, maybe_topic_set)| {
+                    if let Some(topic_set) = maybe_topic_set {
+                        topics[i] = Some(topic_set.0.into_iter().collect());
+                    }
+                })
+        }
+
+        writer
+            .filters
+            .add_log_filter(from_block, to_block, addresses, topics)
+            .map_err(|_| into_jsrpc_error(Web3Error::InternalError))
+            .into_boxed_future()
     }
 
+    /// Creates a filter in the node, to notify when a new block arrives.
+    /// To check if the state has changed, call `eth_getFilterChanges`.
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `jsonrpc_core::Result` that resolves to an `U256` filter id.
     fn new_block_filter(&self) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<U256>> {
-        not_implemented("new_block_filter")
+        let inner = Arc::clone(&self.inner);
+        let mut writer = match inner.write() {
+            Ok(r) => r,
+            Err(_) => {
+                return futures::future::err(into_jsrpc_error(Web3Error::InternalError)).boxed()
+            }
+        };
+
+        writer
+            .filters
+            .add_block_filter()
+            .map_err(|_| into_jsrpc_error(Web3Error::InternalError))
+            .into_boxed_future()
     }
 
-    fn uninstall_filter(&self, _idx: U256) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<bool>> {
-        not_implemented("uninstall_filter")
-    }
-
+    /// Creates a filter in the node, to notify when new pending transactions arrive.
+    /// To check if the state has changed, call `eth_getFilterChanges`.
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `jsonrpc_core::Result` that resolves to an `U256` filter id.
     fn new_pending_transaction_filter(
         &self,
     ) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<U256>> {
-        not_implemented("new_pending_transaction_filter")
+        let inner = Arc::clone(&self.inner);
+        let mut writer = match inner.write() {
+            Ok(r) => r,
+            Err(_) => {
+                return futures::future::err(into_jsrpc_error(Web3Error::InternalError)).boxed()
+            }
+        };
+
+        writer
+            .filters
+            .add_pending_transaction_filter()
+            .map_err(|_| into_jsrpc_error(Web3Error::InternalError))
+            .into_boxed_future()
+    }
+
+    /// Uninstalls a filter with given id. Should always be called when watch is no longer needed.
+    ///
+    /// # Arguments
+    ///
+    /// * `id`: The filter id
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `jsonrpc_core::Result` that resolves to an `U256` filter id.
+    fn uninstall_filter(&self, id: U256) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<bool>> {
+        let inner = Arc::clone(&self.inner);
+        let mut writer = match inner.write() {
+            Ok(r) => r,
+            Err(_) => {
+                return futures::future::err(into_jsrpc_error(Web3Error::InternalError)).boxed()
+            }
+        };
+
+        let result = writer.filters.remove_filter(id);
+        Ok(result).into_boxed_future()
     }
 
     fn get_logs(
@@ -1845,11 +1978,37 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
         not_implemented("get_filter_logs")
     }
 
+    /// Polling method for a filter, which returns an array of logs, block hashes, or transaction hashes,
+    /// depending on the filter type, which occurred since last poll.
+    ///
+    /// # Arguments
+    ///
+    /// * `id`: The filter id
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `jsonrpc_core::Result` that resolves to an array of logs, block hashes, or transaction hashes,
+    /// depending on the filter type, which occurred since last poll.
+    /// * Filters created with `eth_newFilter` return [Log] objects.
+    /// * Filters created with `eth_newBlockFilter` return block hashes.
+    /// * Filters created with `eth_newPendingTransactionFilter` return transaction hashes.
     fn get_filter_changes(
         &self,
-        _filter_index: U256,
+        id: U256,
     ) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<FilterChanges>> {
-        not_implemented("get_filter_changes")
+        let inner = Arc::clone(&self.inner);
+        let mut writer = match inner.write() {
+            Ok(r) => r,
+            Err(_) => {
+                return futures::future::err(into_jsrpc_error(Web3Error::InternalError)).boxed()
+            }
+        };
+
+        writer
+            .filters
+            .get_new_changes(id)
+            .map_err(|_| into_jsrpc_error(Web3Error::InternalError))
+            .into_boxed_future()
     }
 
     fn get_block_transaction_count_by_number(

--- a/src/node.rs
+++ b/src/node.rs
@@ -2208,8 +2208,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
                 .as_u64()
                 .min(1024)
                 // Can't be more than the total number of blocks
-                .min(reader.current_miniblock + 1)
-                .max(1);
+                .clamp(1, reader.current_miniblock + 1);
 
             let mut base_fee_per_gas = vec![U256::from(L2_GAS_PRICE); block_count as usize];
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -1125,7 +1125,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
                 .inner
                 .write()
                 .map_err(|e| format!("Failed to acquire write lock: {}", e))?;
-            inner.filters.notify_new_pending_transaction(l2_tx.hash());
+            inner.filters.notify_new_pending_transaction(tx_hash);
         }
 
         let (keys, result, block, bytecodes) =

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -15,6 +15,8 @@ use httptest::{
 };
 use itertools::Itertools;
 use std::str::FromStr;
+use zksync_basic_types::{H160, U64};
+use zksync_types::api::Log;
 use zksync_types::{fee::Fee, l2::L2Tx, Address, L2ChainId, Nonce, PackedEthSignature, H256, U256};
 
 /// Configuration for the [MockServer]'s initial block.
@@ -386,6 +388,57 @@ pub fn apply_tx<T: ForkSource + std::fmt::Debug>(node: &InMemoryNode<T>, tx_hash
     produced_block_hash
 }
 
+/// Builds transaction logs
+#[derive(Debug, Default, Clone)]
+pub struct LogBuilder {
+    block_number: U64,
+    address: Option<H160>,
+    topics: Option<Vec<H256>>,
+}
+
+impl LogBuilder {
+    /// Create a new instance of [LogBuilder]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the log's block number
+    pub fn set_block(&mut self, number: U64) -> &mut Self {
+        self.block_number = number;
+        self
+    }
+
+    /// Sets the log address
+    pub fn set_address(&mut self, address: H160) -> &mut Self {
+        self.address = Some(address);
+        self
+    }
+
+    /// Sets the log topics
+    pub fn set_topics(&mut self, topics: Vec<H256>) -> &mut Self {
+        self.topics = Some(topics);
+        self
+    }
+
+    /// Builds the [Log] object
+    pub fn build(&mut self) -> Log {
+        Log {
+            address: self.address.clone().unwrap_or_default(),
+            topics: self.topics.clone().unwrap_or_default(),
+            data: Default::default(),
+            block_hash: Some(H256::zero()),
+            block_number: Some(self.block_number),
+            l1_batch_number: Default::default(),
+            transaction_hash: Default::default(),
+            transaction_index: Default::default(),
+            log_index: Default::default(),
+            transaction_log_index: Default::default(),
+            log_type: Default::default(),
+            removed: Default::default(),
+        }
+    }
+}
+
 mod test {
     use super::*;
     use crate::http_fork_source::HttpForkSource;
@@ -491,6 +544,44 @@ mod test {
                 .map(|inner| inner.blocks.contains_key(&actual_block_hash))
                 .unwrap(),
             "block was not produced"
+        );
+    }
+
+    #[test]
+    fn test_log_builder_set_block() {
+        let log = LogBuilder::new().set_block(U64::from(2)).build();
+
+        assert_eq!(Some(U64::from(2)), log.block_number);
+    }
+
+    #[test]
+    fn test_log_builder_set_address() {
+        let log = LogBuilder::new()
+            .set_address(H160::repeat_byte(0x1))
+            .build();
+
+        assert_eq!(H160::repeat_byte(0x1), log.address);
+    }
+
+    #[test]
+    fn test_log_builder_set_topics() {
+        let log = LogBuilder::new()
+            .set_topics(vec![
+                H256::repeat_byte(0x1),
+                H256::repeat_byte(0x2),
+                H256::repeat_byte(0x3),
+                H256::repeat_byte(0x4),
+            ])
+            .build();
+
+        assert_eq!(
+            vec![
+                H256::repeat_byte(0x1),
+                H256::repeat_byte(0x2),
+                H256::repeat_byte(0x3),
+                H256::repeat_byte(0x4),
+            ],
+            log.topics
         );
     }
 }

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -402,6 +402,61 @@ content-type: application/json
 {
     "jsonrpc": "2.0",
     "id": "2",
+    "method": "eth_newBlockFilter",
+    "params": []
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "eth_newFilter",
+    "params": [{"fromBlock": "earliest", "toBlock": "0xa"}]
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "eth_newPendingTransactionFilter",
+    "params": []
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "eth_uninstallFilter",
+    "params": ["0x2"]
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "eth_getFilterChanges",
+    "params": ["0x1"]
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "2",
     "method": "hardhat_setBalance",
     "params": [
         "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",


### PR DESCRIPTION
# What :computer: 
* Adds support for `eth_newBlockFilter`, `eth_newFilter`, `eth_newPendingTransactionFilter`, `eth_uninstallFilter`, and `eth_getFilterChanges`.
* Keeps track of transaction logs in node.

# Why :hand:
* Filters are a quite common use case that enables developers to get the exact information they are interested in, quickly.

# Evidence :camera:
![image](https://github.com/matter-labs/era-test-node/assets/1564843/bad9017d-65cc-4263-a02e-d40965d2e2d9)
![output](https://github.com/matter-labs/era-test-node/assets/1564843/28c91701-93db-420f-b241-43f8e07735d6)


# Notes :memo:
* Fixes #36 
* Fixes #37
* Fixes #38
* Fixes #39
* Fixes #42
