### PR TITLE
chore: updated zksync era dependency to v6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "cs_derive"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-sync_vm.git?branch=v1.3.3#22d9d3a2018df8d4ac4bc0b0ada61c191d0cee30"
+source = "git+https://github.com/matter-labs/era-sync_vm.git?tag=v1.3.3-rc0#23beb8f268427508aefc916cff0d42a36b877586"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.66",
@@ -1739,19 +1739,6 @@ checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -3682,7 +3669,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "multivm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "vlog",
  "vm",
@@ -4613,7 +4600,7 @@ dependencies = [
 [[package]]
 name = "prometheus_exporter"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -6112,7 +6099,7 @@ dependencies = [
 [[package]]
 name = "sync_vm"
 version = "1.3.3"
-source = "git+https://github.com/matter-labs/era-sync_vm.git?branch=v1.3.3#22d9d3a2018df8d4ac4bc0b0ada61c191d0cee30"
+source = "git+https://github.com/matter-labs/era-sync_vm.git?tag=v1.3.3-rc0#23beb8f268427508aefc916cff0d42a36b877586"
 dependencies = [
  "arrayvec 0.7.4",
  "cs_derive",
@@ -6851,7 +6838,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vlog"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -6867,7 +6854,7 @@ dependencies = [
 [[package]]
 name = "vm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -6889,7 +6876,7 @@ dependencies = [
 [[package]]
 name = "vm_m5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "hex",
  "itertools",
@@ -6911,7 +6898,7 @@ dependencies = [
 [[package]]
 name = "vm_m6"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "hex",
  "itertools",
@@ -7312,7 +7299,7 @@ dependencies = [
 [[package]]
 name = "zk_evm"
 version = "1.3.3"
-source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3#c08a8581421d2a0cf1fc8cbbdcd06c00da01fe0e"
+source = "git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc0#c08a8581421d2a0cf1fc8cbbdcd06c00da01fe0e"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7340,7 +7327,7 @@ name = "zkevm-assembly"
 version = "1.3.1"
 source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.1#dabbb07e84dd886ee90dde2b5dde0acbf9b0123a"
 dependencies = [
- "env_logger 0.9.3",
+ "env_logger",
  "hex",
  "lazy_static",
  "log",
@@ -7359,7 +7346,7 @@ name = "zkevm-assembly"
 version = "1.3.2"
 source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2#edc364e59a2eea9c4b1d4ce79f15d0b7c6b55b98"
 dependencies = [
- "env_logger 0.9.3",
+ "env_logger",
  "hex",
  "lazy_static",
  "log",
@@ -7401,14 +7388,14 @@ dependencies = [
 [[package]]
 name = "zkevm_test_harness"
 version = "1.3.3"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.3.3#6453eab3c9c8915f588ff4eceb48d7be9a695ecb"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?tag=v1.3.3-rc1#46391e83330c77f6d79ff7c5fc19bae3d5b3ab82"
 dependencies = [
  "bincode",
  "circuit_testing",
  "codegen 0.2.0",
  "crossbeam 0.8.2",
  "derivative",
- "env_logger 0.10.0",
+ "env_logger",
  "hex",
  "num-bigint 0.4.3",
  "num-integer",
@@ -7428,7 +7415,7 @@ dependencies = [
 [[package]]
 name = "zksync_basic_types"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "serde",
  "web3",
@@ -7437,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "zksync_circuit_breaker"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "async-trait",
  "backon",
@@ -7457,7 +7444,7 @@ dependencies = [
 [[package]]
 name = "zksync_config"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "bigdecimal",
  "envy",
@@ -7474,7 +7461,7 @@ dependencies = [
 [[package]]
 name = "zksync_contracts"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "ethabi 18.0.0",
  "hex",
@@ -7487,7 +7474,7 @@ dependencies = [
 [[package]]
 name = "zksync_core"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "actix-cors",
  "actix-rt",
@@ -7550,7 +7537,7 @@ dependencies = [
 [[package]]
 name = "zksync_crypto"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "base64 0.13.1",
  "blake2 0.10.6",
@@ -7565,7 +7552,7 @@ dependencies = [
 [[package]]
 name = "zksync_dal"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -7592,7 +7579,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_client"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7612,7 +7599,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_signer"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "async-trait",
  "hex",
@@ -7631,7 +7618,7 @@ dependencies = [
 [[package]]
 name = "zksync_health_check"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -7643,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "zksync_mempool"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "metrics",
  "vlog",
@@ -7653,7 +7640,7 @@ dependencies = [
 [[package]]
 name = "zksync_merkle_tree"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "leb128",
  "metrics",
@@ -7669,7 +7656,7 @@ dependencies = [
 [[package]]
 name = "zksync_mini_merkle_tree"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -7679,7 +7666,7 @@ dependencies = [
 [[package]]
 name = "zksync_object_store"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7696,7 +7683,7 @@ dependencies = [
 [[package]]
 name = "zksync_prover_utils"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "async-trait",
  "ctrlc",
@@ -7714,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "zksync_queued_job_processor"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "async-trait",
  "tokio",
@@ -7725,7 +7712,7 @@ dependencies = [
 [[package]]
 name = "zksync_state"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "metrics",
  "mini-moka",
@@ -7739,7 +7726,7 @@ dependencies = [
 [[package]]
 name = "zksync_storage"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "metrics",
  "num_cpus",
@@ -7750,7 +7737,7 @@ dependencies = [
 [[package]]
 name = "zksync_types"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "blake2 0.10.6",
  "chrono",
@@ -7779,7 +7766,7 @@ dependencies = [
 [[package]]
 name = "zksync_utils"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -7801,7 +7788,7 @@ dependencies = [
 [[package]]
 name = "zksync_verification_key_generator_and_server"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "bincode",
  "circuit_testing",
@@ -7819,7 +7806,7 @@ dependencies = [
 [[package]]
 name = "zksync_web3_decl"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=a98e454221da7d6ecad9b317cf44b0786e819659#a98e454221da7d6ecad9b317cf44b0786e819659"
+source = "git+https://github.com/matter-labs/zksync-era.git?tag=v6.0.0-rc1#43abaa9929db8514ff93e1f7e352a0ca7a5f5ff4"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,15 @@ categories = ["cryptography"]
 publish = false # We don't want to publish our binaries.
 
 [dependencies]
-zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
-zksync_core = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
-vm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
-vlog = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
-zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
-zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
-zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
-zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
-zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
+zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v6.0.0-rc1" }
+zksync_core = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v6.0.0-rc1" }
+vm = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v6.0.0-rc1" }
+vlog = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v6.0.0-rc1" }
+zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v6.0.0-rc1" }
+zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v6.0.0-rc1" }
+zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v6.0.0-rc1" }
+zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v6.0.0-rc1" }
+zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v6.0.0-rc1" }
 openssl-sys = { version = "0.9", features = ["vendored"] }
 
 anyhow = "1.0"


### PR DESCRIPTION
# What :computer: 
* Updated the dependency on zksync-era to v6
* this is basically the same as we use today, so there are no changes.

# Why :hand:
* zksync era is doing a major release, that contains a large VM api change
* so we have to clean up our dependency versions, so that era-test-node doesn't get broken 
* as previous commit of zksync-era that we depended on, have sub-dependencies that will be broken soon

# Evidence :camera:
<img width="954" alt="image" src="https://github.com/matter-labs/era-test-node/assets/128217157/6ce4c751-516d-466b-977a-56ddd88096fa">
