### PR TITLE
chore: align current_miniblock, current_batch, current_timestamp to point to the latest entities

### DIFF
--- a/e2e-tests/test/evm-apis.test.ts
+++ b/e2e-tests/test/evm-apis.test.ts
@@ -36,7 +36,7 @@ describe("evm_increaseTime", function () {
       to: userWallet.address,
       value: ethers.utils.parseEther("0.1"),
     });
-    expectedTimestamp += 1; // New transaction will add a second block
+    expectedTimestamp += 2; // New transaction will add two block
 
     // Assert
     const newBlockTimestamp = (await provider.getBlock("latest")).timestamp;

--- a/e2e-tests/test/evm-apis.test.ts
+++ b/e2e-tests/test/evm-apis.test.ts
@@ -36,7 +36,7 @@ describe("evm_increaseTime", function () {
       to: userWallet.address,
       value: ethers.utils.parseEther("0.1"),
     });
-    expectedTimestamp += 2; // New transaction will add two block
+    expectedTimestamp += 2; // New transaction will add two blocks
 
     // Assert
     const newBlockTimestamp = (await provider.getBlock("latest")).timestamp;
@@ -60,7 +60,7 @@ describe("evm_setNextBlockTimestamp", function () {
       to: userWallet.address,
       value: ethers.utils.parseEther("0.1"),
     });
-    expectedTimestamp += 1; // New transaction will add a second block
+    expectedTimestamp += 2; // New transaction will add two blocks
 
     // Assert
     const newBlockTimestamp = (await provider.getBlock("latest")).timestamp;
@@ -84,7 +84,7 @@ describe("evm_setTime", function () {
       to: userWallet.address,
       value: ethers.utils.parseEther("0.1"),
     });
-    expectedTimestamp += 1; // New transaction will add a second block
+    expectedTimestamp += 2; // New transaction will add two blocks
 
     // Assert
     const newBlockTimestamp = (await provider.getBlock("latest")).timestamp;

--- a/e2e-tests/test/hardhat-apis.test.ts
+++ b/e2e-tests/test/hardhat-apis.test.ts
@@ -54,7 +54,7 @@ describe("hardhat_mine", function () {
     const latestBlock = await provider.getBlock("latest");
     expect(latestBlock.number).to.equal(startingBlock.number + numberOfBlocks, "Block number mismatch");
     expect(latestBlock.timestamp).to.equal(
-      startingTimestamp + (numberOfBlocks - 1) * intervalInSeconds * 1000,
+      startingTimestamp + (numberOfBlocks - 1) * intervalInSeconds * 1000 + 1,
       "Timestamp mismatch"
     );
   });

--- a/src/evm.rs
+++ b/src/evm.rs
@@ -466,7 +466,7 @@ mod tests {
             .expect("block exists");
 
         assert_eq!(start_block.number + 1, current_block.number);
-        assert_eq!(start_block.timestamp + 1000, current_block.timestamp);
+        assert_eq!(start_block.timestamp + 1, current_block.timestamp);
 
         let result = evm.evm_mine().await.expect("evm_mine");
         assert_eq!(&result, "0x0");
@@ -478,6 +478,6 @@ mod tests {
             .expect("block exists");
 
         assert_eq!(start_block.number + 2, current_block.number);
-        assert_eq!(start_block.timestamp + 2000, current_block.timestamp);
+        assert_eq!(start_block.timestamp + 2, current_block.timestamp);
     }
 }

