### PR TITLE
chore: update eth_call to serialize output data in console

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -829,10 +829,12 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
 
         match &tx_result.result {
             ExecutionResult::Success { output } => {
-                log::info!("Call: {} {:?}", "SUCCESS".green(), output)
+                log::info!("Call: {}", "SUCCESS".green());
+                let output_bytes = zksync_basic_types::Bytes::from(output.clone());
+                log::info!("Output: {}", serde_json::to_string(&output_bytes).unwrap());
             }
             ExecutionResult::Revert { output } => {
-                log::info!("Call: {}: {}", "FAILED".red(), output)
+                log::info!("Call: {}: {}", "FAILED".red(), output);
             }
             ExecutionResult::Halt { reason } => log::info!("Call: {} {}", "HALTED".red(), reason),
         };


### PR DESCRIPTION
# What :computer: 
* Update `eth_call` to serialize output data in console

# Why :hand:
* So it's easier to read

# Evidence :camera:
This is purely a cosmetic change in the console logs

BEFORE:
```
19:36:22 [INFO] Call: SUCCESS [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 72, 105, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
19:36:22 [INFO] === Console Logs: 
19:36:22 [INFO] === Call traces:
```

AFTER:
```log
20:03:06 [INFO] Call: SUCCESS
20:03:06 [INFO] Output: "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000024869000000000000000000000000000000000000000000000000000000000000"
20:03:06 [INFO] === Console Logs: 
20:03:06 [INFO] === Call traces:
```
