### PR TITLE
feat: add eth_protocolVersion

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -62,7 +62,7 @@ The `status` options are:
 | [`ETH`](#eth-namespace) | [`eth_newBlockFilter`](#`eth_newblockfilter) | `SUPPORTED` | Creates a filter in the node, to notify when a new block arrives |
 | [`ETH`](#eth-namespace) | [`eth_newFilter`](#`eth_newfilter) | `SUPPORTED` | Creates a filter object, based on filter options, to notify when the state changes (logs) |
 | [`ETH`](#eth-namespace) | [`eth_newPendingTransactionFilter`](#`eth_newpendingtransactionfilter) | `SUPPORTED` | Creates a filter in the node, to notify when new pending transactions arrive |
-| `ETH` | `eth_protocolVersion` | `NOT IMPLEMENTED`<br />[GitHub Issue #48](https://github.com/matter-labs/era-test-node/issues/48) | Returns the current ethereum protocol version |
+| [`ETH`](#eth-namespace)` | [`eth_protocolVersion`](#eth_protocolversion) | `SUPPORTED` | Returns the current ethereum protocol version |
 | `ETH` | `eth_sendTransaction` | `NOT IMPLEMENTED` | Creates new message call transaction or a contract creation, if the data field contains code |
 | `ETH` | `eth_sign` | `NOT IMPLEMENTED` | The sign method calculates an Ethereum specific signature with: `sign(keccak256("\x19Ethereum Signed Message:\n" + message.length + message)))` |
 | `ETH` | `eth_signTransaction` | `NOT IMPLEMENTED` | Signs a transaction that can be submitted to the network at a later time using `eth_sendRawTransaction` |
@@ -1098,6 +1098,33 @@ curl --request POST \
     "id": "1",
     "method": "eth_getStorageAt",
     "params": ["0x123456789abcdef123456789abcdef1234567890", "0x0", "latest"]
+}'
+```
+
+### `eth_protocolVersion`
+
+[source](src/node.rs)
+
+Returns the current ethereum protocol version.
+
+#### Arguments
+
++ _NONE_
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "eth_protocolVersion"
 }'
 ```
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -91,8 +91,8 @@ pub const ESTIMATE_GAS_ACCEPTABLE_OVERESTIMATION: u32 = 1_000;
 pub const ESTIMATE_GAS_SCALE_FACTOR: f32 = 1.3;
 /// The maximum number of previous blocks to store the state for.
 pub const MAX_PREVIOUS_STATES: u16 = 128;
-/// The currently supported ethereum protocol version - https://github.com/ethereum/devp2p/blob/master/caps/eth.md#eth63-2016
-pub const SUPPORTED_ETH_PROTOCOL_VERSION: u16 = 63;
+/// The zks protocol version.
+pub const PROTOCOL_VERSION: &str = "zks/1";
 
 pub fn compute_hash(block_number: u64, tx_hash: H256) -> H256 {
     let digest = [&block_number.to_be_bytes()[..], tx_hash.as_bytes()].concat();
@@ -2626,7 +2626,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
     ///
     /// A `BoxFuture` containing a `jsonrpc_core::Result` that resolves to a hex `String` of the version number.
     fn protocol_version(&self) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<String>> {
-        Ok(format!("{:#x}", SUPPORTED_ETH_PROTOCOL_VERSION)).into_boxed_future()
+        Ok(String::from(PROTOCOL_VERSION)).into_boxed_future()
     }
 
     fn syncing(
@@ -4245,7 +4245,7 @@ mod tests {
     async fn test_protocol_version_returns_currently_supported_version() {
         let node = InMemoryNode::<HttpForkSource>::default();
 
-        let expected_version = format!("{:#x}", SUPPORTED_ETH_PROTOCOL_VERSION);
+        let expected_version = String::from(PROTOCOL_VERSION);
         let actual_version = node
             .protocol_version()
             .await

--- a/src/node.rs
+++ b/src/node.rs
@@ -2736,8 +2736,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
         })
     }
 
-    /// Returns the current ethereum protocol version.
-    /// See https://github.com/ethereum/devp2p/blob/master/caps/eth.md#change-log for a list of versions
+    /// Returns the protocol version.
     ///
     /// # Returns
     ///

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -512,6 +512,17 @@ content-type: application/json
 {
     "jsonrpc": "2.0",
     "id": "2",
+    "method": "eth_protocolVersion"
+}
+
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "2",
     "method": "hardhat_setBalance",
     "params": [
         "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",


### PR DESCRIPTION
# What :computer: 
* adds `eth_protocolVersion` with the current [version](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#eth63-2016) being `63` (same as ganache)

# Why :hand:
* Feature parity for the `eth_` namespace.

# Evidence :camera:
![image](https://github.com/matter-labs/era-test-node/assets/1564843/8190581d-ed9e-497a-888e-38beb6c69d37)

# Notes :memo:
* Fixes #48 
