### PR TITLE
feat: add hardhat_setCode

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Pages
         uses: actions/configure-pages@v3
+      - name: Install mdbook
+        run: cargo install mdbook
       - name: Generate rust docs
         run: |
           echo "Generating docs..."

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -97,7 +97,7 @@ The `status` options are:
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_mine`](#hardhat_mine) | Mine any number of blocks at once, in constant time |
 | `HARDHAT` | `hardhat_reset` | `NOT IMPLEMENTED` | Resets the state of the network |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setBalance`](#hardhat_setbalance) | `SUPPORTED` | Modifies the balance of an account |
-| `HARDHAT` | `hardhat_setCode` | `NOT IMPLEMENTED` | Sets the bytecode of a given account |
+| [`HARDHAT`](#hardhat-namespace) | [`hardhat_setCode`](#hardhat_setcode) | `SUPPORTED` | Sets the bytecode of a given account |
 | `HARDHAT` | `hardhat_setCoinbase` | `NOT IMPLEMENTED` | Sets the coinbase address |
 | `HARDHAT` | `hardhat_setLoggingEnabled` | `NOT IMPLEMENTED` | Enables or disables logging in Hardhat Network |
 | `HARDHAT` | `hardhat_setMinGasPrice` | `NOT IMPLEMENTED` | Sets the minimum gas price |
@@ -1376,6 +1376,38 @@ curl --request POST \
         "0x364d6D0333432C3Ac016Ca832fb8594A8cE43Ca6"
     ]
 }'
+```
+
+### `hardhat_setCode`
+
+[source](src/hardhat.rs)
+
+Sets the code for a given address.
+
+#### Arguments
+
++ `address: Address` - The `Address` whose code will be updated
++ `code: Bytes` - The code to set to
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+      "id": "1",
+      "method": "hardhat_setCode",
+      "params": [
+        "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+        [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+      ]
+  }'
 ```
 
 ## `EVM NAMESPACE`

--- a/e2e-tests/contracts/Return5.sol
+++ b/e2e-tests/contracts/Return5.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity >=0.8.2 <0.9.0;
+
+contract Return5 {
+  function value() public pure returns (uint8) {
+    return 5;
+  }
+}

--- a/e2e-tests/test/hardhat-apis.test.ts
+++ b/e2e-tests/test/hardhat-apis.test.ts
@@ -90,7 +90,7 @@ xdescribe("hardhat_impersonateAccount & hardhat_stopImpersonatingAccount", funct
 });
 
 describe("hardhat_setCode", function () {
-  it.only("Should set code at an address", async function () {
+  it("Should set code at an address", async function () {
     // Arrange
     const wallet = new Wallet(RichAccounts[0].PrivateKey);
     const deployer = new Deployer(hre, wallet);
@@ -117,9 +117,7 @@ describe("hardhat_setCode", function () {
     ]);
     expect(BigNumber.from(result).toNumber()).to.eq(5);
   });
-});
 
-describe("hardhat_setCode", function () {
   it("Should update code with a different smart contract", async function () {
     // Arrange
     const wallet = new Wallet(RichAccounts[0].PrivateKey);

--- a/e2e-tests/test/hardhat-apis.test.ts
+++ b/e2e-tests/test/hardhat-apis.test.ts
@@ -1,8 +1,12 @@
 import { expect } from "chai";
 import { Wallet } from "zksync-web3";
-import { getTestProvider } from "../helpers/utils";
+import { deployContract, getTestProvider } from "../helpers/utils";
 import { RichAccounts } from "../helpers/constants";
 import { ethers } from "hardhat";
+import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
+import * as hre from "hardhat";
+import { keccak256 } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
 
 const provider = getTestProvider();
 
@@ -82,5 +86,36 @@ xdescribe("hardhat_impersonateAccount & hardhat_stopImpersonatingAccount", funct
     // Assert
     expect(await userWallet.getBalance()).to.equal(ethers.utils.parseEther("0.42"));
     expect(await provider.getBalance(RichAccounts[0].Account)).to.equal(beforeBalance.sub(0.42));
+  });
+});
+
+describe("hardhat_setCode", function () {
+  it("Should update code with a different smart contract", async function () {
+    // Arrange
+    const wallet = new Wallet(RichAccounts[0].PrivateKey);
+    const deployer = new Deployer(hre, wallet);
+
+    const greeter = await deployContract(deployer, "Greeter", ["Hi"]);
+    expect(await greeter.greet()).to.eq("Hi");
+
+    // Act
+    const artifact = await deployer.loadArtifact("Return5");
+    const newContractCode = [...ethers.utils.arrayify(artifact.deployedBytecode)];
+    await provider.send("hardhat_setCode", [greeter.address, newContractCode]);
+
+    // Assert
+    const result = await provider.send("eth_call", [
+      {
+        to: greeter.address,
+        data: keccak256(ethers.utils.toUtf8Bytes("value()")).substring(0, 10),
+        from: wallet.address,
+        gas: "0x1000",
+        gasPrice: "0x0ee6b280",
+        value: "0x0",
+        nonce: "0x1",
+      },
+      "latest",
+    ]);
+    expect(BigNumber.from(result).toNumber()).to.eq(5);
   });
 });

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -630,6 +630,20 @@ content-type: application/json
 
 {
     "jsonrpc": "2.0",
+    "id": "2",
+    "method": "hardhat_setCode",
+    "params": [
+        "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+        [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+    ]
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
     "id": "1",
     "method": "zks_getTokenPrice",
     "params": ["0x0000000000000000000000000000000000000000"]


### PR DESCRIPTION
# What :computer: 
* adds `hardhat_setCode`

# Why :hand:
* Allows developers to set arbitrary smart contract bytecodes for a given address, aiding in development.

# Evidence :camera:
![image](https://github.com/matter-labs/era-test-node/assets/1564843/ae17a590-c037-42c0-802b-bbe21149e3a8)
![image](https://github.com/matter-labs/era-test-node/assets/1564843/867f55f3-414c-4246-b496-263b4a3f1061)

# Notes :memo:
* Fixes #149 
