### PR TITLE
fix: add back call stacks, console logs, and correct call stack count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2 0.4.9",
- "time 0.3.25",
+ "time",
  "url",
 ]
 
@@ -1033,19 +1033,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "rustc-serialize",
  "serde",
- "time 0.1.43",
  "wasm-bindgen",
- "winapi 0.3.9",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1233,7 +1231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.25",
+ "time",
  "version_check",
 ]
 
@@ -1780,6 +1778,7 @@ version = "0.1.0-alpha.5"
 dependencies = [
  "anyhow",
  "bigdecimal",
+ "chrono",
  "clap 4.3.23",
  "colored",
  "ethabi 16.0.0",
@@ -2394,7 +2393,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.25",
+ "time",
  "tokio",
  "tracing",
  "urlencoding",
@@ -2435,7 +2434,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "thiserror",
- "time 0.3.25",
+ "time",
  "tokio",
  "tracing",
  "url",
@@ -3699,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "multivm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "vlog",
  "vm",
@@ -4573,10 +4572,11 @@ dependencies = [
 [[package]]
 name = "prometheus_exporter"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "anyhow",
  "metrics",
+ "metrics-exporter-prometheus",
  "tokio",
  "vise-exporter",
 ]
@@ -5127,12 +5127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5460,7 +5454,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.25",
+ "time",
  "url",
  "uuid",
 ]
@@ -5677,7 +5671,7 @@ dependencies = [
  "num-bigint 0.4.3",
  "num-traits",
  "thiserror",
- "time 0.3.25",
+ "time",
 ]
 
 [[package]]
@@ -5688,7 +5682,7 @@ checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
 dependencies = [
  "log",
  "termcolor",
- "time 0.3.25",
+ "time",
 ]
 
 [[package]]
