### PR TITLE
feat: impl `zks_getTransactionDetails`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2128,6 +2128,7 @@ version = "0.1.0-alpha.5"
 dependencies = [
  "anyhow",
  "bigdecimal",
+ "chrono",
  "clap 4.3.23",
  "colored",
  "ethabi 16.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ log = "0.4.20"
 simplelog = "0.12.1"
 rustc-hash = "1.1.0"
 indexmap = "2.0.1"
+chrono = { version = "0.4.31", default-features = false }
 
 [dev-dependencies]
 httptest = "0.15.4"

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -124,7 +124,7 @@ The `status` options are:
 | `ZKS` | `zks_getRawBlockTransactions` | `NOT IMPLEMENTED` | Returns data of transactions in a block |
 | `ZKS` | `zks_getTestnetPaymaster` | `NOT IMPLEMENTED` | Returns the address of the testnet paymaster |
 | [`ZKS`](#zks-namespace) | [`zks_getTokenPrice`](#zks_getTokenPrice) | `SUPPORTED` | Gets the USD price of a token <br />_(`ETH` is hard-coded to `1_500`, while some others are `1`)_ |
-| `ZKS` | `zks_getTransactionDetails` | `NOT IMPLEMENTED` | Returns data from a specific transaction given by the transaction hash |
+| [`ZKS`](#zks-namespace) | [`zks_getTransactionDetails`](#zks_gettransactiondetails) | `SUPPORTED` | Returns data from a specific transaction given by the transaction hash |
 | `ZKS` | `zks_L1BatchNumber` | `NOT IMPLEMENTED` | Returns the latest L1 batch number |
 | `ZKS` | `zks_L1ChainId` | `NOT IMPLEMENTED` | Returns the chain id of the underlying L1 |
 
@@ -1686,4 +1686,27 @@ curl --request POST \
   --url http://localhost:8011/ \
   --header 'content-type: application/json' \
   --data '{"jsonrpc": "2.0","id": "1","method": "zks_getTokenPrice","params": ["0x0000000000000000000000000000000000000000"]}'
+```
+
+### `zks_getTransactionDetails`
+
+[source](src/zks.rs)
+
+Returns data from a specific transaction given by the transaction hash.
+
+#### Arguments
+
++ `transactionHash: H256`
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{"jsonrpc": "2.0","id": "1","method": "zks_getTransactionDetails","params": ["0xa5d62a85561295ed58f8daad4e9442691e6da4301a859f364d28a02917d6e04d"]}'
 ```

--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -61,7 +61,7 @@ describe("zks_getTokenPrice", function () {
 });
 
 describe("zks_getTransactionDetails", function () {
-  it.only("Should return fake token Price for ETH", async function () {
+  it.only("Should return transaction details for locally-executed transactions", async function () {
     const wallet = new Wallet(RichAccounts[0].PrivateKey);
     const deployer = new Deployer(hre, wallet);
 

--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -61,7 +61,7 @@ describe("zks_getTokenPrice", function () {
 });
 
 describe("zks_getTransactionDetails", function () {
-  it.only("Should return transaction details for locally-executed transactions", async function () {
+  it("Should return transaction details for locally-executed transactions", async function () {
     const wallet = new Wallet(RichAccounts[0].PrivateKey);
     const deployer = new Deployer(hre, wallet);
 

--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -1,9 +1,11 @@
 import { expect } from "chai";
-import { getTestProvider } from "../helpers/utils";
+import { deployContract, getTestProvider } from "../helpers/utils";
+import * as hre from "hardhat";
 import { Wallet } from "zksync-web3";
 import { RichAccounts } from "../helpers/constants";
 import { ethers } from "ethers";
 import { TransactionRequest } from "zksync-web3/build/src/types";
+import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 
 const provider = getTestProvider();
 
@@ -55,5 +57,20 @@ describe("zks_getTokenPrice", function () {
 
     // Assert
     expect(response).to.equal("1500");
+  });
+});
+
+describe("zks_getTransactionDetails", function () {
+  it.only("Should return fake token Price for ETH", async function () {
+    const wallet = new Wallet(RichAccounts[0].PrivateKey);
+    const deployer = new Deployer(hre, wallet);
+
+    const greeter = await deployContract(deployer, "Greeter", ["Hi"]);
+
+    const txReceipt = await greeter.setGreeting("Luke Skywalker");
+    const details = await provider.send("zks_getTransactionDetails", [txReceipt.hash]);
+
+    expect(details["status"]).to.equal("included");
+    expect(details["initiatorAddress"].toLowerCase()).to.equal(wallet.address.toLowerCase());
   });
 });

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -14,7 +14,9 @@ use tokio::runtime::Builder;
 use zksync_basic_types::{Address, L1BatchNumber, L2ChainId, MiniblockNumber, H256, U256, U64};
 
 use zksync_types::{
-    api::{Block, BlockIdVariant, BlockNumber, Transaction, TransactionVariant},
+    api::{
+        Block, BlockIdVariant, BlockNumber, Transaction, TransactionDetails, TransactionVariant,
+    },
     l2::L2Tx,
     ProtocolVersionId, StorageKey,
 };
@@ -202,8 +204,12 @@ pub trait ForkSource {
 
     /// Returns the bytecode stored under this hash (if available).
     fn get_bytecode_by_hash(&self, hash: H256) -> eyre::Result<Option<Vec<u8>>>;
+
     /// Returns the transaction for a given hash.
     fn get_transaction_by_hash(&self, hash: H256) -> eyre::Result<Option<Transaction>>;
+
+    /// Returns the transaction details for a given hash.
+    fn get_transaction_details(&self, hash: H256) -> eyre::Result<Option<TransactionDetails>>;
 
     /// Gets all transactions that belong to a given miniblock.
     fn get_raw_block_transactions(

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -96,6 +96,9 @@ impl ForkSource for HttpForkSource {
         hash: H256,
     ) -> eyre::Result<Option<zksync_types::api::TransactionDetails>> {
         let client = self.create_client();
+        // n.b- We don't cache these responses as they will change through the lifecycle of the transaction
+        // and caching could be error-prone. in theory we could cache responses once the txn status
+        // is `final` or `failed` but currently this does not warrant the additional complexity.
         block_on(async move { client.get_transaction_details(hash).await })
             .wrap_err("fork http client failed")
     }

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -91,6 +91,15 @@ impl ForkSource for HttpForkSource {
             .wrap_err("fork http client failed")
     }
 
+    fn get_transaction_details(
+        &self,
+        hash: H256,
+    ) -> eyre::Result<Option<zksync_types::api::TransactionDetails>> {
+        let client = self.create_client();
+        block_on(async move { client.get_transaction_details(hash).await })
+            .wrap_err("fork http client failed")
+    }
+
     fn get_raw_block_transactions(
         &self,
         block_number: zksync_basic_types::MiniblockNumber,
@@ -256,7 +265,9 @@ impl ForkSource for HttpForkSource {
 
 #[cfg(test)]
 mod tests {
-    use zksync_basic_types::{MiniblockNumber, H256, U64};
+    use std::str::FromStr;
+
+    use zksync_basic_types::{Address, MiniblockNumber, H256, U64};
     use zksync_types::api::BlockNumber;
 
     use crate::testing;
@@ -497,5 +508,46 @@ mod tests {
             .expect("failed fetching cached transaction")
             .expect("no transaction");
         assert_eq!(input_tx_hash, actual_transaction.hash);
+    }
+
+    #[test]
+    fn test_get_transaction_details() {
+        let input_tx_hash = H256::repeat_byte(0x01);
+        let mock_server = testing::MockServer::run();
+        mock_server.expect(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "zks_getTransactionDetails",
+                "params": [
+                    input_tx_hash,
+                ],
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "result": {
+                    "isL1Originated": false,
+                    "status": "included",
+                    "fee": "0x74293f087500",
+                    "gasPerPubdata": "0x4e20",
+                    "initiatorAddress": "0x63ab285cd87a189f345fed7dd4e33780393e01f0",
+                    "receivedAt": "2023-10-12T15:45:53.094Z",
+                    "ethCommitTxHash": null,
+                    "ethProveTxHash": null,
+                    "ethExecuteTxHash": null
+                },
+                "id": 0
+            }),
+        );
+
+        let fork_source = HttpForkSource::new(mock_server.url(), CacheConfig::Memory);
+        let transaction_details = fork_source
+            .get_transaction_details(input_tx_hash)
+            .expect("failed fetching transaction")
+            .expect("no transaction");
+        assert_eq!(
+            transaction_details.initiator_address,
+            Address::from_str("0x63ab285cd87a189f345fed7dd4e33780393e01f0").unwrap()
+        );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
+use chrono::{DateTime, Utc};
 use futures::Future;
 use vm::{ExecutionResult, VmExecutionResultAndLogs};
 use vm::{HistoryDisabled, Vm};
@@ -243,6 +244,14 @@ pub fn create_debug_output(
     }
 }
 
+/// Converts a timestamp in milliseconds since epoch to a [DateTime] in UTC.
+pub fn utc_datetime_from_epoch_ms(millis: u64) -> DateTime<Utc> {
+    let secs = millis / 1000;
+    let nanos = (millis % 1000) * 1_000_000;
+    // expect() is ok- nanos can't be >2M
+    DateTime::<Utc>::from_timestamp(secs as i64, nanos as u32).expect("valid timestamp")
+}
+
 #[cfg(test)]
 mod tests {
     use zksync_basic_types::{H256, U256};
@@ -250,6 +259,18 @@ mod tests {
     use crate::{http_fork_source::HttpForkSource, node::InMemoryNode, testing};
 
     use super::*;
+
+    #[test]
+    fn test_utc_datetime_from_epoch_ms() {
+        let actual = utc_datetime_from_epoch_ms(1623931200000);
+        assert_eq!(
+            DateTime::<Utc>::from_naive_utc_and_offset(
+                chrono::NaiveDateTime::from_timestamp_opt(1623931200, 0).unwrap(),
+                Utc
+            ),
+            actual
+        );
+    }
 
     #[test]
     fn test_human_sizes() {

--- a/src/zks.rs
+++ b/src/zks.rs
@@ -7,7 +7,7 @@ use zksync_core::api_server::web3::backend_jsonrpc::{
     error::into_jsrpc_error, namespaces::zks::ZksNamespaceT,
 };
 use zksync_types::{
-    api::{BridgeAddresses, ProtocolVersion},
+    api::{BridgeAddresses, ProtocolVersion, TransactionDetails, TransactionStatus},
     fee::Fee,
 };
 use zksync_web3_decl::{
@@ -17,8 +17,8 @@ use zksync_web3_decl::{
 
 use crate::{
     fork::ForkSource,
-    node::InMemoryNodeInner,
-    utils::{not_implemented, IntoBoxedFuture},
+    node::{InMemoryNodeInner, TransactionResult},
+    utils::{not_implemented, utc_datetime_from_epoch_ms, IntoBoxedFuture},
 };
 use colored::Colorize;
 
@@ -197,12 +197,67 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> ZksNamespaceT
         not_implemented("zks_getL1BatchBlockRange")
     }
 
+    /// Get transaction details.
+    ///
+    /// # Arguments
+    ///
+    /// * `transactionHash` - `H256` hash of the transaction
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `Result` with an `Option<TransactionDetails>` representing details of the transaction (if found).
     fn get_transaction_details(
         &self,
-        _hash: zksync_basic_types::H256,
+        hash: zksync_basic_types::H256,
     ) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<Option<zksync_types::api::TransactionDetails>>>
     {
-        not_implemented("zks_getTransactionDetails")
+        let inner = self.node.clone();
+        Box::pin(async move {
+            let reader = match inner.read() {
+                Ok(r) => r,
+                Err(_) => {
+                    return Err(into_jsrpc_error(Web3Error::InternalError));
+                }
+            };
+
+            let maybe_result = {
+                reader
+                    .tx_results
+                    .get(&hash)
+                    .and_then(|TransactionResult { info, receipt, .. }| {
+                        Some(TransactionDetails {
+                            is_l1_originated: false,
+                            status: TransactionStatus::Included,
+                            // if these are not set, fee is effectively 0
+                            fee: receipt.effective_gas_price.unwrap_or_default()
+                                * receipt.gas_used.unwrap_or_default(),
+                            gas_per_pubdata: info.tx.common_data.fee.gas_per_pubdata_limit,
+                            initiator_address: info.tx.initiator_account(),
+                            received_at: utc_datetime_from_epoch_ms(info.tx.received_timestamp_ms),
+                            eth_commit_tx_hash: None,
+                            eth_prove_tx_hash: None,
+                            eth_execute_tx_hash: None,
+                        })
+                    })
+                    .or_else(|| {
+                        reader
+                            .fork_storage
+                            .inner
+                            .read()
+                            .expect("failed reading fork storage")
+                            .fork
+                            .as_ref()
+                            .and_then(|fork| {
+                                fork.fork_source
+                                    .get_transaction_details(hash)
+                                    .ok()
+                                    .flatten()
+                            })
+                    })
+            };
+
+            Ok(maybe_result)
+        })
     }
 
     /// Retrieves details for a given L1 batch.
@@ -259,12 +314,16 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> ZksNamespaceT
 mod tests {
     use std::str::FromStr;
 
-    use crate::node::ShowCalls;
-    use crate::system_contracts;
+    use crate::cache::CacheConfig;
+    use crate::fork::ForkDetails;
+    use crate::node::{ShowCalls, ShowGasDetails, ShowStorageLogs, ShowVMDetails};
+    use crate::testing::{ForkBlockConfig, MockServer};
     use crate::{http_fork_source::HttpForkSource, node::InMemoryNode};
+    use crate::{system_contracts, testing};
 
     use super::*;
-    use zksync_basic_types::Address;
+    use zksync_basic_types::{Address, H256};
+    use zksync_types::api::TransactionReceipt;
     use zksync_types::transaction_request::CallRequest;
 
     #[tokio::test]
@@ -357,5 +416,94 @@ mod tests {
 
         // Assert
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_transaction_details_local() {
+        // Arrange
+        let node = InMemoryNode::<HttpForkSource>::default();
+        let namespace = ZkMockNamespaceImpl::new(node.get_inner());
+        let inner = node.get_inner();
+        {
+            let mut writer = inner.write().unwrap();
+            writer.tx_results.insert(
+                H256::repeat_byte(0x1),
+                TransactionResult {
+                    info: testing::default_tx_execution_info(),
+                    receipt: TransactionReceipt {
+                        logs: vec![],
+                        gas_used: Some(U256::from(10_000)),
+                        effective_gas_price: Some(U256::from(1_000_000_000)),
+                        ..Default::default()
+                    },
+                    debug: testing::default_tx_debug_info(),
+                },
+            );
+        }
+        // Act
+        let result = namespace
+            .get_transaction_details(H256::repeat_byte(0x1))
+            .await
+            .expect("get transaction details")
+            .expect("transaction details");
+
+        // Assert
+        assert!(matches!(result.status, TransactionStatus::Included));
+        assert_eq!(result.fee, U256::from(10_000_000_000_000u64));
+    }
+
+    #[tokio::test]
+    async fn test_get_transaction_details_fork() {
+        let mock_server = MockServer::run_with_config(ForkBlockConfig {
+            number: 10,
+            transaction_count: 0,
+            hash: H256::repeat_byte(0xab),
+        });
+        let input_tx_hash = H256::repeat_byte(0x02);
+        mock_server.expect(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "zks_getTransactionDetails",
+                "params": [
+                    format!("{:#x}", input_tx_hash),
+                ],
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "result": {
+                    "isL1Originated": false,
+                    "status": "included",
+                    "fee": "0x74293f087500",
+                    "gasPerPubdata": "0x4e20",
+                    "initiatorAddress": "0x63ab285cd87a189f345fed7dd4e33780393e01f0",
+                    "receivedAt": "2023-10-12T15:45:53.094Z",
+                    "ethCommitTxHash": null,
+                    "ethProveTxHash": null,
+                    "ethExecuteTxHash": null
+                },
+                "id": 0
+            }),
+        );
+
+        let node = InMemoryNode::<HttpForkSource>::new(
+            Some(ForkDetails::from_network(&mock_server.url(), None, CacheConfig::None).await),
+            crate::node::ShowCalls::None,
+            ShowStorageLogs::None,
+            ShowVMDetails::None,
+            ShowGasDetails::None,
+            false,
+            &system_contracts::Options::BuiltIn,
+        );
+
+        let namespace = ZkMockNamespaceImpl::new(node.get_inner());
+        let result = namespace
+            .get_transaction_details(input_tx_hash)
+            .await
+            .expect("get transaction details")
+            .expect("transaction details");
+
+        assert!(matches!(result.status, TransactionStatus::Included));
+        assert_eq!(result.fee, U256::from(127_720_500_000_000u64));
     }
 }

--- a/src/zks.rs
+++ b/src/zks.rs
@@ -224,8 +224,8 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> ZksNamespaceT
                 reader
                     .tx_results
                     .get(&hash)
-                    .and_then(|TransactionResult { info, receipt, .. }| {
-                        Some(TransactionDetails {
+                    .map(|TransactionResult { info, receipt, .. }| {
+                        TransactionDetails {
                             is_l1_originated: false,
                             status: TransactionStatus::Included,
                             // if these are not set, fee is effectively 0
@@ -237,7 +237,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> ZksNamespaceT
                             eth_commit_tx_hash: None,
                             eth_prove_tx_hash: None,
                             eth_execute_tx_hash: None,
-                        })
+                        }
                     })
                     .or_else(|| {
                         reader

--- a/src/zks.rs
+++ b/src/zks.rs
@@ -213,12 +213,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> ZksNamespaceT
     {
         let inner = self.node.clone();
         Box::pin(async move {
-            let reader = match inner.read() {
-                Ok(r) => r,
-                Err(_) => {
-                    return Err(into_jsrpc_error(Web3Error::InternalError));
-                }
-            };
+            let reader = match inner.read().map_err(|err| into_jsrpc_error(Web3Error::InternalError))?;
 
             let maybe_result = {
                 reader

--- a/src/zks.rs
+++ b/src/zks.rs
@@ -213,7 +213,9 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> ZksNamespaceT
     {
         let inner = self.node.clone();
         Box::pin(async move {
-            let reader = match inner.read().map_err(|err| into_jsrpc_error(Web3Error::InternalError))?;
+            let reader = inner
+                .read()
+                .map_err(|_err| into_jsrpc_error(Web3Error::InternalError))?;
 
             let maybe_result = {
                 reader

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -675,6 +675,17 @@ content-type: application/json
 {
     "jsonrpc": "2.0",
     "id": "1",
+    "method": "zks_getTransactionDetails",
+    "params": ["0xa5d62a85561295ed58f8daad4e9442691e6da4301a859f364d28a02917d6e04d"]
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "1",
     "method": "eth_feeHistory",
     "params": ["0x1", "latest", [25, 50 , 75]]
 }


### PR DESCRIPTION
# What :computer: 
* Added `get_transaction_details` to `http_fork_choice`
* Implemented handler for `zks_getTransactionDetails` to zks namespace

# Why :hand:
* Allow users to retrieve tx details

# Evidence :camera:
![image](https://github.com/matter-labs/era-test-node/assets/140627974/4c8bd889-2f96-4d1e-ae5b-4fa8c7074cb7)
![image](https://github.com/matter-labs/era-test-node/assets/140627974/c12e1976-a224-4eda-8303-0cf12414828f)

# Notes :memo:
* We are not caching these responses due to their mutable status. We could cache when `status == Finalized`, but didn't seem worth it. wdyt?
* Fixes https://github.com/matter-labs/era-test-node/issues/146