### PR TITLE
feat: support builtInWithoutSecurity option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Please note that `era-test-node` is still in its **alpha** stage. Some features 
    make run
    ```
 
+## 📄 System Contracts
+
+The system contract within the node can be specified via the `--dev-system-contracts` option. 
+It can take one of the following options:
+   * `built-in`: Use the compiled built-in contracts
+   * `built-in-no-verify`: Use the compiled built-in contracts, but without signature verification
+   * `local`: Load contracts from `ZKSYNC_HOME`
+
 ## 📃 Logging
 
 The node may be started in either of `debug`, `info`, `warn` or `error` logging levels via the `--log` option:

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,8 +216,9 @@ struct Cli {
     /// It will make debug log more readable, but will decrease the performance.
     resolve_hashes: bool,
 
-    /// Specifies the option for the system contracts (load locally or use compiled built-in with or without signature verification).
-    #[arg(long)]
+    /// Specifies the option for the system contracts (use compiled built-in with or without signature verification, or load locally).
+    /// Default: built-in
+    #[arg(long, default_value = "built-in")]
     dev_system_contracts: DevSystemContracts,
 
     /// Log filter level - default: info

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,7 +351,7 @@ async fn main() -> anyhow::Result<()> {
     let system_contracts_options = match opt.dev_system_contracts {
         DevSystemContracts::BuiltIn => system_contracts::Options::BuiltIn,
         DevSystemContracts::BuiltInNoVerify => system_contracts::Options::BuiltInWithoutSecurity,
-        DevSystemContracts::Local => system_contracts::Options::BuiltIn,
+        DevSystemContracts::Local => system_contracts::Options::Local,
     };
 
     let node = InMemoryNode::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,14 @@ enum CacheType {
     Disk,
 }
 
+/// System contract options.
+#[derive(ValueEnum, Debug, Clone)]
+enum DevSystemContracts {
+    BuiltIn,
+    BuiltInNoVerify,
+    Local,
+}
+
 #[derive(Debug, Parser)]
 #[command(author = "Matter Labs", version, about = "Test Node", long_about = None)]
 struct Cli {
@@ -208,9 +216,9 @@ struct Cli {
     /// It will make debug log more readable, but will decrease the performance.
     resolve_hashes: bool,
 
+    /// Specifies the option for the system contracts (load locally or use compiled built-in with or without signature verification).
     #[arg(long)]
-    /// If true, will load the locally compiled system contracts (useful when doing changes to system contracts or bootloader)
-    dev_use_local_contracts: bool,
+    dev_system_contracts: DevSystemContracts,
 
     /// Log filter level - default: info
     #[arg(long, default_value = "info")]
@@ -296,7 +304,7 @@ async fn main() -> anyhow::Result<()> {
     ])
     .expect("failed instantiating logger");
 
-    if opt.dev_use_local_contracts {
+    if matches!(opt.dev_system_contracts, DevSystemContracts::Local) {
         if let Some(path) = env::var_os("ZKSYNC_HOME") {
             log::info!("+++++ Reading local contracts from {:?} +++++", path);
         }
@@ -340,10 +348,10 @@ async fn main() -> anyhow::Result<()> {
     } else {
         vec![]
     };
-    let system_contracts_options = if opt.dev_use_local_contracts {
-        system_contracts::Options::Local
-    } else {
-        system_contracts::Options::BuiltIn
+    let system_contracts_options = match opt.dev_system_contracts {
+        DevSystemContracts::BuiltIn => system_contracts::Options::BuiltIn,
+        DevSystemContracts::BuiltInNoVerify => system_contracts::Options::BuiltInWithoutSecurity,
+        DevSystemContracts::Local => system_contracts::Options::BuiltIn,
     };
 
     let node = InMemoryNode::new(


### PR DESCRIPTION
# What :computer: 
* Adds support for `builtInWithoutSecurity` option via `--dev-system-contracts` parameter, which can take the following options:
   * `built-in`: Use the compiled built-in contracts
   * `built-in-no-verify`: Use the compiled built-in contracts, but without signature verification
   * `local`: Load contracts from `ZKSYNC_HOME`
* Remove `--dev-use-local-contracts` in favor of  `--dev-system-contracts` 

# Why :hand:
* Allows easier debugging of local setups

# Evidence :camera:
![image](https://github.com/matter-labs/era-test-node/assets/1564843/885cd1f4-5acd-4cfc-b56f-d9911354b01e)

![image](https://github.com/matter-labs/era-test-node/assets/1564843/9775b75c-247c-465b-a1bf-463878eda100)


# Notes :memo:
* Fixes #105 
