### PR TITLE
feat: impl `hardhat_impersonateAccount` and `hardhat_stopImpersonationAccount`

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -90,7 +90,7 @@ The `status` options are:
 | `EVM` | `evm_snapshot` | `NOT IMPLEMENTED`<br />[GitHub Issue #69](https://github.com/matter-labs/era-test-node/issues/69) | Snapshot the state of the blockchain at the current block |
 | `HARDHAT` | `hardhat_addCompilationResult` | `NOT IMPLEMENTED` | Add information about compiled contracts |
 | `HARDHAT` | `hardhat_dropTransaction` | `NOT IMPLEMENTED` | Remove a transaction from the mempool |
-| `HARDHAT` | `hardhat_impersonateAccount` | `NOT IMPLEMENTED`<br />[GitHub Issue #73](https://github.com/matter-labs/era-test-node/issues/73) | Impersonate an account |
+| [`HARDHAT`](#hardhat-namespace) | [`hardhat_impersonateAccount`](#hardhat_impersonateaccount) | `SUPPORTED` | Impersonate an account |
 | `HARDHAT` | `hardhat_getAutomine` | `NOT IMPLEMENTED` | Returns `true` if automatic mining is enabled, and `false` otherwise |
 | `HARDHAT` | `hardhat_metadata` | `NOT IMPLEMENTED` | Returns the metadata of the current network |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_mine`](#hardhat_mine) | Mine any number of blocks at once, in constant time |
@@ -104,7 +104,7 @@ The `status` options are:
 | `HARDHAT` | `hardhat_setPrevRandao` | `NOT IMPLEMENTED` | Sets the PREVRANDAO value of the next block |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setNonce`](#hardhat_setnonce) | `SUPPORTED` | Sets the nonce of a given account |
 | `HARDHAT` | `hardhat_setStorageAt` | `NOT IMPLEMENTED` | Sets the storage value at a given key for a given account |
-| `HARDHAT` | `hardhat_stopImpersonatingAccount` | `NOT IMPLEMENTED`<br />[GitHub Issue #74](https://github.com/matter-labs/era-test-node/issues/74) | Stop impersonating an account after having previously used `hardhat_impersonateAccount` |
+| [`HARDHAT`](#hardhat-namespace) | [`hardhat_stopImpersonatingAccount`](#hardhat_stopimpersonatingaccount) | `SUPPORTED` | Stop impersonating an account after having previously used `hardhat_impersonateAccount` |
 | [`NETWORK`](#network-namespace) | [`net_version`](#net_version) | `SUPPORTED` | Returns the current network id <br />_(default is `260`)_ |
 | [`NETWORK`](#network-namespace) | [`net_peerCount`](#net_peercount) | `SUPPORTED` | Returns the number of peers currently connected to the client <br/>_(hard-coded to `0`)_ |
 | [`NETWORK`](#network-namespace) | [`net_listening`](#net_listening) | `SUPPORTED` | Returns `true` if the client is actively listening for network connections <br />_(hard-coded to `false`)_ |
@@ -907,6 +907,60 @@ curl --request POST \
     "params": [
         "0xaa",
         "0x100"
+    ]
+}'
+
+```
+### `hardhat_impersonateAccount`
+
+[source](src/hardhat.rs)
+
+Begin impersonating account- subsequent transactions sent to the node will be committed as if they were initiated by the supplied address.
+
+#### Arguments
+
+- `address: Address` - The address to begin impersonating
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "hardhat_impersonateAccount",
+    "params": [
+        "0x364d6D0333432C3Ac016Ca832fb8594A8cE43Ca6"
+    ]
+}'
+```
+
+### `hardhat_stopImpersonatingAccount`
+
+[source](src/hardhat.rs)
+
+Stop impersonating account, should be used after calling `hardhat_impersonateAccount`.
+Since we only impersonate one account at a time, the `address` argument is ignored and the current
+impersonated account (if any) is cleared.
+
+#### Arguments
+
+- `address: Address` - (Optional) Argument accepted for compatibility and will be ignored
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "hardhat_stopImpersonatingAccount",
+    "params": [
+        "0x364d6D0333432C3Ac016Ca832fb8594A8cE43Ca6"
     ]
 }'
 ```

--- a/src/node.rs
+++ b/src/node.rs
@@ -6,8 +6,7 @@ use crate::{
     formatter,
     system_contracts::{self, Options, SystemContracts},
     utils::{
-        adjust_l1_gas_price_for_tx, adjust_tx_initiator, derive_gas_estimation_overhead,
-        to_human_size, IntoBoxedFuture,
+        adjust_l1_gas_price_for_tx, derive_gas_estimation_overhead, to_human_size, IntoBoxedFuture,
     },
 };
 use clap::Parser;
@@ -1139,7 +1138,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
                     "🕵️ Executing tx from impersonated account {:?}",
                     impersonated_account
                 );
-                l2_tx = adjust_tx_initiator(l2_tx, impersonated_account);
+                l2_tx.common_data.initiator_address = impersonated_account;
             }
         }
         log::info!("");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,7 @@ use zksync_basic_types::{H256, U256};
 use zksync_state::StorageView;
 use zksync_state::WriteStorage;
 use zksync_types::{
-    api::Block, zk_evm::zkevm_opcode_defs::system_params::MAX_TX_ERGS_LIMIT,
+    api::Block, l2::L2Tx, zk_evm::zkevm_opcode_defs::system_params::MAX_TX_ERGS_LIMIT,
     ExecuteTransactionCommon, L1TxCommonData, L2TxCommonData, Transaction, MAX_TXS_IN_BLOCK,
 };
 use zksync_utils::{ceil_div_u256, u256_to_h256};
@@ -248,23 +248,13 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
 }
 
 /// Adjusts the transaction initiator address.
-pub fn adjust_tx_initiator(tx: Transaction, initiator: Address) -> Transaction {
-    match tx.common_data {
-        ExecuteTransactionCommon::L1(data) => Transaction {
-            common_data: ExecuteTransactionCommon::L1(L1TxCommonData {
-                sender: initiator,
-                ..data
-            }),
-            ..tx
+pub fn adjust_tx_initiator(tx: L2Tx, initiator: Address) -> L2Tx {
+    L2Tx {
+        common_data: L2TxCommonData {
+            initiator_address: initiator,
+            ..tx.common_data
         },
-        ExecuteTransactionCommon::L2(data) => Transaction {
-            common_data: ExecuteTransactionCommon::L2(L2TxCommonData {
-                initiator_address: initiator,
-                ..data
-            }),
-            ..tx
-        },
-        ExecuteTransactionCommon::ProtocolUpgrade(_) => tx,
+        ..tx
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,8 @@ use zksync_basic_types::{H256, U256};
 use zksync_state::StorageView;
 use zksync_state::WriteStorage;
 use zksync_types::{
-    api::Block, zk_evm::zkevm_opcode_defs::system_params::MAX_TX_ERGS_LIMIT, MAX_TXS_IN_BLOCK,
+    api::Block, zk_evm::zkevm_opcode_defs::system_params::MAX_TX_ERGS_LIMIT,
+    ExecuteTransactionCommon, L1TxCommonData, L2TxCommonData, Transaction, MAX_TXS_IN_BLOCK,
 };
 use zksync_utils::{ceil_div_u256, u256_to_h256};
 
@@ -22,6 +23,7 @@ use crate::{
     fork::{ForkSource, ForkStorage},
     node::{compute_hash, InMemoryNodeInner},
 };
+use zksync_basic_types::Address;
 
 pub(crate) trait IntoBoxedFuture: Sized + Send + 'static {
     fn into_boxed_future(self) -> Pin<Box<dyn Future<Output = Self> + Send>> {
@@ -243,6 +245,27 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
 
     // increment batch
     node.current_batch = node.current_batch.saturating_add(1);
+}
+
+/// Adjusts the transaction initiator address.
+pub fn adjust_tx_initiator(tx: Transaction, initiator: Address) -> Transaction {
+    match tx.common_data {
+        ExecuteTransactionCommon::L1(data) => Transaction {
+            common_data: ExecuteTransactionCommon::L1(L1TxCommonData {
+                sender: initiator,
+                ..data
+            }),
+            ..tx
+        },
+        ExecuteTransactionCommon::L2(data) => Transaction {
+            common_data: ExecuteTransactionCommon::L2(L2TxCommonData {
+                initiator_address: initiator,
+                ..data
+            }),
+            ..tx
+        },
+        ExecuteTransactionCommon::ProtocolUpgrade(_) => tx,
+    }
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,7 @@ use zksync_state::StorageView;
 use zksync_state::WriteStorage;
 use zksync_types::{
     api::Block, l2::L2Tx, zk_evm::zkevm_opcode_defs::system_params::MAX_TX_ERGS_LIMIT,
-    ExecuteTransactionCommon, L1TxCommonData, L2TxCommonData, Transaction, MAX_TXS_IN_BLOCK,
+    L2TxCommonData, MAX_TXS_IN_BLOCK,
 };
 use zksync_utils::{ceil_div_u256, u256_to_h256};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,8 +14,7 @@ use zksync_basic_types::{H256, U256};
 use zksync_state::StorageView;
 use zksync_state::WriteStorage;
 use zksync_types::{
-    api::Block, l2::L2Tx, zk_evm::zkevm_opcode_defs::system_params::MAX_TX_ERGS_LIMIT,
-    L2TxCommonData, MAX_TXS_IN_BLOCK,
+    api::Block, zk_evm::zkevm_opcode_defs::system_params::MAX_TX_ERGS_LIMIT, MAX_TXS_IN_BLOCK,
 };
 use zksync_utils::{ceil_div_u256, u256_to_h256};
 
@@ -23,7 +22,6 @@ use crate::{
     fork::{ForkSource, ForkStorage},
     node::{compute_hash, InMemoryNodeInner},
 };
-use zksync_basic_types::Address;
 
 pub(crate) trait IntoBoxedFuture: Sized + Send + 'static {
     fn into_boxed_future(self) -> Pin<Box<dyn Future<Output = Self> + Send>> {
@@ -245,17 +243,6 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
 
     // increment batch
     node.current_batch = node.current_batch.saturating_add(1);
-}
-
-/// Adjusts the transaction initiator address.
-pub fn adjust_tx_initiator(tx: L2Tx, initiator: Address) -> L2Tx {
-    L2Tx {
-        common_data: L2TxCommonData {
-            initiator_address: initiator,
-            ..tx.common_data
-        },
-        ..tx
-    }
 }
 
 #[cfg(test)]

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -454,6 +454,32 @@ content-type: application/json
 
 {
     "jsonrpc": "2.0",
+    "id": "2",
+    "method": "hardhat_impersonateAccount",
+    "params": [
+        "0x364d6D0333432C3Ac016Ca832fb8594A8cE43Ca6"
+    ]
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "hardhat_stopImpersonatingAccount",
+    "params": [
+        "0x364d6D0333432C3Ac016Ca832fb8594A8cE43Ca6"
+    ]
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
     "id": "1",
     "method": "zks_getTokenPrice",
     "params": ["0x0000000000000000000000000000000000000000"]


### PR DESCRIPTION
# What :computer: 
* Adds a field `impersonated_account: Option<Address>` to node; in `run_l2_tx` method, adjust the tx to have initiator = impersonated account if set. This requires setting `self.system_contracts = SystemContracts::from_options(&Options::BuiltInWithoutSecurity)` to disable signature verification
* Adds `hardhat_impersonateAccount` and `hardhat_stopImpersonationAccount` RPCs

# Why :hand:
* Allow user to send transactions from arbitrary addresses, useful for testing

# Evidence :camera:
<img width="679" alt="Screenshot 2023-09-19 at 16 55 19" src="https://github.com/matter-labs/era-test-node/assets/140627974/78b7943e-7836-4441-9b57-03ac05a1871b">

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any suggestions for better tests? We don't have any test for `send_raw_transaction`- I tried a bit to write one but was quite hard, just re-used `apply_txs`
