### PR TITLE
fix: install mdbook for ci

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Pages
         uses: actions/configure-pages@v3
+      - name: Install mdbook
+        run: cargo install mdbook
       - name: Generate rust docs
         run: |
           echo "Generating docs..."


### PR DESCRIPTION
# What :computer: 
* installs `mdbook` for ci, so the rustbook can be generated

# Why :hand:
* This is currently not working on `main`

# Evidence :camera:
https://github.com/matter-labs/era-test-node/actions/runs/6481038664/job/17597775592
