### PR TITLE
fix: Release drafts now attach files correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,20 +140,18 @@ jobs:
         # The formatting here is borrowed from reth which borrowed it from Lighthouse (which is borrowed from OpenEthereum): https://github.com/openethereum/openethereum/blob/main/.github/workflows/build.yml
         run: |
           body=$(cat <<- "ENDBODY"
-          Release: ${{ env.VERSION }}
-          
           <!--Watch Release Notes video below 👇 
           [![YouTube Release Notes](https://img.youtube.com/vi/FZefCZW7JJk/0.jpg)](https://www.youtube.com/watch?v=FZefCZW7JJk)-->
 
           ## 📋 Summary
           
-          🐛 **Bug Fixes:**
+          ### 🐛 Bug Fixes:
           - TBD
           
-          ✨ **New Features:**
+          ### ✨ New Features:
           - TBD
           
-          ⚠️ **Breaking Changes:**
+          ### ⚠️ Breaking Changes:
           - TBD
           
           ## 📜 All Changes
@@ -169,6 +167,7 @@ jobs:
           | System | Architecture | Binary |
           |:---:|:---:|:---:|
           | <img src="https://simpleicons.org/icons/linux.svg" style="width: 32px;"/> | x86_64 | [era-test-node-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/era_test_node-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz) | 
+          | <img src="https://simpleicons.org/icons/linux.svg" style="width: 32px;"/> | aarch64 | [era-test-node-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/era_test_node-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz) | 
           | <img src="https://simpleicons.org/icons/apple.svg" style="width: 32px;"/> | x86_64 | [era-test-node-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/era_test_node-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz) | 
           | <img src="https://simpleicons.org/icons/apple.svg" style="width: 32px;"/> | aarch64 | [era-test-node-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/era_test_node-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz) |
           | | | | 
@@ -179,4 +178,4 @@ jobs:
               assets+=("$asset/$asset")
           done
           tag_name="${{ env.VERSION }}"
-          echo "$body" | gh release create "$tag_name" "${assets[@]}" --draft -F "-"
+          echo "$body" | gh release create "$tag_name" "${assets[@]}" --draft -F "-" -t "Release: $tag_name"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
           )
           assets=()
           for asset in ./era_test_node-*.tar.gz*; do
-              assets+=("-a" "$asset/$asset")
+              assets+=("$asset/$asset")
           done
           tag_name="${{ env.VERSION }}"
-          echo "$body" | gh release create --draft "${assets[@]}" -F "-" "$tag_name"
+          echo "$body" | gh release create "$tag_name" "${assets[@]}" --draft -F "-"


### PR DESCRIPTION
# What :computer: 
* Fix `gh` CLI command for creating GitHub Release drafts

# Why :hand:
* It's currently broken as the previous `hub` CLI tool accepted `-a <file_name>`

# Evidence :camera:
Validated with release on my personal fork: https://github.com/MexicanAce/era-test-node/releases/tag/v0.0.3-nick

NOTE: Release drafts will NOT properly have a tag in the release URL. So the links to download the binaries in the table only work one the Release has been published 
