### PR TITLE
feat: add zks_getBridgeContracts

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -113,7 +113,7 @@ The `status` options are:
 | `ZKS` | `zks_estimateGasL1ToL2` | `NOT IMPLEMENTED` | Estimate of the gas required for a L1 to L2 transaction |
 | `ZKS` | `zks_getAllAccountBalances` | `NOT IMPLEMENTED` | Returns all balances for confirmed tokens given by an account address |
 | `ZKS` | `zks_getBlockDetails` | `NOT IMPLEMENTED` | Returns additional zkSync-specific information about the L2 block |
-| `ZKS` | `zks_getBridgeContracts` | `NOT IMPLEMENTED` | Returns L1/L2 addresses of default bridges |
+| [`ZKS`](#zks-namespace) | [`zks_getBridgeContracts`](#zks_getbridgecontracts) | `SUPPORTED` | Returns L1/L2 addresses of default bridges |
 | `ZKS` | `zks_getBytecodeByHash` | `NOT IMPLEMENTED` | Returns bytecode of a transaction given by its hash |
 | `ZKS` | `zks_getConfirmedTokens` | `NOT IMPLEMENTED` | Returns [address, symbol, name, and decimal] information of all tokens within a range of ids given by parameters `from` and `limit` |
 | `ZKS` | `zks_getL1BatchBlockRange` | `NOT IMPLEMENTED` | Returns the range of blocks contained within a batch given by batch number |
@@ -1741,4 +1741,31 @@ curl --request POST \
   --url http://localhost:8011/ \
   --header 'content-type: application/json' \
   --data '{"jsonrpc": "2.0","id": "1","method": "zks_getTransactionDetails","params": ["0xa5d62a85561295ed58f8daad4e9442691e6da4301a859f364d28a02917d6e04d"]}'
+```
+
+### `zks_getBridgeContracts`
+
+[source](src/zks.rs)
+
+Returns L1/L2 addresses of default bridges.
+
+#### Arguments
+
++ _NONE_
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+      "id": "2",
+      "method": "zks_getBridgeContracts"
+  }'
 ```

--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -74,3 +74,16 @@ describe("zks_getTransactionDetails", function () {
     expect(details["initiatorAddress"].toLowerCase()).to.equal(wallet.address.toLowerCase());
   });
 });
+
+describe("zks_getBridgeContracts", function () {
+  it("Should return default values", async function () {
+    const bridgeAddresses = await provider.send("zks_getBridgeContracts", []);
+
+    expect(bridgeAddresses).to.deep.equal({
+      l1Erc20DefaultBridge: "0x0000000000000000000000000000000000000000",
+      l2Erc20DefaultBridge: "0x0000000000000000000000000000000000000000",
+      l1WethBridge: null,
+      l2WethBridge: null,
+    });
+  });
+});

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -10,12 +10,18 @@ use zksync_basic_types::H256;
 use zksync_types::api::{Block, BridgeAddresses, Transaction, TransactionVariant};
 use zksync_types::Transaction as RawTransaction;
 
+/// Caches full blocks by their hashes
 const CACHE_TYPE_BLOCKS_FULL: &str = "blocks_full";
+/// Caches minimal blocks by their hashes
 const CACHE_TYPE_BLOCKS_MIN: &str = "blocks_min";
+/// Caches raw transactions by their hashes
 const CACHE_TYPE_BLOCK_RAW_TRANSACTIONS: &str = "block_raw_transactions";
+/// Caches transactions by their hashes
 const CACHE_TYPE_TRANSACTIONS: &str = "transactions";
+/// Caches arbitrary values by their keys
 const CACHE_TYPE_KEY_VALUE: &str = "key_value";
 
+/// Caching key for bridge addresses
 const CACHE_KEY_BRIDGE_ADDRESSES: &str = "bridge_addresses";
 
 /// Cache configuration. Can be one of:

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -7,13 +7,16 @@ use std::path::Path;
 use std::result::Result;
 use std::str::FromStr;
 use zksync_basic_types::H256;
