### PR TITLE
feat: adds `eth_accounts` and updates `get_transaction_by_hash` to retrieve from fork if needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,7 +1776,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "era_test_node"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.5"
 dependencies = [
  "anyhow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.5"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -25,7 +25,7 @@ The `status` options are:
 | `DEBUG` | `debug_traceBlockByHash` | `NOT IMPLEMENTED`<br />[GitHub Issue #63](https://github.com/matter-labs/era-test-node/issues/63) | Returns structured traces for operations within the block of the specified block hash |
 | `DEBUG` | `debug_traceBlockByNumber` | `NOT IMPLEMENTED`<br />[GitHub Issue #64](https://github.com/matter-labs/era-test-node/issues/64) | Returns structured traces for operations within the block of the specified block number |
 | `DEBUG` | `debug_traceTransaction` | `NOT IMPLEMENTED`<br />[GitHub Issue #65](https://github.com/matter-labs/era-test-node/issues/65) | Returns a structured trace of the execution of the specified transaction |
-| `ETH` | `eth_accounts` | `NOT IMPLEMENTED`<br />[GitHub Issue #50](https://github.com/matter-labs/era-test-node/issues/50) | Returns a list of addresses owned by client |
+| `ETH` | `eth_accounts` | `SUPPORTED` | Returns a list of addresses owned by client |
 | [`ETH`](#eth-namespace) | [`eth_chainId`](#eth_chainid) | `SUPPORTED` | Returns the currently configured chain id <br />_(default is `260`)_ |
 | `ETH` | `eth_coinbase` | `NOT IMPLEMENTED` | Returns the client coinbase address |
 | [`ETH`](#eth-namespace) | [`eth_estimateGas`](#eth_estimategas) | `SUPPORTED` | Generates and returns an estimate of how much gas is necessary for the transaction to complete |
@@ -363,6 +363,29 @@ curl --request POST \
 ```
 
 ## `ETH NAMESPACE`
+
+### `eth_accounts`
+
+[source](src/node.rs)
+
+Returns the current chain id
+
+#### Arguments
+
++ _NONE_
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{"jsonrpc": "2.0","id": "1","method": "eth_accounts","params": []}'
+```
 
 ### `eth_chainId`
 

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -368,7 +368,7 @@ curl --request POST \
 
 [source](src/node.rs)
 
-Returns the current chain id
+Returns a list of addresses owned by client
 
 #### Arguments
 

--- a/e2e-tests/helpers/constants.ts
+++ b/e2e-tests/helpers/constants.ts
@@ -1,42 +1,42 @@
-export const RichAccounts = {
-  0: {
+export const RichAccounts = [
+  {
     Account: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
     PrivateKey: "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110",
   },
-  1: {
+  {
     Account: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
     PrivateKey: "0xac1e735be8536c6534bb4f17f06f6afc73b2b5ba84ac2cfb12f7461b20c0bbe3",
   },
-  2: {
+  {
     Account: "0x0D43eB5B8a47bA8900d84AA36656c92024e9772e",
     PrivateKey: "0xd293c684d884d56f8d6abd64fc76757d3664904e309a0645baf8522ab6366d9e",
   },
-  3: {
+  {
     Account: "0xA13c10C0D5bd6f79041B9835c63f91de35A15883",
     PrivateKey: "0x850683b40d4a740aa6e745f889a6fdc8327be76e122f5aba645a5b02d0248db8",
   },
-  4: {
+  {
     Account: "0x8002cD98Cfb563492A6fB3E7C8243b7B9Ad4cc92",
     PrivateKey: "0xf12e28c0eb1ef4ff90478f6805b68d63737b7f33abfa091601140805da450d93",
   },
-  5: {
+  {
     Account: "0x4F9133D1d3F50011A6859807C837bdCB31Aaab13",
     PrivateKey: "0xe667e57a9b8aaa6709e51ff7d093f1c5b73b63f9987e4ab4aa9a5c699e024ee8",
   },
-  6: {
+  {
     Account: "0xbd29A1B981925B94eEc5c4F1125AF02a2Ec4d1cA",
     PrivateKey: "0x28a574ab2de8a00364d5dd4b07c4f2f574ef7fcc2a86a197f65abaec836d1959",
   },
-  7: {
+  {
     Account: "0xedB6F5B4aab3dD95C7806Af42881FF12BE7e9daa",
     PrivateKey: "0x74d8b3a188f7260f67698eb44da07397a298df5427df681ef68c45b34b61f998",
   },
-  8: {
+  {
     Account: "0xe706e60ab5Dc512C36A4646D719b889F398cbBcB",
     PrivateKey: "0xbe79721778b48bcc679b78edac0ce48306a8578186ffcb9f2ee455ae6efeace1",
   },
-  9: {
+  {
     Account: "0xE90E12261CCb0F3F7976Ae611A29e84a6A85f424",
     PrivateKey: "0x3eb15da85647edd9a1159a4a13b9e7c56877c4eb33f614546d4db06a51868b1c",
   },
-} as const;
+] as const;

--- a/e2e-tests/test/eth-apis.test.ts
+++ b/e2e-tests/test/eth-apis.test.ts
@@ -1,0 +1,20 @@
+import { expect } from "chai";
+import { getTestProvider } from "../helpers/utils";
+import { RichAccounts } from "../helpers/constants";
+import { ethers } from "ethers";
+
+const provider = getTestProvider();
+
+describe("eth_accounts", function () {
+  it("Should return rich accounts", async function () {
+    // Arrange
+    const richAccounts = RichAccounts.map((ra) => ethers.utils.getAddress(ra.Account)).sort();
+
+    // Act
+    const response: string[] = await provider.send("eth_accounts", []);
+    const accounts = response.map((addr) => ethers.utils.getAddress(addr)).sort();
+
+    // Assert
+    expect(accounts).to.deep.equal(richAccounts);
+  });
+});

--- a/src/node.rs
+++ b/src/node.rs
@@ -2439,7 +2439,7 @@ mod tests {
         cache::CacheConfig,
         http_fork_source::HttpForkSource,
         node::InMemoryNode,
-        testing::{self, ForkBlockConfig, LogBuilder, MockServer, RICH_WALLETS},
+        testing::{self, ForkBlockConfig, LogBuilder, MockServer},
     };
     use zksync_types::api::BlockNumber;
     use zksync_web3_decl::types::{SyncState, ValueOrArray};

--- a/src/node.rs
+++ b/src/node.rs
@@ -2332,14 +2332,14 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
     /// A `BoxFuture` containing a `jsonrpc_core::Result` that resolves to a `Vec<H160>` of addresses.
     fn accounts(&self) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<Vec<H160>>> {
         let inner = Arc::clone(&self.inner);
-        let writer = match inner.write() {
+        let reader = match inner.read() {
             Ok(r) => r,
             Err(_) => {
                 return futures::future::err(into_jsrpc_error(Web3Error::InternalError)).boxed()
             }
         };
 
-        let accounts: Vec<H160> = writer.rich_accounts.clone().into_iter().collect();
+        let accounts: Vec<H160> = reader.rich_accounts.clone().into_iter().collect();
         futures::future::ok(accounts).boxed()
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -2321,8 +2321,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
     }
     /// Returns a list of available accounts.
     ///
-    /// This function fetches the rich accounts from the inner state, clones them,
-    /// and returns them as a list of addresses (`H160`).
+    /// This function fetches the accounts from the inner state, and returns them as a list of addresses (`H160`).
     ///
     /// # Errors
     ///

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -561,3 +561,14 @@ content-type: application/json
     "method": "eth_feeHistory",
     "params": ["0x1", "latest", [25, 50 , 75]]
 }
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "eth_accounts",
+    "params": []
+}


### PR DESCRIPTION
# What :computer: 
* Adds `eth_accounts` endpoint
* Updates `get_transaction_by_hash` to retrieve transaction from fork if unavailable
* Bumps cargo.toml to latest version

# Why :hand:
* Unsupported API was needed to work alongside [Rivet](https://github.com/paradigmxyz/rivet) 
* Previously was not returning tx's when unavailable in local memory 
* Was set to an outdated version 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->
<img width="818" alt="Screenshot 2023-09-27 at 12 09 09 PM" src="https://github.com/matter-labs/era-test-node/assets/29983536/bd667423-ab3d-495e-8546-56acd5c24c93">

---

<img width="1181" alt="Screenshot 2023-09-27 at 12 09 51 PM" src="https://github.com/matter-labs/era-test-node/assets/29983536/cfeb1a50-85c4-4c5b-a0fa-904718338634">

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?
