### PR TITLE
chore: remove hub usage in favour of gh for draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,10 +131,6 @@ jobs:
           echo "CONTRIBUTORS<<EOF" >> $GITHUB_OUTPUT
           echo "$(git log --pretty=format:"- %aN (%aE)" $(git describe --tags --abbrev=0 ${{ env.VERSION }}^)..${{ env.VERSION }} | sort | uniq)" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      
-      # TODO: switch to gh cli. See https://github.com/actions/runner-images/issues/8362
-      - name: Install hub
-        run: sudo apt-get update && sudo apt-get install -y hub
         
       - name: Create release draft
         env:
@@ -183,4 +179,4 @@ jobs:
               assets+=("-a" "$asset/$asset")
           done
           tag_name="${{ env.VERSION }}"
-          echo "$body" | hub release create --draft "${assets[@]}" -F "-" "$tag_name"
+          echo "$body" | gh release create --draft "${assets[@]}" -F "-" "$tag_name"


### PR DESCRIPTION
# What :computer: 
* Replaces `hub` for `gh`

# Why :hand:
* `hub` is being removed from runners in favour of `gh`

# Evidence :camera:

![Screenshot 2023-10-12 at 10 07 37 AM](https://github.com/matter-labs/era-test-node/assets/29983536/9af72283-c0a0-43ae-84d9-3edf8dabd6ad)

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
