### PR TITLE
fix: add aarch64-unknown-linux-gnu target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,11 @@ jobs:
     name: build release
     strategy:
       matrix:
-        # TODO: fix and add aarch64-unknown-linux-gnu target
-        # See: https://github.com/matter-labs/era-test-node/issues/56
-        arch: [x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
+        arch: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
         include:
           -   arch: x86_64-unknown-linux-gnu
+              platform: ubuntu-20.04
+          -   arch: aarch64-unknown-linux-gnu
               platform: ubuntu-20.04
           -   arch: x86_64-apple-darwin
               platform: macos-latest


### PR DESCRIPTION
# What :computer: 
* adds aarch64-unknown-linux-gnu target

# Why :hand:
* Allows building for aarch64 platform

# Evidence :camera:
https://github.com/Moonsong-Labs/era-test-node/actions/runs/6248332681/job/16962735340
![image](https://github.com/matter-labs/era-test-node/assets/1564843/70df04dd-2972-49c2-93d1-293515b2cbdd)

# Notes :memo:
* Fixes #56 
