### PR TITLE
chore: adds proper null response to zks_batchDetails method

### DIFF
--- a/src/zks.rs
+++ b/src/zks.rs
@@ -206,12 +206,26 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> ZksNamespaceT
         not_implemented!()
     }
 
+    /// Retrieves details for a given L1 batch.
+    ///
+    /// This method is intended to handle queries related to L1 batch details. However, as of the current implementation,
+    /// L1 communication is not supported. Instead of an error or no method found, this method intentionally returns
+    /// `{"jsonrpc":"2.0","result":null,"id":1}` to ensure compatibility with block explorer integration.
+    ///
+    /// # Parameters
+    ///
+    /// * `_batch`: The batch number of type `zksync_basic_types::L1BatchNumber` for which the details are to be fetched.
+    ///
+    /// # Returns
+    ///
+    /// A boxed future resolving to a `jsonrpc_core::Result` containing an `Option` of `zksync_types::api::L1BatchDetails`.
+    /// Given the current implementation, this will always be `None`.
     fn get_l1_batch_details(
         &self,
         _batch: zksync_basic_types::L1BatchNumber,
     ) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<Option<zksync_types::api::L1BatchDetails>>>
     {
-        not_implemented!()
+        Box::pin(async { Ok(None) })
     }
 
     fn get_bytecode_by_hash(


### PR DESCRIPTION
# What :computer: 
* Updates `get_l1_batch_details` to return properly formed `null` response

# Why :hand:
* Although L1 communication is currently not supported, for block explorer integration this method is required to respond with a properly formed response. This will now always respond with `{"jsonrpc":"2.0","result":null,"id":1}` for this reason. 
CC: @vasyl-ivanchuk 

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<img width="640" alt="Screenshot 2023-09-29 at 3 14 26 PM" src="https://github.com/matter-labs/era-test-node/assets/29983536/e1cb94f5-636a-431f-864f-d9ed0697c57d">

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?