-use zksync_types::api::{Block, Transaction, TransactionVariant};
+use zksync_types::api::{Block, BridgeAddresses, Transaction, TransactionVariant};
 use zksync_types::Transaction as RawTransaction;
 
 const CACHE_TYPE_BLOCKS_FULL: &str = "blocks_full";
 const CACHE_TYPE_BLOCKS_MIN: &str = "blocks_min";
 const CACHE_TYPE_BLOCK_RAW_TRANSACTIONS: &str = "block_raw_transactions";
 const CACHE_TYPE_TRANSACTIONS: &str = "transactions";
+const CACHE_TYPE_KEY_VALUE: &str = "key_value";
+
+const CACHE_KEY_BRIDGE_ADDRESSES: &str = "bridge_addresses";
 
 /// Cache configuration. Can be one of:
 ///
@@ -40,6 +43,7 @@ pub(crate) struct Cache {
     blocks_min: FxHashMap<H256, Block<TransactionVariant>>,
     block_raw_transactions: FxHashMap<u64, Vec<RawTransaction>>,
     transactions: FxHashMap<H256, Transaction>,
+    bridge_addresses: Option<BridgeAddresses>,
 }
 
 impl Cache {
@@ -57,6 +61,7 @@ impl Cache {
                     CACHE_TYPE_BLOCKS_MIN,
                     CACHE_TYPE_BLOCK_RAW_TRANSACTIONS,
                     CACHE_TYPE_TRANSACTIONS,
+                    CACHE_TYPE_KEY_VALUE,
                 ] {
                     fs::remove_dir_all(Path::new(dir).join(cache_type)).unwrap_or_else(|err| {
                         log::warn!(
@@ -76,6 +81,7 @@ impl Cache {
                 CACHE_TYPE_BLOCKS_MIN,
                 CACHE_TYPE_BLOCK_RAW_TRANSACTIONS,
                 CACHE_TYPE_TRANSACTIONS,
+                CACHE_TYPE_KEY_VALUE,
             ] {
                 fs::create_dir_all(Path::new(dir).join(cache_type)).unwrap_or_else(|err| {
                     panic!("failed creating directory {}: {:?}", cache_type, err)
@@ -186,6 +192,29 @@ impl Cache {
         self.transactions.insert(hash, transaction);
     }
 
+    /// Returns the cached bridge addresses for the provided hash.
+    pub(crate) fn get_bridge_addresses(&self) -> Option<&BridgeAddresses> {
+        if matches!(self.config, CacheConfig::None) {
+            return None;
+        }
+
+        self.bridge_addresses.as_ref()
+    }
+
+    /// Cache default bridge addresses.
+    pub(crate) fn set_bridge_addresses(&mut self, bridge_addresses: BridgeAddresses) {
+        if matches!(self.config, CacheConfig::None) {
+            return;
+        }
+
+        self.write_to_disk(
+            CACHE_TYPE_KEY_VALUE,
+            String::from(CACHE_KEY_BRIDGE_ADDRESSES),
+            &bridge_addresses,
+        );
+        self.bridge_addresses = Some(bridge_addresses);
+    }
+
     /// Reads the cache contents from the disk, if available.
     fn read_all_from_disk(&mut self, dir: &str) -> Result<(), String> {
         for cache_type in [
@@ -193,6 +222,7 @@ impl Cache {
             CACHE_TYPE_BLOCKS_MIN,
             CACHE_TYPE_BLOCK_RAW_TRANSACTIONS,
             CACHE_TYPE_TRANSACTIONS,
+            CACHE_TYPE_KEY_VALUE,
         ] {
             let cache_dir = Path::new(dir).join(cache_type);
             let dir_listing = fs::read_dir(cache_dir.clone())
@@ -252,6 +282,18 @@ impl Cache {
                             })?;
                         self.transactions.insert(key, transaction);
                     }
+                    CACHE_TYPE_KEY_VALUE => match key.as_str() {
+                        CACHE_KEY_BRIDGE_ADDRESSES => {
+                            self.bridge_addresses =
+                                Some(serde_json::from_reader(reader).map_err(|err| {
+                                    format!(
+                                        "failed parsing json for cache file '{:?}': {:?}",
+                                        key, err
+                                    )
+                                })?);
+                        }
+                        _ => return Err(format!("invalid cache_type_value key {}", cache_type)),
+                    },
                     _ => return Err(format!("invalid cache_type {}", cache_type)),
                 }
             }
@@ -282,8 +324,10 @@ impl Cache {
 #[cfg(test)]
 mod tests {
     use tempdir::TempDir;
-    use zksync_basic_types::U64;
+    use zksync_basic_types::{H160, U64};
     use zksync_types::{Execute, ExecuteTransactionCommon};
+
+    use crate::testing;
 
     use super::*;
 
@@ -330,6 +374,12 @@ mod tests {
             received_timestamp_ms: 0,
             raw_bytes: None,
         }];
+        let bridge_addresses = BridgeAddresses {
+            l1_erc20_default_bridge: H160::repeat_byte(0x1),
+            l2_erc20_default_bridge: H160::repeat_byte(0x2),
+            l1_weth_bridge: Some(H160::repeat_byte(0x3)),
+            l2_weth_bridge: Some(H160::repeat_byte(0x4)),
+        };
 
         let mut cache = Cache::new(CacheConfig::Memory);
 
@@ -355,6 +405,12 @@ mod tests {
 
         cache.insert_transaction(H256::zero(), transaction.clone());
         assert_eq!(Some(&transaction), cache.get_transaction(&H256::zero()));
+
+        cache.set_bridge_addresses(bridge_addresses.clone());
+        testing::assert_bridge_addresses_eq(
+            &bridge_addresses,
+            cache.get_bridge_addresses().expect("expected addresses"),
+        );
     }
 
     #[test]
@@ -381,6 +437,12 @@ mod tests {
             received_timestamp_ms: 0,
             raw_bytes: None,
         }];
+        let bridge_addresses = BridgeAddresses {
+            l1_erc20_default_bridge: H160::repeat_byte(0x1),
+            l2_erc20_default_bridge: H160::repeat_byte(0x2),
+            l1_weth_bridge: Some(H160::repeat_byte(0x3)),
+            l2_weth_bridge: Some(H160::repeat_byte(0x4)),
+        };
 
         let cache_dir = TempDir::new("cache-test").expect("failed creating temporary dir");
         let cache_dir_path = cache_dir
@@ -416,6 +478,12 @@ mod tests {
         cache.insert_transaction(H256::zero(), transaction.clone());
         assert_eq!(Some(&transaction), cache.get_transaction(&H256::zero()));
 
+        cache.set_bridge_addresses(bridge_addresses.clone());
+        testing::assert_bridge_addresses_eq(
+            &bridge_addresses,
+            cache.get_bridge_addresses().expect("expected addresses"),
+        );
+
         let new_cache = Cache::new(CacheConfig::Disk {
             dir: cache_dir_path,
             reset: false,
@@ -435,6 +503,12 @@ mod tests {
             new_cache.get_block_raw_transactions(&0)
         );
         assert_eq!(Some(&transaction), new_cache.get_transaction(&H256::zero()));
+        testing::assert_bridge_addresses_eq(
+            &bridge_addresses,
+            new_cache
+                .get_bridge_addresses()
+                .expect("expected addresses"),
+        );
     }
 
     #[test]
@@ -461,6 +535,12 @@ mod tests {
             received_timestamp_ms: 0,
             raw_bytes: None,
         }];
+        let bridge_addresses = BridgeAddresses {
+            l1_erc20_default_bridge: H160::repeat_byte(0x1),
+            l2_erc20_default_bridge: H160::repeat_byte(0x2),
+            l1_weth_bridge: Some(H160::repeat_byte(0x3)),
+            l2_weth_bridge: Some(H160::repeat_byte(0x4)),
+        };
 
         let cache_dir = TempDir::new("cache-test").expect("failed creating temporary dir");
         let cache_dir_path = cache_dir
@@ -496,6 +576,12 @@ mod tests {
         cache.insert_transaction(H256::zero(), transaction.clone());
         assert_eq!(Some(&transaction), cache.get_transaction(&H256::zero()));
 
+        cache.set_bridge_addresses(bridge_addresses.clone());
+        testing::assert_bridge_addresses_eq(
+            &bridge_addresses,
+            cache.get_bridge_addresses().expect("expected addresses"),
+        );
+
         let new_cache = Cache::new(CacheConfig::Disk {
             dir: cache_dir_path,
             reset: true,
@@ -506,6 +592,7 @@ mod tests {
         assert_eq!(None, new_cache.get_block_hash(&2));
         assert_eq!(None, new_cache.get_block_raw_transactions(&0));
         assert_eq!(None, new_cache.get_transaction(&H256::zero()));
+        assert!(new_cache.get_bridge_addresses().is_none());
     }
 
     #[test]

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -15,7 +15,8 @@ use zksync_basic_types::{Address, L1BatchNumber, L2ChainId, MiniblockNumber, H25
 
 use zksync_types::{
     api::{
-        Block, BlockIdVariant, BlockNumber, Transaction, TransactionDetails, TransactionVariant,
+        Block, BlockIdVariant, BlockNumber, BridgeAddresses, Transaction, TransactionDetails,
+        TransactionVariant,
     },
     l2::L2Tx,
     ProtocolVersionId, StorageKey,
@@ -253,6 +254,9 @@ pub trait ForkSource {
         block_number: BlockNumber,
         index: Index,
     ) -> eyre::Result<Option<Transaction>>;
+
+    /// Returns addresses of the default bridge contracts.
+    fn get_bridge_contracts(&self) -> eyre::Result<BridgeAddresses>;
 }
 
 /// Holds the information about the original chain.

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -2,7 +2,7 @@ use std::sync::RwLock;
 
 use eyre::Context;
 use zksync_basic_types::{H256, U256};
-use zksync_types::api::Transaction;
+use zksync_types::api::{BridgeAddresses, Transaction};
 use zksync_web3_decl::{
     jsonrpsee::http_client::{HttpClient, HttpClientBuilder},
     namespaces::{EthNamespaceClient, ZksNamespaceClient},
@@ -264,13 +264,42 @@ impl ForkSource for HttpForkSource {
         })
         .wrap_err("fork http client failed")
     }
+
+    /// Returns addresses of the default bridge contracts.
+    fn get_bridge_contracts(&self) -> eyre::Result<BridgeAddresses> {
+        if let Some(bridge_addresses) = self
+            .cache
+            .read()
+            .ok()
+            .and_then(|guard| guard.get_bridge_addresses().cloned())
+        {
+            log::debug!("using cached bridge contracts");
+            return Ok(bridge_addresses);
+        };
+
+        let client = self.create_client();
+        block_on(async move { client.get_bridge_contracts().await })
+            .map(|bridge_addresses| {
+                self.cache
+                    .write()
+                    .map(|mut guard| guard.set_bridge_addresses(bridge_addresses.clone()))
+                    .unwrap_or_else(|err| {
+                        log::warn!(
+                            "failed writing to cache for 'get_bridge_contracts': {:?}",
+                            err
+                        )
+                    });
+                bridge_addresses
+            })
+            .wrap_err("fork http client failed")
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
 
-    use zksync_basic_types::{Address, MiniblockNumber, H256, U64};
+    use zksync_basic_types::{Address, MiniblockNumber, H160, H256, U64};
     use zksync_types::api::BlockNumber;
 
     use crate::testing;
@@ -552,5 +581,45 @@ mod tests {
             transaction_details.initiator_address,
             Address::from_str("0x63ab285cd87a189f345fed7dd4e33780393e01f0").unwrap()
         );
+    }
+
+    #[test]
+    fn test_get_bridge_contracts_is_cached() {
+        let input_bridge_addresses = BridgeAddresses {
+            l1_erc20_default_bridge: H160::repeat_byte(0x1),
+            l2_erc20_default_bridge: H160::repeat_byte(0x2),
+            l1_weth_bridge: Some(H160::repeat_byte(0x3)),
+            l2_weth_bridge: Some(H160::repeat_byte(0x4)),
+        };
+        let mock_server = testing::MockServer::run();
+        mock_server.expect(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "zks_getBridgeContracts",
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "result": {
+                    "l1Erc20DefaultBridge": format!("{:#x}", input_bridge_addresses.l1_erc20_default_bridge),
+                    "l2Erc20DefaultBridge": format!("{:#x}", input_bridge_addresses.l2_erc20_default_bridge),
+                    "l1WethBridge": format!("{:#x}", input_bridge_addresses.l1_weth_bridge.clone().unwrap()),
+                    "l2WethBridge": format!("{:#x}", input_bridge_addresses.l2_weth_bridge.clone().unwrap())
+                },
+                "id": 0
+            }),
+        );
+
+        let fork_source = HttpForkSource::new(mock_server.url(), CacheConfig::Memory);
+
+        let actual_bridge_addresses = fork_source
+            .get_bridge_contracts()
+            .expect("failed fetching bridge addresses");
+        testing::assert_bridge_addresses_eq(&input_bridge_addresses, &actual_bridge_addresses);
+
+        let actual_bridge_addresses = fork_source
+            .get_bridge_contracts()
+            .expect("failed fetching bridge addresses");
+        testing::assert_bridge_addresses_eq(&input_bridge_addresses, &actual_bridge_addresses);
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -18,7 +18,7 @@ use itertools::Itertools;
 use std::str::FromStr;
 use vm::VmExecutionResultAndLogs;
 use zksync_basic_types::{H160, U64};
-use zksync_types::api::{DebugCall, DebugCallType, Log};
+use zksync_types::api::{BridgeAddresses, DebugCall, DebugCallType, Log};
 use zksync_types::{
     fee::Fee, l2::L2Tx, Address, L2ChainId, Nonce, PackedEthSignature, ProtocolVersionId, H256,
     U256,
@@ -597,6 +597,29 @@ pub fn default_tx_debug_info() -> DebugCall {
             calls: vec![],
         }],
     }
+}
+
+/// Asserts that two instances of [BridgeAddresses] are equal
+pub fn assert_bridge_addresses_eq(
+    expected_bridge_addresses: &BridgeAddresses,
+    actual_bridge_addresses: &BridgeAddresses,
+) {
+    assert_eq!(
+        expected_bridge_addresses.l1_erc20_default_bridge,
+        actual_bridge_addresses.l1_erc20_default_bridge
+    );
+    assert_eq!(
+        expected_bridge_addresses.l2_erc20_default_bridge,
+        actual_bridge_addresses.l2_erc20_default_bridge
+    );
+    assert_eq!(
+        expected_bridge_addresses.l1_weth_bridge,
+        actual_bridge_addresses.l1_weth_bridge
+    );
+    assert_eq!(
+        expected_bridge_addresses.l2_weth_bridge,
+        actual_bridge_addresses.l2_weth_bridge
+    );
 }
 
 mod test {

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -700,6 +700,16 @@ content-type: application/json
 {
     "jsonrpc": "2.0",
     "id": "1",
+    "method": "zks_getBridgeContracts",
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "1",
     "method": "eth_feeHistory",
     "params": ["0x1", "latest", [25, 50 , 75]]
 }


### PR DESCRIPTION
# What :computer: 
* Adds `zks_getBridgeContracts` rpc. This returns the default values in local `run` mode and queries the fork in `fork` mode.

# Why :hand:
* Required for the block explorer

# Evidence :camera:
![image](https://github.com/matter-labs/era-test-node/assets/1564843/0e9ea2c6-b61e-4799-9131-d27540b93877)
![image](https://github.com/matter-labs/era-test-node/assets/1564843/dfc5cfab-6c3b-4bdf-bfda-1c08cff73f2e)

# Notes :memo:
* Fixes #153 
