### PR TITLE
feat: account impersonating improvements and eth_sendTransaction

### DIFF
--- a/src/eth_test.rs
+++ b/src/eth_test.rs
@@ -1,0 +1,13 @@
+use jsonrpc_core::{BoxFuture, Result};
+use jsonrpc_derive::rpc;
+use zksync_basic_types::H256;
+use zksync_types::transaction_request::CallRequest;
+
+///
+/// ETH namespace extension for the test node.
+///
+#[rpc]
+pub trait EthTestNodeNamespaceT {
+    #[rpc(name = "eth_sendTransaction")]
+    fn send_transaction(&self, tx: CallRequest) -> BoxFuture<Result<H256>>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub mod bootloader_debug;
 pub mod configuration_api;
 pub mod console_log;
 pub mod deps;
+pub mod eth_test;
 pub mod filters;
 pub mod fork;
 pub mod formatter;
@@ -54,7 +55,6 @@ pub mod resolver;
 pub mod system_contracts;
 pub mod utils;
 pub mod zks;
-pub mod eth_test;
 
 mod cache;
 mod testing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub mod resolver;
 pub mod system_contracts;
 pub mod utils;
 pub mod zks;
+pub mod eth_test;
 
 mod cache;
 mod testing;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod configuration_api;
 mod console_log;
 mod deps;
 mod evm;
+mod eth_test;
 mod filters;
 mod fork;
 mod formatter;
@@ -56,6 +57,7 @@ use crate::{configuration_api::ConfigurationApiNamespace, node::TEST_NODE_NETWOR
 use zksync_core::api_server::web3::backend_jsonrpc::namespaces::{
     eth::EthNamespaceT, net::NetNamespaceT, zks::ZksNamespaceT,
 };
+use crate::eth_test::EthTestNodeNamespaceT;
 
 /// List of wallets (address, private key) that we seed with tokens at start.
 pub const RICH_WALLETS: [(&str, &str); 10] = [
@@ -118,7 +120,8 @@ async fn build_json_http<
 
     let io_handler = {
         let mut io = MetaIoHandler::with_middleware(LoggingMiddleware::new(log_level_filter));
-        io.extend_with(node.to_delegate());
+        io.extend_with(EthNamespaceT::to_delegate(node.clone()));
+        io.extend_with(EthTestNodeNamespaceT::to_delegate(node));
         io.extend_with(net.to_delegate());
         io.extend_with(config_api.to_delegate());
         io.extend_with(evm.to_delegate());

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ mod cache;
 mod configuration_api;
 mod console_log;
 mod deps;
-mod evm;
 mod eth_test;
+mod evm;
 mod filters;
 mod fork;
 mod formatter;
@@ -53,11 +53,11 @@ use futures::{
 use jsonrpc_core::MetaIoHandler;
 use zksync_basic_types::{L2ChainId, H160, H256};
 
+use crate::eth_test::EthTestNodeNamespaceT;
 use crate::{configuration_api::ConfigurationApiNamespace, node::TEST_NODE_NETWORK_ID};
 use zksync_core::api_server::web3::backend_jsonrpc::namespaces::{
     eth::EthNamespaceT, net::NetNamespaceT, zks::ZksNamespaceT,
 };
-use crate::eth_test::EthTestNodeNamespaceT;
 
 /// List of wallets (address, private key) that we seed with tokens at start.
 pub const RICH_WALLETS: [(&str, &str); 10] = [

--- a/src/node.rs
+++ b/src/node.rs
@@ -66,6 +66,7 @@ use zksync_web3_decl::{
     error::Web3Error,
     types::{FeeHistory, Filter, FilterChanges},
 };
+use crate::eth_test::EthTestNodeNamespaceT;
 
 /// Max possible size of an ABI encoded tx (in bytes).
 pub const MAX_TX_SIZE: usize = 1_000_000;
@@ -412,7 +413,14 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
 
         let storage = storage_view.to_rc_ptr();
 
-        let execution_mode = TxExecutionMode::EstimateFee;
+        let execution_mode = if self
+            .impersonated_accounts
+            .contains(&l2_tx.common_data.initiator_address)
+        {
+            TxExecutionMode::EthCall
+        } else {
+            TxExecutionMode::EstimateFee
+        };
         let mut batch_env = self.create_l1_batch_env(storage.clone());
         batch_env.l1_gas_price = l1_gas_price;
         let system_env = self.create_system_env(
@@ -651,6 +659,15 @@ fn not_implemented<T: Send + 'static>(
 /// All contents are removed when object is destroyed.
 pub struct InMemoryNode<S> {
     inner: Arc<RwLock<InMemoryNodeInner<S>>>,
+}
+
+// Derive doesn't work
+impl<S> Clone for InMemoryNode<S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone()
+        }
+    }
 }
 
 fn contract_address_from_tx_result(execution_result: &VmExecutionResultAndLogs) -> Option<H160> {
@@ -2393,6 +2410,86 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
                 reward,
             })
         })
+    }
+}
+
+impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthTestNodeNamespaceT for InMemoryNode<S> {
+    /// Sends a transaction to the L2 network. Can be used for the impersonated account.
+    ///
+    /// # Arguments
+    ///
+    /// * `tx` - A `CallRequest` struct representing the transaction.
+    ///
+    /// # Returns
+    ///
+    /// A future that resolves to the hash of the transaction if successful, or an error if the transaction is invalid or execution fails.
+    fn send_transaction(
+        &self,
+        tx: zksync_types::transaction_request::CallRequest,
+    ) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<zksync_basic_types::H256>> {
+        let chain_id = match self.inner.read() {
+            Ok(reader) => reader.fork_storage.chain_id,
+            Err(_) => {
+                return futures::future::err(into_jsrpc_error(Web3Error::InternalError)).boxed()
+            }
+        };
+
+        let mut tx_req = TransactionRequest::from(tx);
+        // If the sender is impersonated signature will be ignored.
+        tx_req.r = Some(U256::default());
+        tx_req.s = Some(U256::default());
+        tx_req.v = Some(U64::from(27));
+
+        let hash = match tx_req.get_tx_hash(chain_id) {
+            Ok(result) => result,
+            Err(e) => {
+                return futures::future::err(into_jsrpc_error(Web3Error::SerializationError(e)))
+                    .boxed()
+            }
+        };
+        // v = 27 corresponds to 0
+        let bytes = tx_req.get_signed_bytes(&PackedEthSignature::from_rsv(&H256::default(), &H256::default(), 0), chain_id);
+        let mut l2_tx: L2Tx = match L2Tx::from_request(tx_req, MAX_TX_SIZE) {
+            Ok(tx) => tx,
+            Err(e) => {
+                return futures::future::err(into_jsrpc_error(Web3Error::SerializationError(e)))
+                    .boxed()
+            }
+        };
+
+        l2_tx.set_input(bytes, hash);
+        if hash != l2_tx.hash() {
+            return futures::future::err(into_jsrpc_error(Web3Error::InvalidTransactionData(
+                zksync_types::ethabi::Error::InvalidData,
+            )))
+                .boxed();
+        };
+
+        match self.inner.read() {
+            Ok(reader) => {
+                if !reader.impersonated_accounts.contains(&l2_tx.common_data.initiator_address) {
+                    return futures::future::err(into_jsrpc_error(Web3Error::InvalidTransactionData(
+                        zksync_types::ethabi::Error::InvalidData,
+                    )))
+                        .boxed()
+                }
+            },
+            Err(_) => {
+                return futures::future::err(into_jsrpc_error(Web3Error::InternalError)).boxed()
+            }
+        }
+
+        match self.run_l2_tx(l2_tx.clone()) {
+            Ok(_) => Ok(hash).into_boxed_future(),
+            Err(e) => {
+                let error_message = format!("Execution error: {}", e);
+                futures::future::err(into_jsrpc_error(Web3Error::SubmitTransactionError(
+                    error_message,
+                    l2_tx.hash().as_bytes().to_vec(),
+                )))
+                    .boxed()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# What :computer: 
* Using playground bootloader with eth_call flag for impersonating
* The same logic implemented for the eth_estimateGas
* eth_sendTransaction method implemented

# Why :hand:
* It allows to avoid any account checks, and use any address for the impersonating
* It will return the correct amount of gas, when impersonating is used
* For now, it works only with impersonated accounts, it allows to reuse existent js tools, for example, hardhat signer

# Evidence :camera:
<img width="1007" alt="Screenshot 2023-09-27 at 14 59 27" src="https://github.com/matter-labs/era-test-node/assets/74021421/59ce02a1-b939-407b-9a45-ad23149bfbe8">

<img width="429" alt="Screenshot 2023-09-27 at 14 58 49" src="https://github.com/matter-labs/era-test-node/assets/74021421/abfda890-fa9a-4ce1-9f48-1507bdda9a7a">