@@ -6149,36 +6143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "time"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6501,7 +6465,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.25",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -6687,7 +6651,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vise"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vise.git?rev=856eedd0a36a2ff2c8d965b0f0186d4bb8465d8c#856eedd0a36a2ff2c8d965b0f0186d4bb8465d8c"
+source = "git+https://github.com/matter-labs/vise.git?rev=9d097ab747b037b6e62504df1db5b975425b6bdd#9d097ab747b037b6e62504df1db5b975425b6bdd"
 dependencies = [
  "elsa",
  "linkme",
@@ -6699,7 +6663,7 @@ dependencies = [
 [[package]]
 name = "vise-exporter"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vise.git?rev=856eedd0a36a2ff2c8d965b0f0186d4bb8465d8c#856eedd0a36a2ff2c8d965b0f0186d4bb8465d8c"
+source = "git+https://github.com/matter-labs/vise.git?rev=9d097ab747b037b6e62504df1db5b975425b6bdd#9d097ab747b037b6e62504df1db5b975425b6bdd"
 dependencies = [
  "hyper",
  "metrics-exporter-prometheus",
@@ -6712,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "vise-macros"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vise.git?rev=856eedd0a36a2ff2c8d965b0f0186d4bb8465d8c#856eedd0a36a2ff2c8d965b0f0186d4bb8465d8c"
+source = "git+https://github.com/matter-labs/vise.git?rev=9d097ab747b037b6e62504df1db5b975425b6bdd#9d097ab747b037b6e62504df1db5b975425b6bdd"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
@@ -6722,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "vlog"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "chrono",
  "sentry",
@@ -6734,15 +6698,15 @@ dependencies = [
 [[package]]
 name = "vm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "anyhow",
  "hex",
  "itertools",
- "metrics",
  "once_cell",
  "thiserror",
  "tracing",
+ "vise",
  "zk_evm 1.3.3",
  "zksync_config",
  "zksync_contracts",
@@ -6754,13 +6718,12 @@ dependencies = [
 [[package]]
 name = "vm_1_3_2"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
  "hex",
  "itertools",
- "metrics",
  "once_cell",
  "thiserror",
  "tracing",
@@ -6776,11 +6739,10 @@ dependencies = [
 [[package]]
 name = "vm_m5"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "hex",
  "itertools",
- "metrics",
  "once_cell",
  "thiserror",
  "tracing",
@@ -6798,11 +6760,10 @@ dependencies = [
 [[package]]
 name = "vm_m6"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "hex",
  "itertools",
- "metrics",
  "once_cell",
  "thiserror",
  "tracing",
@@ -7304,7 +7265,7 @@ dependencies = [
 [[package]]
 name = "zksync_basic_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "serde",
  "web3",
@@ -7313,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "zksync_circuit_breaker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7321,9 +7282,11 @@ dependencies = [
  "convert_case 0.6.0",
  "futures 0.3.28",
  "hex",
+ "metrics",
  "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
  "zksync_config",
  "zksync_contracts",
  "zksync_dal",
@@ -7334,8 +7297,9 @@ dependencies = [
 [[package]]
 name = "zksync_config"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
+ "anyhow",
  "bigdecimal",
  "envy",
  "hex",
@@ -7352,7 +7316,7 @@ dependencies = [
 [[package]]
 name = "zksync_contracts"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "envy",
  "ethabi 18.0.0",
@@ -7366,7 +7330,7 @@ dependencies = [
 [[package]]
 name = "zksync_core"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "actix-cors",
  "actix-rt",
@@ -7377,7 +7341,6 @@ dependencies = [
  "bigdecimal",
  "bitflags 1.3.2",
  "chrono",
- "clap 4.3.23",
  "ctrlc",
  "futures 0.3.28",
  "governor",
@@ -7399,7 +7362,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tikv-jemallocator",
  "tokio",
  "tower",
  "tower-http",
@@ -7430,7 +7392,7 @@ dependencies = [
 [[package]]
 name = "zksync_crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "base64 0.13.1",
  "blake2 0.10.6",
@@ -7445,14 +7407,13 @@ dependencies = [
 [[package]]
 name = "zksync_dal"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "anyhow",
  "bigdecimal",
  "bincode",
  "hex",
  "itertools",
- "metrics",
  "num 0.3.1",
  "once_cell",
  "serde",
@@ -7462,6 +7423,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "vise",
  "zksync_config",
  "zksync_contracts",
  "zksync_health_check",
@@ -7472,17 +7434,17 @@ dependencies = [
 [[package]]
 name = "zksync_eth_client"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "anyhow",
  "async-trait",
  "hex",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "metrics",
  "serde",
  "thiserror",
  "tokio",
  "tracing",
+ "vise",
  "zksync_config",
  "zksync_contracts",
  "zksync_eth_signer",
@@ -7492,7 +7454,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_signer"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "async-trait",
  "hex",
@@ -7511,7 +7473,7 @@ dependencies = [
 [[package]]
 name = "zksync_health_check"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -7524,9 +7486,8 @@ dependencies = [
 [[package]]
 name = "zksync_mempool"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
- "metrics",
  "tracing",
  "zksync_types",
 ]
@@ -7534,7 +7495,7 @@ dependencies = [
 [[package]]
 name = "zksync_merkle_tree"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "leb128",
  "once_cell",
@@ -7550,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "zksync_mini_merkle_tree"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -7560,16 +7521,17 @@ dependencies = [
 [[package]]
 name = "zksync_object_store"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bincode",
  "google-cloud-auth",
  "google-cloud-storage",
  "http",
- "metrics",
  "tokio",
  "tracing",
+ "vise",
  "zksync_config",
  "zksync_types",
 ]
@@ -7577,13 +7539,12 @@ dependencies = [
 [[package]]
 name = "zksync_prover_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "anyhow",
  "async-trait",
  "ctrlc",
  "futures 0.3.28",
- "metrics",
  "regex",
  "reqwest",
  "tokio",
@@ -7598,7 +7559,7 @@ dependencies = [
 [[package]]
 name = "zksync_queued_job_processor"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7610,13 +7571,13 @@ dependencies = [
 [[package]]
 name = "zksync_state"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "anyhow",
- "metrics",
  "mini-moka",
  "tokio",
  "tracing",
+ "vise",
  "zksync_dal",
  "zksync_storage",
  "zksync_types",
@@ -7626,24 +7587,24 @@ dependencies = [
 [[package]]
 name = "zksync_storage"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
- "metrics",
  "num_cpus",
+ "once_cell",
  "rocksdb",
  "tracing",
+ "vise",
 ]
 
 [[package]]
 name = "zksync_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "blake2 0.10.6",
  "chrono",
  "codegen 0.1.0",
  "ethereum-types 0.12.1",
- "metrics",
  "num 0.3.1",
  "num_enum",
  "once_cell",
@@ -7666,11 +7627,10 @@ dependencies = [
 [[package]]
 name = "zksync_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "anyhow",
  "bigdecimal",
- "envy",
  "futures 0.3.28",
  "hex",
  "itertools",
@@ -7689,8 +7649,9 @@ dependencies = [
 [[package]]
 name = "zksync_verification_key_generator_and_server"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
+ "anyhow",
  "bincode",
  "circuit_testing",
  "ff_ce",
@@ -7708,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "zksync_web3_decl"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?tag=v7.0.0-rc0#a43bc402a204ac92fb74ad348b68f61e24d7a84a"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=8df11278ca76000d842fc0f73f5233dfc85ef77e#8df11278ca76000d842fc0f73f5233dfc85ef77e"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,15 @@ categories = ["cryptography"]
 publish = false # We don't want to publish our binaries.
 
 [dependencies]
-zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v7.0.0-rc0" }
-zksync_core = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v7.0.0-rc0" }
-vm = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v7.0.0-rc0" }
-vlog = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v7.0.0-rc0" }
-zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v7.0.0-rc0" }
-zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v7.0.0-rc0" }
-zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v7.0.0-rc0" }
-zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v7.0.0-rc0" }
-zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", tag = "v7.0.0-rc0" }
+zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "8df11278ca76000d842fc0f73f5233dfc85ef77e" }
+zksync_core = { git = "https://github.com/matter-labs/zksync-era.git", rev = "8df11278ca76000d842fc0f73f5233dfc85ef77e" }
+vm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "8df11278ca76000d842fc0f73f5233dfc85ef77e" }
+vlog = { git = "https://github.com/matter-labs/zksync-era.git", rev = "8df11278ca76000d842fc0f73f5233dfc85ef77e" }
+zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", rev = "8df11278ca76000d842fc0f73f5233dfc85ef77e" }
+zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "8df11278ca76000d842fc0f73f5233dfc85ef77e" }
+zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "8df11278ca76000d842fc0f73f5233dfc85ef77e" }
+zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", rev = "8df11278ca76000d842fc0f73f5233dfc85ef77e" }
+zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "8df11278ca76000d842fc0f73f5233dfc85ef77e" }
 
 
 
@@ -51,6 +51,7 @@ itertools = "0.10.5"
 log = "0.4.20"
 simplelog = "0.12.1"
 rustc-hash = "1.1.0"
+chrono = "0.4.31"
 
 [dev-dependencies]
 httptest = "0.15.4"

--- a/src/console_log.rs
+++ b/src/console_log.rs
@@ -44,10 +44,10 @@ impl Default for ConsoleLogHandler {
 }
 
 impl ConsoleLogHandler {
-    pub fn handle_call_recurive(&self, current_call: &Call) {
+    pub fn handle_call_recursive(&self, current_call: &Call) {
         self.handle_call(current_call);
         for call in &current_call.calls {
-            self.handle_call_recurive(call);
+            self.handle_call_recursive(call);
         }
     }
     pub fn handle_call(&self, current_call: &Call) {

--- a/src/node.rs
+++ b/src/node.rs
@@ -38,7 +38,7 @@ use vm::{
 };
 use zksync_basic_types::{
     web3::{self, signing::keccak256},
-    AccountTreeId, Address, Bytes, L1BatchNumber, H160, H256, U256, U64, MiniblockNumber,
+    AccountTreeId, Address, Bytes, L1BatchNumber, MiniblockNumber, H160, H256, U256, U64,
 };
 use zksync_contracts::BaseSystemContracts;
 use zksync_core::api_server::web3::backend_jsonrpc::{
@@ -47,6 +47,7 @@ use zksync_core::api_server::web3::backend_jsonrpc::{
 use zksync_state::{ReadStorage, StoragePtr, StorageView, WriteStorage};
 use zksync_types::{
     api::{Block, Log, TransactionReceipt, TransactionVariant},
+    block::legacy_miniblock_hash,
     fee::Fee,
     get_code_key, get_nonce_key,
     l2::L2Tx,
@@ -56,7 +57,7 @@ use zksync_types::{
         storage_key_for_standard_token_balance,
     },
     PackedEthSignature, StorageKey, StorageLogQueryType, Transaction, ACCOUNT_CODE_STORAGE_ADDRESS,
-    EIP_712_TX_TYPE, L2_ETH_TOKEN_ADDRESS, MAX_GAS_PER_PUBDATA_BYTE, MAX_L2_TX_GAS_LIMIT, block::legacy_miniblock_hash,
+    EIP_712_TX_TYPE, L2_ETH_TOKEN_ADDRESS, MAX_GAS_PER_PUBDATA_BYTE, MAX_L2_TX_GAS_LIMIT,
 };
 use zksync_utils::{
     bytecode::{compress_bytecode, hash_bytecode},
@@ -1175,7 +1176,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
             inner.console_log_handler.handle_call_recursive(call);
         }
         log::info!("");
-        let call_traces_count = if call_traces.len() > 0 {
+        let call_traces_count = if !call_traces.is_empty() {
             // All calls/sub-calls are stored within the first call trace
             call_traces[0].calls.len()
         } else {

--- a/src/node.rs
+++ b/src/node.rs
@@ -290,6 +290,8 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
         let last_l2_block_hash = if let Some(last_l2_block) = load_last_l2_block(storage.clone()) {
             last_l2_block.hash
         } else {
+            // This is the scenario of either the first L2 block ever or
+            // the first block after the upgrade for support of L2 blocks.
             legacy_miniblock_hash(MiniblockNumber(self.current_miniblock as u32))
         };
         let block_ctx = BlockContext::from_current(
@@ -865,7 +867,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
 
         log::info!("=== Console Logs: ");
         for call in &call_traces {
-            inner.console_log_handler.handle_call_recurive(call);
+            inner.console_log_handler.handle_call_recursive(call);
         }
 
         log::info!("=== Call traces:");
@@ -1170,10 +1172,11 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
         log::info!("");
         log::info!("==== Console logs: ");
         for call in call_traces {
-            inner.console_log_handler.handle_call_recurive(call);
+            inner.console_log_handler.handle_call_recursive(call);
         }
         log::info!("");
         let call_traces_count = if call_traces.len() > 0 {
+            // All calls/sub-calls are stored within the first call trace
             call_traces[0].calls.len()
         } else {
             0

--- a/src/node.rs
+++ b/src/node.rs
@@ -38,7 +38,7 @@ use vm::{
 };
 use zksync_basic_types::{
     web3::{self, signing::keccak256},
-    AccountTreeId, Address, Bytes, L1BatchNumber, H160, H256, U256, U64,
+    AccountTreeId, Address, Bytes, L1BatchNumber, H160, H256, U256, U64, MiniblockNumber,
 };
 use zksync_contracts::BaseSystemContracts;
 use zksync_core::api_server::web3::backend_jsonrpc::{
@@ -56,7 +56,7 @@ use zksync_types::{
         storage_key_for_standard_token_balance,
     },
     PackedEthSignature, StorageKey, StorageLogQueryType, Transaction, ACCOUNT_CODE_STORAGE_ADDRESS,
-    EIP_712_TX_TYPE, L2_ETH_TOKEN_ADDRESS, MAX_GAS_PER_PUBDATA_BYTE, MAX_L2_TX_GAS_LIMIT,
+    EIP_712_TX_TYPE, L2_ETH_TOKEN_ADDRESS, MAX_GAS_PER_PUBDATA_BYTE, MAX_L2_TX_GAS_LIMIT, block::legacy_miniblock_hash,
 };
 use zksync_utils::{
     bytecode::{compress_bytecode, hash_bytecode},
@@ -287,7 +287,11 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
         &self,
         storage: StoragePtr<ST>,
     ) -> (L1BatchEnv, BlockContext) {
-        let last_l2_block = load_last_l2_block(storage);
+        let last_l2_block_hash = if let Some(last_l2_block) = load_last_l2_block(storage.clone()) {
+            last_l2_block.hash
+        } else {
+            legacy_miniblock_hash(MiniblockNumber(self.current_miniblock as u32))
+        };
         let block_ctx = BlockContext::from_current(
             self.current_batch,
             self.current_miniblock,
@@ -308,7 +312,7 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
                 // So the next one should be one higher.
                 number: block_ctx.miniblock as u32,
                 timestamp: block_ctx.timestamp,
-                prev_block_hash: last_l2_block.hash,
+                prev_block_hash: last_l2_block_hash,
                 // This is only used during zksyncEra block timestamp/number transition.
                 // In case of starting a new network, it doesn't matter.
                 // In theory , when forking mainnet, we should match this value
@@ -1089,10 +1093,7 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
 
         let tx_result = vm.inspect(custom_tracers, vm::VmExecutionMode::OneTx);
 
-        let call_traces = Arc::try_unwrap(call_tracer_result)
-            .unwrap()
-            .take()
-            .unwrap_or_default();
+        let call_traces = call_tracer_result.get().unwrap();
 
         let spent_on_pubdata =
             tx_result.statistics.gas_used - tx_result.statistics.computational_gas_used;
@@ -1168,17 +1169,22 @@ impl<S: ForkSource + std::fmt::Debug> InMemoryNode<S> {
 
         log::info!("");
         log::info!("==== Console logs: ");
-        for call in &call_traces {
+        for call in call_traces {
             inner.console_log_handler.handle_call_recurive(call);
         }
         log::info!("");
+        let call_traces_count = if call_traces.len() > 0 {
+            call_traces[0].calls.len()
+        } else {
+            0
+        };
         log::info!(
             "==== {} Use --show-calls flag or call config_setShowCalls to display more info.",
-            format!("{:?} call traces. ", call_traces.len()).bold()
+            format!("{:?} call traces. ", call_traces_count).bold()
         );
 
         if inner.show_calls != ShowCalls::None {
-            for call in &call_traces {
+            for call in call_traces {
                 formatter::print_call(call, 0, &inner.show_calls, inner.resolve_hashes);
             }
         }


### PR DESCRIPTION
# What :computer: 
* Update version of `zksync-era` to include the call stack fix
* Add dependency on `chrono`
* Provide default block hash during L1 batch creation
* Determine call stack count using first call from trace

# Why :hand:
* This fixes the console logs and adds back the call stack
* `zksync_dal` updated their use of some DateTime functions to pull from the `sqlx` version of `chrono`
* An upstream change updated the logic for `load_last_l2_block`
* Call stacks now have a single root, so using `.len()` will always return 1 if there are any call traces. 

# Evidence :camera:
`make test-e2e`:
![image](https://github.com/matter-labs/era-test-node/assets/1890113/cf3a148e-182d-4e29-83f9-460e367751c4)

Same e2e tests but with `--show-calls`:
<img width="666" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/bfaafdc8-3ce2-46c6-a4d6-e26d04fcaffc">

