### PR TITLE
impl debug_traceTransaction

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -24,7 +24,7 @@ The `status` options are:
 | [`DEBUG`](#debug-namespace) | [`debug_traceCall`](#debug_tracecall) | `SUPPORTED` | Performs a call and returns structured traces of the execution |
 | `DEBUG` | `debug_traceBlockByHash` | `NOT IMPLEMENTED`<br />[GitHub Issue #63](https://github.com/matter-labs/era-test-node/issues/63) | Returns structured traces for operations within the block of the specified block hash |
 | `DEBUG` | `debug_traceBlockByNumber` | `NOT IMPLEMENTED`<br />[GitHub Issue #64](https://github.com/matter-labs/era-test-node/issues/64) | Returns structured traces for operations within the block of the specified block number |
-| `DEBUG` | `debug_traceTransaction` | `NOT IMPLEMENTED`<br />[GitHub Issue #65](https://github.com/matter-labs/era-test-node/issues/65) | Returns a structured trace of the execution of the specified transaction |
+| [`DEBUG`](#debug-namespace) | [`debug_traceTransaction`](#debug_tracetransaction) | `SUPPORTED` | Returns a structured trace of the execution of the specified transaction |
 | `ETH` | `eth_accounts` | `SUPPORTED` | Returns a list of addresses owned by client |
 | [`ETH`](#eth-namespace) | [`eth_chainId`](#eth_chainid) | `SUPPORTED` | Returns the currently configured chain id <br />_(default is `260`)_ |
 | `ETH` | `eth_coinbase` | `NOT IMPLEMENTED` | Returns the client coinbase address |
@@ -334,6 +334,43 @@ curl --request POST \
           "value": "0x0000",
           "nonce": "0x0000"
       }, "latest"]
+  }'
+```
+
+### `debug_traceTransaction`
+
+[source](src/debug.rs)
+
+Returns call traces for the transaction with given hash.
+
+Currently only transactions executed on the dev node itself (ie, not from upstream when using fork mode) can be traced.
+
+The third argument mirrors the [`TraceConfig` of go-ethereum](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#traceconfig), but with the restriction that the only supported tracer is `CallTracer`. Memory, Stack and Storage traces are not supported.
+
+#### Arguments
+
+- `tx_hash: H256`
+
+- `options: TracerConfig` (optional)
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+      "id": "2",
+      "method": "debug_traceTransaction",
+      "params": [
+        "0xd3a94ff697a573cb174ecce05126e952ecea6dee051526a3e389747ff86b0d99",
+        { "tracer": "callTracer", "tracerConfig": { "onlyTopCall": true } }
+      ]
   }'
 ```
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -332,7 +332,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_trace_transactiom() {
+    async fn test_trace_transaction() {
         let node = InMemoryNode::<HttpForkSource>::default();
         let inner = node.get_inner();
         {
@@ -360,7 +360,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_trace_transactiom_only_top() {
+    async fn test_trace_transaction_only_top() {
         let node = InMemoryNode::<HttpForkSource>::default();
         let inner = node.get_inner();
         {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,25 +1,22 @@
 use crate::{
     fork::ForkSource,
     node::{InMemoryNodeInner, MAX_TX_SIZE},
-    utils::not_implemented,
+    utils::{create_debug_output, not_implemented},
 };
 use jsonrpc_core::{BoxFuture, Result};
 use once_cell::sync::OnceCell;
 use std::sync::{Arc, RwLock};
-use vm::{
-    constants::ETH_CALL_GAS_LIMIT, CallTracer, ExecutionResult, HistoryDisabled, TxExecutionMode,
-    Vm,
-};
+use vm::{constants::ETH_CALL_GAS_LIMIT, CallTracer, HistoryDisabled, TxExecutionMode, Vm};
 use zksync_basic_types::H256;
 use zksync_core::api_server::web3::backend_jsonrpc::{
     error::into_jsrpc_error, namespaces::debug::DebugNamespaceT,
 };
 use zksync_state::StorageView;
 use zksync_types::{
-    api::{BlockId, BlockNumber, DebugCall, DebugCallType, ResultDebugCall, TracerConfig},
+    api::{BlockId, BlockNumber, DebugCall, ResultDebugCall, TracerConfig},
     l2::L2Tx,
     transaction_request::CallRequest,
-    PackedEthSignature, Transaction, CONTRACT_DEPLOYER_ADDRESS,
+    PackedEthSignature, Transaction,
 };
 use zksync_web3_decl::error::Web3Error;
 
@@ -122,57 +119,34 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> DebugNamespaceT
                     .unwrap_or_default()
             };
 
-            let calltype = if l2_tx.recipient_account() == CONTRACT_DEPLOYER_ADDRESS {
-                DebugCallType::Create
-            } else {
-                DebugCallType::Call
-            };
+            let debug =
+                create_debug_output(&l2_tx, &tx_result, call_traces).map_err(into_jsrpc_error)?;
 
-            let result = match &tx_result.result {
-                ExecutionResult::Success { output } => DebugCall {
-                    gas_used: tx_result.statistics.gas_used.into(),
-                    output: output.clone().into(),
-                    r#type: calltype,
-                    from: l2_tx.initiator_account(),
-                    to: l2_tx.recipient_account(),
-                    gas: l2_tx.common_data.fee.gas_limit,
-                    value: l2_tx.execute.value,
-                    input: l2_tx.execute.calldata().into(),
-                    error: None,
-                    revert_reason: None,
-                    calls: call_traces.into_iter().map(Into::into).collect(),
-                },
-                ExecutionResult::Revert { output } => DebugCall {
-                    gas_used: tx_result.statistics.gas_used.into(),
-                    output: Default::default(),
-                    r#type: calltype,
-                    from: l2_tx.initiator_account(),
-                    to: l2_tx.recipient_account(),
-                    gas: l2_tx.common_data.fee.gas_limit,
-                    value: l2_tx.execute.value,
-                    input: l2_tx.execute.calldata().into(),
-                    error: None,
-                    revert_reason: Some(output.to_string()),
-                    calls: call_traces.into_iter().map(Into::into).collect(),
-                },
-                ExecutionResult::Halt { reason } => {
-                    return Err(into_jsrpc_error(Web3Error::SubmitTransactionError(
-                        reason.to_string(),
-                        vec![],
-                    )))
-                }
-            };
-
-            Ok(result)
+            Ok(debug)
         })
     }
 
     fn trace_transaction(
         &self,
-        _tx_hash: H256,
-        _options: Option<TracerConfig>,
+        tx_hash: H256,
+        options: Option<TracerConfig>,
     ) -> BoxFuture<Result<Option<DebugCall>>> {
-        not_implemented("debug_traceTransaction")
+        let only_top = options.is_some_and(|o| o.tracer_config.only_top_call);
+        let inner = Arc::clone(&self.node);
+        Box::pin(async move {
+            let inner = inner
+                .read()
+                .map_err(|_| into_jsrpc_error(Web3Error::InternalError))?;
+
+            let tx = inner.tx_results.get(&tx_hash).ok_or_else(|| {
+                into_jsrpc_error(Web3Error::SubmitTransactionError(
+                    "Transaction not found".to_string(),
+                    vec![],
+                ))
+            })?;
+
+            Ok(Some(tx.debug_info(only_top)))
+        })
     }
 }
 
@@ -180,13 +154,15 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> DebugNamespaceT
 mod tests {
     use super::*;
     use crate::{
-        deps::system_contracts::bytecode_from_slice, http_fork_source::HttpForkSource,
-        node::InMemoryNode, testing,
+        deps::system_contracts::bytecode_from_slice,
+        http_fork_source::HttpForkSource,
+        node::{InMemoryNode, TransactionResult},
+        testing::{self, LogBuilder},
     };
     use ethers::abi::{short_signature, AbiEncode, HumanReadableParser, ParamType, Token};
-    use zksync_basic_types::{Address, Nonce, U256};
+    use zksync_basic_types::{Address, Nonce, H160, U256};
     use zksync_types::{
-        api::{CallTracerConfig, SupportedTracers},
+        api::{CallTracerConfig, SupportedTracers, TransactionReceipt},
         transaction_request::CallRequestBuilder,
         utils::deployed_address_create,
     };
@@ -353,5 +329,69 @@ mod tests {
 
         // the contract subcall should have reverted
         assert!(contract_call.revert_reason.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_trace_transactiom() {
+        let node = InMemoryNode::<HttpForkSource>::default();
+        let inner = node.get_inner();
+        {
+            let mut writer = inner.write().unwrap();
+            writer.tx_results.insert(
+                H256::repeat_byte(0x1),
+                TransactionResult {
+                    info: testing::default_tx_execution_info(),
+                    receipt: TransactionReceipt {
+                        logs: vec![LogBuilder::new()
+                            .set_address(H160::repeat_byte(0xa1))
+                            .build()],
+                        ..Default::default()
+                    },
+                    debug: testing::default_tx_debug_info(),
+                },
+            );
+        }
+        let result = DebugNamespaceImpl::new(inner)
+            .trace_transaction(H256::repeat_byte(0x1), None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.calls.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_trace_transactiom_only_top() {
+        let node = InMemoryNode::<HttpForkSource>::default();
+        let inner = node.get_inner();
+        {
+            let mut writer = inner.write().unwrap();
+            writer.tx_results.insert(
+                H256::repeat_byte(0x1),
+                TransactionResult {
+                    info: testing::default_tx_execution_info(),
+                    receipt: TransactionReceipt {
+                        logs: vec![LogBuilder::new()
+                            .set_address(H160::repeat_byte(0xa1))
+                            .build()],
+                        ..Default::default()
+                    },
+                    debug: testing::default_tx_debug_info(),
+                },
+            );
+        }
+        let result = DebugNamespaceImpl::new(inner)
+            .trace_transaction(
+                H256::repeat_byte(0x1),
+                Some(TracerConfig {
+                    tracer: SupportedTracers::CallTracer,
+                    tracer_config: CallTracerConfig {
+                        only_top_call: true,
+                    },
+                }),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(result.calls.is_empty());
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -18,7 +18,7 @@ use itertools::Itertools;
 use std::str::FromStr;
 use vm::VmExecutionResultAndLogs;
 use zksync_basic_types::{H160, U64};
-use zksync_types::api::Log;
+use zksync_types::api::{DebugCall, DebugCallType, Log};
 use zksync_types::{
     fee::Fee, l2::L2Tx, Address, L2ChainId, Nonce, PackedEthSignature, ProtocolVersionId, H256,
     U256,
@@ -567,6 +567,35 @@ pub fn default_tx_execution_info() -> TxExecutionInfo {
             statistics: Default::default(),
             refunds: Default::default(),
         },
+    }
+}
+
+/// Returns a default instance for a successful [DebugCall]
+pub fn default_tx_debug_info() -> DebugCall {
+    DebugCall {
+        r#type: DebugCallType::Call,
+        from: Address::zero(),
+        to: Address::zero(),
+        gas: U256::zero(),
+        gas_used: U256::zero(),
+        value: U256::zero(),
+        output: Default::default(),
+        input: Default::default(),
+        error: None,
+        revert_reason: None,
+        calls: vec![DebugCall {
+            r#type: DebugCallType::Call,
+            from: Address::zero(),
+            to: Address::zero(),
+            gas: U256::zero(),
+            gas_used: U256::zero(),
+            value: U256::zero(),
+            output: Default::default(),
+            input: Default::default(),
+            error: None,
+            revert_reason: None,
+            calls: vec![],
+        }],
     }
 }
 

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -156,6 +156,17 @@ content-type: application/json
 {
     "jsonrpc": "2.0",
     "id": "1",
+    "method": "debug_traceTransaction",
+    "params": ["0xd3a94ff697a573cb174ecce05126e952ecea6dee051526a3e389747ff86b0d99", { "tracer": "callTracer", "tracerConfig": { "onlyTopCall": true } }]
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "1",
     "method": "eth_chainId",
     "params": []
 }


### PR DESCRIPTION
# What :computer: 
* Store `DebugCall` output alongside execution result in `tx_results` hashmap
* Adds handler for `debug_traceTransaction` which returns this data

# Why :hand:
* Users can view traces for previously-executed transactions

# Evidence :camera:
![image](https://github.com/matter-labs/era-test-node/assets/140627974/3cc73c4d-5d32-4d2b-95ba-cf9ba187e9d4)
![image](https://github.com/matter-labs/era-test-node/assets/140627974/ebfad7be-900c-4db1-acd3-cf16d0d2cf2d)