--- a/src/hardhat.rs
+++ b/src/hardhat.rs
@@ -316,7 +316,7 @@ mod tests {
             .expect("block exists");
 
         assert_eq!(start_block.number + 1, current_block.number);
-        assert_eq!(start_block.timestamp + 1000, current_block.timestamp);
+        assert_eq!(start_block.timestamp + 1, current_block.timestamp);
         let result = hardhat
             .hardhat_mine(None, None)
             .await
@@ -330,7 +330,7 @@ mod tests {
             .expect("block exists");
 
         assert_eq!(start_block.number + 2, current_block.number);
-        assert_eq!(start_block.timestamp + 2000, current_block.timestamp);
+        assert_eq!(start_block.timestamp + 2, current_block.timestamp);
     }
 
     #[tokio::test]
@@ -347,7 +347,7 @@ mod tests {
 
         let num_blocks = 5;
         let interval = 3;
-        let start_timestamp = start_block.timestamp + 1_000;
+        let start_timestamp = start_block.timestamp + 1;
 
         let result = hardhat
             .hardhat_mine(Some(U64::from(num_blocks)), Some(U64::from(interval)))

--- a/src/node.rs
+++ b/src/node.rs
@@ -730,7 +730,10 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
             let mut block_hashes = HashMap::<u64, H256>::new();
             block_hashes.insert(0, H256::zero());
             let mut blocks = HashMap::<H256, Block<TransactionVariant>>::new();
-            blocks.insert(H256::zero(), create_empty_block(0, 0, 1));
+            blocks.insert(
+                H256::zero(),
+                create_empty_block(0, NON_FORK_FIRST_BLOCK_TIMESTAMP, 0),
+            );
 
             InMemoryNodeInner {
                 current_timestamp: NON_FORK_FIRST_BLOCK_TIMESTAMP,

--- a/src/node.rs
+++ b/src/node.rs
@@ -238,13 +238,14 @@ pub struct TransactionResult {
 /// Helper struct for InMemoryNode.
 /// S - is the Source of the Fork.
 pub struct InMemoryNodeInner<S> {
-    /// Timestamp, batch number that will be used by the next block.
+    /// The latest timestamp that was already generated.
+    /// Next block will be current_timestamp + 1
     pub current_timestamp: u64,
-    /// Batch number that will be used by the next block.
+    /// The latest batch number that was already generated.
+    /// Next block will be current_batch + 1
     pub current_batch: u32,
     /// The latest miniblock number that was already generated.
     /// Next transaction will go to the block current_miniblock + 1
-    /// (for now, this is a different behavior than the current_batch)
     pub current_miniblock: u64,
     pub l1_gas_price: u64,
     // Map from transaction to details about the exeuction
@@ -277,16 +278,26 @@ type L2TxResult = (
     VmExecutionResultAndLogs,
     Block<TransactionVariant>,
     HashMap<U256, Vec<U256>>,
+    NextBlock,
 );
 
 impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
-    pub fn create_l1_batch_env<ST: ReadStorage>(&self, storage: StoragePtr<ST>) -> L1BatchEnv {
+    pub fn create_l1_batch_env<ST: ReadStorage>(
+        &self,
+        storage: StoragePtr<ST>,
+    ) -> (L1BatchEnv, NextBlock) {
         let last_l2_block = load_last_l2_block(storage);
-        L1BatchEnv {
+        let next_block = NextBlock::from_current(
+            self.current_batch,
+            self.current_miniblock,
+            self.current_timestamp,
+        );
+        let next_block = next_block.new_batch();
+        let batch_env = L1BatchEnv {
             // TODO: set the previous batch hash properly (take from fork, when forking, and from local storage, when this is not the first block).
             previous_batch_hash: None,
-            number: L1BatchNumber::from(self.current_batch),
-            timestamp: self.current_timestamp,
+            number: L1BatchNumber::from(next_block.batch),
+            timestamp: next_block.timestamp,
             l1_gas_price: self.l1_gas_price,
             fair_l2_gas_price: L2_GAS_PRICE,
             fee_account: H160::zero(),
@@ -294,8 +305,8 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
             first_l2_block: vm::L2BlockEnv {
                 // the 'current_miniblock' contains the block that was already produced.
                 // So the next one should be one higher.
-                number: self.current_miniblock.saturating_add(1) as u32,
-                timestamp: self.current_timestamp,
+                number: next_block.miniblock as u32,
+                timestamp: next_block.timestamp,
                 prev_block_hash: last_l2_block.hash,
                 // This is only used during zksyncEra block timestamp/number transition.
                 // In case of starting a new network, it doesn't matter.
@@ -306,7 +317,9 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
                 // depend on block number or timestamp.
                 max_virtual_blocks_to_create: 1,
             },
-        }
+        };
+
+        (batch_env, next_block)
     }
 
     pub fn create_system_env(
@@ -413,7 +426,7 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
         let storage = storage_view.to_rc_ptr();
 
         let execution_mode = TxExecutionMode::EstimateFee;
-        let mut batch_env = self.create_l1_batch_env(storage.clone());
+        let (mut batch_env, next_block) = self.create_l1_batch_env(storage.clone());
         batch_env.l1_gas_price = l1_gas_price;
         let system_env = self.create_system_env(
             self.system_contracts.contracts_for_fee_estimate().clone(),
@@ -695,8 +708,8 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
             blocks.insert(f.l2_block.hash, f.l2_block.clone());
 
             InMemoryNodeInner {
-                current_timestamp: f.block_timestamp + 1,
-                current_batch: f.l1_block.0 + 1,
+                current_timestamp: f.block_timestamp,
+                current_batch: f.l1_block.0,
                 current_miniblock: f.l2_miniblock,
                 l1_gas_price: f.l1_gas_price,
                 tx_results: Default::default(),
@@ -721,13 +734,14 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
                 H256::zero(),
                 Block::<TransactionVariant> {
                     gas_limit: U256::from(ETH_CALL_GAS_LIMIT),
+                    timestamp: U256::from(NON_FORK_FIRST_BLOCK_TIMESTAMP),
                     ..Default::default()
                 },
             );
 
             InMemoryNodeInner {
                 current_timestamp: NON_FORK_FIRST_BLOCK_TIMESTAMP,
-                current_batch: 1,
+                current_batch: 0,
                 current_miniblock: 0,
                 l1_gas_price: L1_GAS_PRICE,
                 tx_results: Default::default(),
@@ -804,7 +818,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
 
         // init vm
 
-        let batch_env = inner.create_l1_batch_env(storage.clone());
+        let (batch_env, _) = inner.create_l1_batch_env(storage.clone());
         let system_env = inner.create_system_env(bootloader_code.clone(), execution_mode);
 
         let mut vm = Vm::new(batch_env, system_env, storage, HistoryDisabled);
@@ -1027,7 +1041,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
 
         let storage = StorageView::new(&inner.fork_storage).to_rc_ptr();
 
-        let batch_env = inner.create_l1_batch_env(storage.clone());
+        let (batch_env, next_block) = inner.create_l1_batch_env(storage.clone());
 
         // if we are impersonating an account, we need to use non-verifying system contracts
         let nonverifying_contracts;
@@ -1179,7 +1193,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
         let hash = compute_hash(batch_env.number.0, l2_tx.hash());
         let block = Block {
             hash,
-            number: U64::from(inner.current_miniblock.saturating_add(1)),
+            number: U64::from(next_block.miniblock),
             timestamp: U256::from(batch_env.timestamp),
             l1_batch_number: Some(U64::from(batch_env.number.0)),
             transactions: vec![TransactionVariant::Full(
@@ -1202,7 +1216,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
         vm.execute(vm::VmExecutionMode::Bootloader);
 
         let modified_keys = storage.borrow().modified_storage_keys().clone();
-        Ok((modified_keys, tx_result, block, bytecodes))
+        Ok((modified_keys, tx_result, block, bytecodes, next_block))
     }
 
     /// Runs L2 transaction and commits it to a new block.
@@ -1219,7 +1233,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
             inner.filters.notify_new_pending_transaction(tx_hash);
         }
 
-        let (keys, result, block, bytecodes) =
+        let (keys, result, block, bytecodes, next_block) =
             self.run_l2_tx_inner(l2_tx.clone(), execution_mode)?;
 
         if let ExecutionResult::Halt { reason } = result.result {
@@ -1251,8 +1265,6 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
             )
         }
 
-        let current_miniblock = inner.current_miniblock.saturating_add(1);
-
         for (log_idx, event) in result.logs.events.iter().enumerate() {
             inner.filters.notify_new_log(
                 &Log {
@@ -1269,7 +1281,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
                     log_type: None,
                     removed: None,
                 },
-                U64::from(current_miniblock),
+                block.number,
             );
         }
         let tx_receipt = TransactionReceipt {
@@ -1319,45 +1331,105 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
                 info: TxExecutionInfo {
                     tx: l2_tx,
                     batch_number: block.l1_batch_number.unwrap_or_default().as_u32(),
-                    miniblock_number: current_miniblock,
+                    miniblock_number: block.number.as_u64(),
                     result,
                 },
                 receipt: tx_receipt,
             },
         );
-        let block_hash = block.hash;
-        inner.block_hashes.insert(current_miniblock, block.hash);
-        inner.blocks.insert(block.hash, block);
-        inner.filters.notify_new_block(block_hash);
 
         // With the introduction of 'l2 blocks' (and virtual blocks),
         // we are adding one l2 block at the end of each batch (to handle things like remaining events etc).
-
+        //  You can look at insert_fictive_l2_block function in VM to see how this fake block is inserted.
+        let next_block = next_block.new_block();
         let empty_block_at_end_of_batch = create_empty_block(
-            (current_miniblock + 1) as u32,
-            inner.current_timestamp + 1,
-            inner.current_batch,
+            next_block.miniblock as u32,
+            next_block.timestamp,
+            next_block.batch,
         );
-        let empty_block_hash = empty_block_at_end_of_batch.hash;
-        inner
-            .block_hashes
-            .insert(current_miniblock + 1, empty_block_hash);
-        inner.blocks.insert(
-            empty_block_at_end_of_batch.hash,
-            empty_block_at_end_of_batch,
-        );
-        inner.filters.notify_new_block(empty_block_hash);
 
-        {
-            // That's why here, we increase the batch by 1, but miniblock (and timestamp) by 2.
-            // You can look at insert_fictive_l2_block function in VM to see how this fake block is inserted.
+        let new_batch = inner.current_batch.saturating_add(1);
+        let mut current_miniblock = inner.current_miniblock;
+        let mut current_timestamp = inner.current_timestamp;
 
-            inner.current_batch += 1;
-            inner.current_miniblock += 2;
-            inner.current_timestamp += 2;
+        for block in vec![block, empty_block_at_end_of_batch] {
+            current_miniblock = current_miniblock.saturating_add(1);
+            current_timestamp = current_timestamp.saturating_add(1);
+
+            let actual_l1_batch_number = block
+                .l1_batch_number
+                .expect("block must have a l1_batch_number");
+            if actual_l1_batch_number.as_u32() != new_batch {
+                panic!(
+                    "expected next block to have batch_number {}, got {}",
+                    new_batch,
+                    actual_l1_batch_number.as_u32()
+                );
+            }
+
+            if block.number.as_u64() != current_miniblock {
+                panic!(
+                    "expected next block to have miniblock {}, got {}",
+                    current_miniblock,
+                    block.number.as_u64()
+                );
+            }
+
+            if block.timestamp.as_u64() != current_timestamp {
+                panic!(
+                    "expected next block to have timestamp {}, got {}",
+                    current_timestamp,
+                    block.timestamp.as_u64()
+                );
+            }
+
+            let block_hash = block.hash;
+            inner.block_hashes.insert(block.number.as_u64(), block.hash);
+            inner.blocks.insert(block.hash, block);
+            inner.filters.notify_new_block(block_hash);
         }
 
+        inner.current_batch = new_batch;
+        inner.current_miniblock = current_miniblock;
+        inner.current_timestamp = current_timestamp;
+
         Ok(())
+    }
+}
+
+/// Keeps track of next block's batch number, miniblock number and timestamp.
+pub struct NextBlock {
+    pub batch: u32,
+    pub miniblock: u64,
+    pub timestamp: u64,
+}
+
+impl NextBlock {
+    /// Create the current instance that represents the latest block.
+    pub fn from_current(batch: u32, miniblock: u64, timestamp: u64) -> Self {
+        Self {
+            batch,
+            miniblock,
+            timestamp,
+        }
+    }
+
+    /// Create the next batch instance that has all parameters incremented by `1`.
+    pub fn new_batch(&self) -> Self {
+        Self {
+            batch: self.batch.saturating_add(1),
+            miniblock: self.miniblock.saturating_add(1),
+            timestamp: self.timestamp.saturating_add(1),
+        }
+    }
+
+    /// Create the next batch instance that uses the same batch number, and has all other parameters incremented by `1`.
+    pub fn new_block(&self) -> NextBlock {
+        Self {
+            batch: self.batch,
+            miniblock: self.miniblock.saturating_add(1),
+            timestamp: self.timestamp.saturating_add(1),
+        }
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -735,6 +735,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
                 Block::<TransactionVariant> {
                     gas_limit: U256::from(ETH_CALL_GAS_LIMIT),
                     timestamp: U256::from(NON_FORK_FIRST_BLOCK_TIMESTAMP),
+                    l1_batch_number: Some(U64::zero()),
                     ..Default::default()
                 },
             );

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -360,7 +360,7 @@ pub fn apply_tx<T: ForkSource + std::fmt::Debug>(node: &InMemoryNode<T>, tx_hash
     let current_batch = node
         .get_inner()
         .read()
-        .map(|reader| reader.current_batch)
+        .map(|reader| reader.current_batch.saturating_add(1))
         .expect("failed getting current batch number");
     let produced_block_hash = compute_hash(current_batch, tx_hash);
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -357,12 +357,12 @@ impl RawTransactionsResponseBuilder {
 
 /// Applies a transaction with a given hash to the node and returns the block hash.
 pub fn apply_tx<T: ForkSource + std::fmt::Debug>(node: &InMemoryNode<T>, tx_hash: H256) -> H256 {
-    let current_batch = node
+    let next_miniblock = node
         .get_inner()
         .read()
-        .map(|reader| reader.current_batch.saturating_add(1))
+        .map(|reader| reader.current_miniblock.saturating_add(1))
         .expect("failed getting current batch number");
-    let produced_block_hash = compute_hash(current_batch, tx_hash);
+    let produced_block_hash = compute_hash(next_miniblock, tx_hash);
 
     let private_key = H256::random();
     let from_account = PackedEthSignature::address_from_private_key(&private_key)
@@ -561,7 +561,7 @@ mod test {
         let actual_block_hash = apply_tx(&node, H256::repeat_byte(0x01));
 
         assert_eq!(
-            H256::from_str("0x89c0aa770eba1f187235bdad80de9c01fe81bca415d442ca892f087da56fa109")
+            H256::from_str("0xd97ba6a5ab0f2d7fbfc697251321cce20bff3da2b0ddaf12c80f80f0ab270b15")
                 .unwrap(),
             actual_block_hash,
         );

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -107,6 +107,7 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
             // we need these to use the unsafeOverrideBlock method in SystemContext.sol
             let bootloader_code = node.system_contracts.contacts_for_l2_call();
             let (batch_env, mut next_block) = node.create_l1_batch_env(storage.clone());
+            println!("timestamp {}", next_block.timestamp);
             // override the next block's timestamp to match up with interval for subsequent blocks
             if i != 0 {
                 next_block.timestamp = node.current_timestamp.saturating_add(interval_ms);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -107,7 +107,6 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
             // we need these to use the unsafeOverrideBlock method in SystemContext.sol
             let bootloader_code = node.system_contracts.contacts_for_l2_call();
             let (batch_env, mut next_block) = node.create_l1_batch_env(storage.clone());
-            println!("timestamp {}", next_block.timestamp);
             // override the next block's timestamp to match up with interval for subsequent blocks
             if i != 0 {
                 next_block.timestamp = node.current_timestamp.saturating_add(interval_ms);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -100,16 +100,16 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
     // build and insert new blocks
     for i in 0..num_blocks {
         // roll the vm
-        let (keys, bytecodes, next_block) = {
+        let (keys, bytecodes, block_ctx) = {
             let storage = StorageView::new(&node.fork_storage).to_rc_ptr();
 
             // system_contract.contacts_for_l2_call() will give playground contracts
             // we need these to use the unsafeOverrideBlock method in SystemContext.sol
             let bootloader_code = node.system_contracts.contacts_for_l2_call();
-            let (batch_env, mut next_block) = node.create_l1_batch_env(storage.clone());
+            let (batch_env, mut block_ctx) = node.create_l1_batch_env(storage.clone());
             // override the next block's timestamp to match up with interval for subsequent blocks
             if i != 0 {
-                next_block.timestamp = node.current_timestamp.saturating_add(interval_ms);
+                block_ctx.timestamp = node.current_timestamp.saturating_add(interval_ms);
             }
 
             // init vm
@@ -126,7 +126,7 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
                 .map(|b| bytecode_to_factory_dep(b.original.clone()))
                 .collect();
             let modified_keys = storage.borrow().modified_storage_keys().clone();
-            (modified_keys, bytecodes, next_block)
+            (modified_keys, bytecodes, block_ctx)
         };
 
         for (key, value) in keys.iter() {
@@ -147,16 +147,15 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
             )
         }
 
-        let block =
-            create_empty_block(next_block.miniblock, next_block.timestamp, next_block.batch);
+        let block = create_empty_block(block_ctx.miniblock, block_ctx.timestamp, block_ctx.batch);
 
         node.block_hashes.insert(block.number.as_u64(), block.hash);
         node.blocks.insert(block.hash, block);
 
         // leave node state ready for next interaction
-        node.current_batch = next_block.batch;
-        node.current_miniblock = next_block.miniblock;
-        node.current_timestamp = next_block.timestamp;
+        node.current_batch = block_ctx.batch;
+        node.current_miniblock = block_ctx.miniblock;
+        node.current_timestamp = block_ctx.timestamp;
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -147,11 +147,8 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
             )
         }
 
-        let block = create_empty_block(
-            next_block.miniblock as u32,
-            next_block.timestamp,
-            next_block.batch,
-        );
+        let block =
+            create_empty_block(next_block.miniblock, next_block.timestamp, next_block.batch);
 
         node.block_hashes.insert(block.number.as_u64(), block.hash);
         node.blocks.insert(block.hash, block);


### PR DESCRIPTION
# What :computer: 
* Aligns current_miniblock, current_batch, current_timestamp to point to the latest entities. Previously current_miniblock would contain the latest block but others would contain values for the next block
* Fix `compute_hash` type for block_number being `u32` instead of `u64`
* Fixes behavior mining blocks according to the `current_timestamp` rules.

# Why :hand:
* The code should not be confusing to any new contributors and must be consistent.

# Evidence :camera:
* All tests pass
* New tests for creating empty blocks
![image](https://github.com/matter-labs/era-test-node/assets/1564843/2bb68722-e418-49df-8674-60e438e759a0)


# Notes :memo:
* Fixes #131 
