### PR TITLE
chore: updates zksync dep, and replaces vm with multivm crate

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -16,14 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest nightly
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-07-23
           components: rustfmt, clippy
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
 
       - uses: actions/setup-node@v3
         with:
@@ -45,12 +42,9 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+          toolchain: nightly-2023-07-23
 
       - name: Build Code
         run: make all

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Install Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly-2023-07-23
+        toolchain: nightly-2023-07-21
     
     - name: Install cargo-nextest
       run: cargo install cargo-nextest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+
 jobs:
   test:
     name: unit-tests
@@ -30,3 +31,21 @@ jobs:
         
     - name: Run tests
       run: cargo nextest run
+
+    - name: System Info (Ubuntu)
+      if: always() && startsWith(runner.os, 'Linux')
+      run: |
+        echo "Memory Usage:"
+        free -h
+        echo "CPU Info:"
+        lscpu
+        echo "Disk Space:"
+        df -h
+
+    - name: System Info (macOS)
+      if: always() && startsWith(runner.os, 'macOS')
+      run: |
+        echo "Memory Usage:"
+        vm_stat
+        echo "Disk Space:"
+        df -h

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,12 +21,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with: 
-        toolchain: stable
-
-    - name: Cache Rust Dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: nightly-2023-07-23
     
     - name: Install cargo-nextest
       run: cargo +stable install cargo-nextest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     name: unit-tests
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest, ubuntu-22.04-github-hosted-16core]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     name: unit-tests
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, ubuntu-22.04-github-hosted-16core]
+        platform: [macos-latest, ubuntu-22.04-github-hosted-16core]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -31,21 +31,3 @@ jobs:
         
     - name: Run tests
       run: cargo nextest run
-
-    - name: System Info (Ubuntu)
-      if: always() && startsWith(runner.os, 'Linux')
-      run: |
-        echo "Memory Usage:"
-        free -h
-        echo "CPU Info:"
-        lscpu
-        echo "Disk Space:"
-        df -h
-
-    - name: System Info (macOS)
-      if: always() && startsWith(runner.os, 'macOS')
-      run: |
-        echo "Memory Usage:"
-        vm_stat
-        echo "Disk Space:"
-        df -h

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
         toolchain: nightly-2023-07-23
     
     - name: Install cargo-nextest
-      run: cargo +stable install cargo-nextest
+      run: cargo install cargo-nextest
         
     - name: Run tests
       run: cargo nextest run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
  "actix-utils",
  "ahash 0.8.3",
  "base64 0.21.4",
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "brotli",
  "bytes 1.5.0",
  "bytestring",
@@ -129,7 +129,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio 0.8.8",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio",
  "tracing",
 ]
@@ -190,7 +190,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "time",
  "url",
 ]
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb42b2197bf15ccb092b62c74515dbd8b86d0effd934795f6687c93b6e679a2c"
+checksum = "f658e2baef915ba0f26f1f7c42bfb8e12f532a01f449a090ded75ae7a07e9ba2"
 dependencies = [
  "brotli",
  "flate2",
@@ -481,8 +481,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "zstd 0.12.4",
- "zstd-safe 6.0.6",
+ "zstd 0.13.0",
+ "zstd-safe 7.0.0",
 ]
 
 [[package]]
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
@@ -712,7 +712,7 @@ source = "git+https://github.com/matter-labs/bellman?branch=dev#5520aa2274afe73d
 dependencies = [
  "arrayvec 0.7.4",
  "bit-vec",
- "blake2s_const",
+ "blake2s_const 0.6.0 (git+https://github.com/matter-labs/bellman?branch=dev)",
  "blake2s_simd",
  "byteorder",
  "cfg-if 1.0.0",
@@ -721,7 +721,30 @@ dependencies = [
  "hex",
  "lazy_static",
  "num_cpus",
- "pairing_ce",
+ "pairing_ce 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6",
+ "serde",
+ "smallvec",
+ "tiny-keccak 1.5.0",
+]
+
+[[package]]
+name = "bellman_ce"
+version = "0.3.2"
+source = "git+https://github.com/matter-labs/bellman?branch=snark-wrapper#e01e5fa08a97a113e76ec8a69d06fe6cc2c82d17"
+dependencies = [
+ "arrayvec 0.7.4",
+ "bit-vec",
+ "blake2s_const 0.6.0 (git+https://github.com/matter-labs/bellman?branch=snark-wrapper)",
+ "blake2s_simd",
+ "byteorder",
+ "cfg-if 1.0.0",
+ "crossbeam 0.7.3",
+ "futures 0.3.28",
+ "hex",
+ "lazy_static",
+ "num_cpus",
+ "pairing_ce 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6",
  "serde",
  "smallvec",
@@ -796,9 +819,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitvec"
@@ -845,6 +868,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "git+https://github.com/RustCrypto/hashes.git?rev=1f727ce37ff40fa0cce84eb8543a45bdd3ca4a4e#1f727ce37ff40fa0cce84eb8543a45bdd3ca4a4e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "blake2-rfc_bellman_edition"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +890,16 @@ dependencies = [
 name = "blake2s_const"
 version = "0.6.0"
 source = "git+https://github.com/matter-labs/bellman?branch=dev#5520aa2274afe73d281373c92b007a2ecdebfbea"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_const"
+version = "0.6.0"
+source = "git+https://github.com/matter-labs/bellman?branch=snark-wrapper#e01e5fa08a97a113e76ec8a69d06fe6cc2c82d17"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
@@ -933,6 +974,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "boojum"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/era-boojum.git?branch=main#84754b066959c8fdfb77edf730fc13ed87404907"
+dependencies = [
+ "arrayvec 0.7.4",
+ "bincode",
+ "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "const_format",
+ "convert_case 0.6.0",
+ "crossbeam 0.8.2",
+ "crypto-bigint 0.5.3",
+ "cs_derive 0.1.0 (git+https://github.com/matter-labs/era-boojum.git?branch=main)",
+ "derivative",
+ "ethereum-types 0.14.1",
+ "firestorm",
+ "itertools 0.10.5",
+ "lazy_static",
+ "num-modular",
+ "num_cpus",
+ "packed_simd",
+ "pairing_ce 0.28.5 (git+https://github.com/matter-labs/pairing.git)",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "sha2 0.10.8",
+ "sha3 0.10.6 (git+https://github.com/RustCrypto/hashes.git?rev=7a187e934c1f6c68e4b4e5cf37541b7a0d64d303)",
+ "smallvec",
+ "unroll",
+]
+
+[[package]]
 name = "brotli"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,7 +1031,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "tinyvec",
 ]
 
@@ -1174,11 +1246,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "circuit_definitions"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#43aeb53d7d9c909508a98f9fc140edff0e9d2357"
+dependencies = [
+ "crossbeam 0.8.2",
+ "derivative",
+ "serde",
+ "snark_wrapper",
+ "zk_evm 1.4.0",
+ "zkevm_circuits",
+]
+
+[[package]]
 name = "circuit_testing"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/era-circuit_testing.git?branch=main#164c0adac85be39ee44bd9456b2b91cdede5af80"
 dependencies = [
- "bellman_ce",
+ "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
 ]
 
 [[package]]
@@ -1262,11 +1347,11 @@ version = "0.1.0"
 source = "git+https://github.com/matter-labs/solidity_plonk_verifier.git?branch=dev#82f96b7156551087f1c9bfe4f0ea68845b6debfc"
 dependencies = [
  "ethereum-types 0.14.1",
- "franklin-crypto",
+ "franklin-crypto 0.0.5 (git+https://github.com/matter-labs/franklin-crypto?branch=dev)",
  "handlebars",
  "hex",
  "paste",
- "rescue_poseidon",
+ "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon)",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1293,7 +1378,7 @@ dependencies = [
  "hmac 0.12.1",
  "k256 0.13.1",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -1309,7 +1394,7 @@ dependencies = [
  "once_cell",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -1328,8 +1413,8 @@ dependencies = [
  "ripemd",
  "serde",
  "serde_derive",
- "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha2 0.10.8",
+ "sha3 0.10.6 (git+https://github.com/RustCrypto/hashes?tag=sha3-v0.10.6)",
  "thiserror",
 ]
 
@@ -1385,6 +1470,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "unicode-xid 0.2.4",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,9 +1539,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "3fbc60abd742b35f2492f808e1abbb83d45f72db402e14c55057edc9c7b1e9e4"
 dependencies = [
  "libc",
 ]
@@ -1677,7 +1782,18 @@ dependencies = [
 [[package]]
 name = "cs_derive"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-sync_vm.git?branch=v1.3.3#3a21c8dee43c77604350fdf33c1615e25bf1dacd"
+source = "git+https://github.com/matter-labs/era-boojum.git?branch=main#84754b066959c8fdfb77edf730fc13ed87404907"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cs_derive"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/era-sync_vm.git?branch=v1.3.3#dad50e7eb7462a3819af8d5209d6ca243395bf51"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.69",
@@ -1756,10 +1872,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.2",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.8",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -1775,7 +1891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "serde",
- "uuid 1.4.1",
+ "uuid 1.5.0",
 ]
 
 [[package]]
@@ -1811,10 +1927,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -2073,7 +2190,7 @@ dependencies = [
  "rand 0.8.5",
  "rlp",
  "serde",
- "sha3 0.10.6",
+ "sha3 0.10.6 (git+https://github.com/RustCrypto/hashes?tag=sha3-v0.10.6)",
  "zeroize",
 ]
 
@@ -2120,7 +2237,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "era_test_node"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.8"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -2141,17 +2258,18 @@ dependencies = [
  "jsonrpc-http-server",
  "lazy_static",
  "maplit",
+ "multivm",
  "once_cell",
  "openssl-sys",
  "reqwest",
  "rustc-hash",
  "serde",
  "serde_json",
+ "sha3 0.10.6 (git+https://github.com/RustCrypto/hashes?tag=sha3-v0.10.6)",
  "tempdir",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vm",
  "zksync-web3-rs",
  "zksync_basic_types",
  "zksync_contracts",
@@ -2197,8 +2315,8 @@ dependencies = [
  "scrypt 0.10.0",
  "serde",
  "serde_json",
- "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha2 0.10.8",
+ "sha3 0.10.6 (git+https://github.com/RustCrypto/hashes?tag=sha3-v0.10.6)",
  "thiserror",
  "uuid 0.8.2",
 ]
@@ -2230,7 +2348,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha3 0.10.6",
+ "sha3 0.10.6 (git+https://github.com/RustCrypto/hashes?tag=sha3-v0.10.6)",
  "thiserror",
  "uint",
 ]
@@ -2295,9 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "2.0.8"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b4026b97da8281276744741fac7eb385da905f6093c583331fa2953fdd4253"
+checksum = "1ad13497f6e0a24292fc7b408e30d22fe9dc262da1f40d7b542c3a44e7fc0476"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -2427,9 +2545,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "2.0.8"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c339aad74ae5c451d27e0e49c7a3c7d22620b119b4f9291d7aa21f72d7f366"
+checksum = "473f1ccd0c793871bbc248729fa8df7e6d2981d6226e4343e3bbaa9281074d5d"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2491,19 +2609,19 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.8"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4864d387456a9c09a1157fa10e1528b29d90f1d859443acf06a1b23365fb518c"
+checksum = "5ea44bec930f12292866166f9ddbea6aa76304850e4d8dcd66dc492b43d00ff1"
 dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
+ "const-hex",
  "elliptic-curve 0.13.6",
  "eth-keystore",
  "ethers-core",
- "hex",
  "rand 0.8.5",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "thiserror",
  "tracing",
 ]
@@ -2644,6 +2762,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
+name = "firestorm"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5f6c2c942da57e2aaaa84b8a521489486f14e75e7fa91dab70aba913975f98"
+
+[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2675,9 +2799,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2719,12 +2843,44 @@ version = "0.0.5"
 source = "git+https://github.com/matter-labs/franklin-crypto?branch=dev#5695d07c7bc604c2c39a27712ffac171d39ee1ed"
 dependencies = [
  "arr_macro",
- "bellman_ce",
+ "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
  "bit-vec",
  "blake2 0.9.2",
  "blake2-rfc_bellman_edition",
  "blake2s_simd",
  "byteorder",
+ "digest 0.9.0",
+ "hex",
+ "indexmap 1.9.3",
+ "itertools 0.10.5",
+ "lazy_static",
+ "num-bigint 0.4.4",
+ "num-derive 0.2.5",
+ "num-integer",
+ "num-traits",
+ "rand 0.4.6",
+ "serde",
+ "sha2 0.9.9",
+ "sha3 0.9.1",
+ "smallvec",
+ "splitmut",
+ "tiny-keccak 1.5.0",
+]
+
+[[package]]
+name = "franklin-crypto"
+version = "0.0.5"
+source = "git+https://github.com/matter-labs/franklin-crypto?branch=snark_wrapper#900332b8c2fe528b5008bb4e6bf2d3f206a9ae56"
+dependencies = [
+ "arr_macro",
+ "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=snark-wrapper)",
+ "bit-vec",
+ "blake2 0.9.2",
+ "blake2-rfc_bellman_edition",
+ "blake2s_simd",
+ "boojum",
+ "byteorder",
+ "derivative",
  "digest 0.9.0",
  "hex",
  "indexmap 1.9.3",
@@ -3092,7 +3248,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "thiserror",
  "time",
  "tokio",
@@ -3207,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "hashers"
@@ -3435,7 +3591,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3473,16 +3629,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -3589,7 +3745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -3996,7 +4152,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
- "sha2 0.10.6",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -4009,7 +4165,7 @@ dependencies = [
  "ecdsa 0.16.8",
  "elliptic-curve 0.13.6",
  "once_cell",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "signature 2.1.0",
 ]
 
@@ -4179,9 +4335,9 @@ checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg 1.1.0",
  "scopeguard",
@@ -4437,16 +4593,20 @@ dependencies = [
 [[package]]
 name = "multivm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
- "vlog",
- "vm",
- "vm_1_3_2",
- "vm_m5",
- "vm_m6",
- "vm_virtual_blocks",
+ "anyhow",
+ "hex",
+ "itertools 0.10.5",
+ "once_cell",
+ "thiserror",
+ "tracing",
+ "vise",
+ "zk_evm 1.3.1",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc1)",
  "zksync_contracts",
  "zksync_state",
+ "zksync_system_constants",
  "zksync_types",
  "zksync_utils",
 ]
@@ -4492,7 +4652,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cfg-if 1.0.0",
  "libc",
 ]
@@ -4667,6 +4827,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-modular"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4811,7 +4981,7 @@ version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -4883,10 +5053,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "packed_simd"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9f08af0c877571712e2e3e686ad79efad9657dbf0f7c3c8ba943ff6c38932d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num-traits",
+]
+
+[[package]]
 name = "pairing_ce"
 version = "0.28.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db007b21259660d025918e653508f03050bf23fb96a88601f9936329faadc597"
+dependencies = [
+ "byteorder",
+ "cfg-if 1.0.0",
+ "ff_ce",
+ "rand 0.4.6",
+ "serde",
+]
+
+[[package]]
+name = "pairing_ce"
+version = "0.28.5"
+source = "git+https://github.com/matter-labs/pairing.git#d06c2a112913b0abfb75996cc29a6b6075717e99"
 dependencies = [
  "byteorder",
  "cfg-if 1.0.0",
@@ -5007,7 +5199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.8",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -5026,13 +5218,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets",
 ]
@@ -5101,7 +5293,7 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
  "password-hash 0.4.2",
- "sha2 0.10.6",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -5186,7 +5378,7 @@ checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.6",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -5347,6 +5539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5488,12 +5686,13 @@ dependencies = [
 [[package]]
 name = "prometheus_exporter"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "anyhow",
  "metrics",
  "metrics-exporter-prometheus",
  "tokio",
+ "vise",
  "vise-exporter",
 ]
 
@@ -5817,6 +6016,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5829,14 +6037,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.0"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.1",
- "regex-syntax 0.8.1",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -5850,13 +6058,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.1",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -5873,9 +6081,9 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "remove_dir_all"
@@ -5935,13 +6143,35 @@ dependencies = [
 [[package]]
 name = "rescue_poseidon"
 version = "0.4.1"
+source = "git+https://github.com/matter-labs/rescue-poseidon.git?branch=poseidon2#c4a788471710bdb7aa0f59e8756b45ef93cdd2b2"
+dependencies = [
+ "addchain",
+ "arrayvec 0.7.4",
+ "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "derivative",
+ "franklin-crypto 0.0.5 (git+https://github.com/matter-labs/franklin-crypto?branch=snark_wrapper)",
+ "log",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.4.6",
+ "serde",
+ "sha3 0.9.1",
+ "smallvec",
+]
+
+[[package]]
+name = "rescue_poseidon"
+version = "0.4.1"
 source = "git+https://github.com/matter-labs/rescue-poseidon#d059b5042df5ed80e151f05751410b524a54d16c"
 dependencies = [
  "addchain",
  "arrayvec 0.7.4",
- "blake2 0.10.6",
+ "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder",
- "franklin-crypto",
+ "franklin-crypto 0.0.5 (git+https://github.com/matter-labs/franklin-crypto?branch=dev)",
  "num-bigint 0.3.3",
  "num-integer",
  "num-iter",
@@ -6089,11 +6319,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.18"
+version = "0.38.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a74ee2d7c2581cd139b42447d7d9389b889bdaad3a73f1ebb16f2a3237bb19c"
+checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -6184,9 +6414,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0a159d0c45c12b20c5a844feb1fe4bea86e28f17b92a5f0c42193634d3782"
+checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "cfg-if 1.0.0",
  "derive_more",
@@ -6196,9 +6426,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
+checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2 1.0.69",
@@ -6246,7 +6476,7 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "salsa20 0.10.2",
- "sha2 0.10.6",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -6473,23 +6703,23 @@ dependencies = [
  "thiserror",
  "time",
  "url",
- "uuid 1.4.1",
+ "uuid 1.5.0",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
@@ -6624,8 +6854,18 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.6"
+source = "git+https://github.com/RustCrypto/hashes.git?rev=1731ced4a116d61ba9dc6ee6d0f38fb8102e357a#1731ced4a116d61ba9dc6ee6d0f38fb8102e357a"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -6647,8 +6887,16 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+source = "git+https://github.com/RustCrypto/hashes?tag=sha3-v0.10.6#7a187e934c1f6c68e4b4e5cf37541b7a0d64d303"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.6"
+source = "git+https://github.com/RustCrypto/hashes.git?rev=7a187e934c1f6c68e4b4e5cf37541b7a0d64d303#7a187e934c1f6c68e4b4e5cf37541b7a0d64d303"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -6751,12 +6999,25 @@ name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "snark_wrapper"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/snark-wrapper.git?branch=main#52f9ef98a7e6c86b405dd0ec42291dacf6e2bcb4"
+dependencies = [
+ "derivative",
+ "rand 0.4.6",
+ "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon.git?branch=poseidon2)",
+]
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -6764,9 +7025,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys",
@@ -6907,7 +7168,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha-1 0.10.1",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "smallvec",
  "sqlformat",
  "sqlx-rt",
@@ -6933,7 +7194,7 @@ dependencies = [
  "quote 1.0.33",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "sqlx-core",
  "sqlx-rt",
  "syn 1.0.109",
@@ -7039,7 +7300,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros 0.25.2",
+ "strum_macros 0.25.3",
 ]
 
 [[package]]
@@ -7057,9 +7318,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.69",
@@ -7088,7 +7349,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "thiserror",
  "url",
  "zip",
@@ -7130,12 +7391,12 @@ dependencies = [
 [[package]]
 name = "sync_vm"
 version = "1.3.3"
-source = "git+https://github.com/matter-labs/era-sync_vm.git?branch=v1.3.3#3a21c8dee43c77604350fdf33c1615e25bf1dacd"
+source = "git+https://github.com/matter-labs/era-sync_vm.git?branch=v1.3.3#dad50e7eb7462a3819af8d5209d6ca243395bf51"
 dependencies = [
  "arrayvec 0.7.4",
- "cs_derive",
+ "cs_derive 0.1.0 (git+https://github.com/matter-labs/era-sync_vm.git?branch=v1.3.3)",
  "derivative",
- "franklin-crypto",
+ "franklin-crypto 0.0.5 (git+https://github.com/matter-labs/franklin-crypto?branch=dev)",
  "hex",
  "itertools 0.10.5",
  "num-bigint 0.4.4",
@@ -7144,12 +7405,12 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rand 0.4.6",
- "rescue_poseidon",
+ "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon)",
  "serde",
- "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha2 0.10.8",
+ "sha3 0.10.6 (git+https://github.com/RustCrypto/hashes.git?rev=7a187e934c1f6c68e4b4e5cf37541b7a0d64d303)",
  "smallvec",
- "zk_evm 1.3.3",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3)",
  "zkevm_opcode_defs 1.3.2",
 ]
 
@@ -7228,22 +7489,22 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "test-log"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9601d162c1d77e62c1ea0bc8116cd1caf143ce3af947536c3c9052a1677fe0c"
+checksum = "f66edd6b6cd810743c0c71e1d085e92b01ce6a72782032e3f794c8284fe4bcdd"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -7257,18 +7518,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
@@ -7287,12 +7548,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -7360,7 +7622,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys",
 ]
@@ -7534,7 +7796,7 @@ checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "async-compression",
  "base64 0.21.4",
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "bytes 1.5.0",
  "futures-core",
  "futures-util",
@@ -7553,7 +7815,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "uuid 1.4.1",
+ "uuid 1.5.0",
 ]
 
 [[package]]
@@ -7570,11 +7832,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -7583,9 +7844,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
@@ -7594,9 +7855,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -7781,6 +8042,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unroll"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad948c1cb799b1a70f836077721a92a35ac177d4daddf4c20a633786d4cf618"
+dependencies = [
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7841,9 +8112,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "getrandom 0.2.10",
  "serde",
@@ -7876,7 +8147,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vise"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vise.git?rev=9d097ab747b037b6e62504df1db5b975425b6bdd#9d097ab747b037b6e62504df1db5b975425b6bdd"
+source = "git+https://github.com/matter-labs/vise.git?rev=dd05139b76ab0843443ab3ff730174942c825dae#dd05139b76ab0843443ab3ff730174942c825dae"
 dependencies = [
  "elsa",
  "linkme",
@@ -7888,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "vise-exporter"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vise.git?rev=9d097ab747b037b6e62504df1db5b975425b6bdd#9d097ab747b037b6e62504df1db5b975425b6bdd"
+source = "git+https://github.com/matter-labs/vise.git?rev=dd05139b76ab0843443ab3ff730174942c825dae#dd05139b76ab0843443ab3ff730174942c825dae"
 dependencies = [
  "hyper",
  "metrics-exporter-prometheus",
@@ -7901,7 +8172,7 @@ dependencies = [
 [[package]]
 name = "vise-macros"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vise.git?rev=9d097ab747b037b6e62504df1db5b975425b6bdd#9d097ab747b037b6e62504df1db5b975425b6bdd"
+source = "git+https://github.com/matter-labs/vise.git?rev=dd05139b76ab0843443ab3ff730174942c825dae#dd05139b76ab0843443ab3ff730174942c825dae"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
@@ -7911,117 +8182,13 @@ dependencies = [
 [[package]]
 name = "vlog"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "chrono",
  "sentry",
  "serde_json",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "vm"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
-dependencies = [
- "anyhow",
- "hex",
- "itertools 0.10.5",
- "once_cell",
- "thiserror",
- "tracing",
- "vise",
- "zk_evm 1.3.3",
- "zksync_config",
- "zksync_contracts",
- "zksync_state",
- "zksync_types",
- "zksync_utils",
-]
-
-[[package]]
-name = "vm_1_3_2"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
-dependencies = [
- "anyhow",
- "ethabi 18.0.0",
- "hex",
- "itertools 0.10.5",
- "once_cell",
- "thiserror",
- "tracing",
- "zk_evm 1.3.3",
- "zkevm-assembly 1.3.2",
- "zksync_config",
- "zksync_contracts",
- "zksync_state",
- "zksync_types",
- "zksync_utils",
-]
-
-[[package]]
-name = "vm_m5"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
-dependencies = [
- "hex",
- "itertools 0.10.5",
- "once_cell",
- "thiserror",
- "tracing",
- "vlog",
- "zk_evm 1.3.1",
- "zksync_config",
- "zksync_contracts",
- "zksync_crypto",
- "zksync_state",
- "zksync_storage",
- "zksync_types",
- "zksync_utils",
-]
-
-[[package]]
-name = "vm_m6"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
-dependencies = [
- "hex",
- "itertools 0.10.5",
- "once_cell",
- "thiserror",
- "tracing",
- "vlog",
- "zk_evm 1.3.1",
- "zkevm-assembly 1.3.1",
- "zksync_config",
- "zksync_contracts",
- "zksync_crypto",
- "zksync_state",
- "zksync_storage",
- "zksync_types",
- "zksync_utils",
-]
-
-[[package]]
-name = "vm_virtual_blocks"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
-dependencies = [
- "anyhow",
- "hex",
- "itertools 0.10.5",
- "once_cell",
- "thiserror",
- "tracing",
- "vise",
- "zk_evm 1.3.3",
- "zksync_config",
- "zksync_contracts",
- "zksync_state",
- "zksync_types",
- "zksync_utils",
 ]
 
 [[package]]
@@ -8250,10 +8417,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets",
 ]
@@ -8326,9 +8493,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
+checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
 dependencies = [
  "memchr",
 ]
@@ -8422,16 +8589,16 @@ dependencies = [
 [[package]]
 name = "zk_evm"
 version = "1.3.1"
-source = "git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.1-rc0#877ba31cc1d82316fd924e8d83a9f5f1a77b1b9a"
+source = "git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.1-rc2#0a7c775932db4839ff6b7fb0db9bdb3583ab54c0"
 dependencies = [
- "blake2 0.10.6",
+ "blake2 0.10.6 (git+https://github.com/RustCrypto/hashes.git?rev=1f727ce37ff40fa0cce84eb8543a45bdd3ca4a4e)",
  "k256 0.11.6",
  "lazy_static",
  "num 0.4.1",
  "serde",
  "serde_json",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3 0.10.6 (git+https://github.com/RustCrypto/hashes.git?rev=7a187e934c1f6c68e4b4e5cf37541b7a0d64d303)",
  "static_assertions",
  "zkevm_opcode_defs 1.3.1",
 ]
@@ -8439,7 +8606,37 @@ dependencies = [
 [[package]]
 name = "zk_evm"
 version = "1.3.3"
-source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3#fe8215a7047d24430ad470cf15a19bedb4d6ba0b"
+source = "git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc1#fe8215a7047d24430ad470cf15a19bedb4d6ba0b"
+dependencies = [
+ "anyhow",
+ "lazy_static",
+ "num 0.4.1",
+ "serde",
+ "serde_json",
+ "static_assertions",
+ "zk_evm_abstractions",
+ "zkevm_opcode_defs 1.3.2",
+]
+
+[[package]]
+name = "zk_evm"
+version = "1.3.3"
+source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3#fbee20f5bac7d6ca3e22ae69b2077c510a07de4e"
+dependencies = [
+ "anyhow",
+ "lazy_static",
+ "num 0.4.1",
+ "serde",
+ "serde_json",
+ "static_assertions",
+ "zk_evm_abstractions",
+ "zkevm_opcode_defs 1.3.2",
+]
+
+[[package]]
+name = "zk_evm"
+version = "1.4.0"
+source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.4.0#dd76fc5badf2c05278a21b38015a7798fe2fe358"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -8464,25 +8661,6 @@ dependencies = [
 
 [[package]]
 name = "zkevm-assembly"
-version = "1.3.1"
-source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?tag=v1.3.1-rc0#dabbb07e84dd886ee90dde2b5dde0acbf9b0123a"
-dependencies = [
- "env_logger 0.9.3",
- "hex",
- "lazy_static",
- "log",
- "nom",
- "num-bigint 0.4.4",
- "num-traits",
- "sha3 0.10.6",
- "smallvec",
- "structopt",
- "thiserror",
- "zkevm_opcode_defs 1.3.1",
-]
-
-[[package]]
-name = "zkevm-assembly"
 version = "1.3.2"
 source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2#3c61d450cbe6548068be8f313ed02f1bd229a865"
 dependencies = [
@@ -8493,10 +8671,30 @@ dependencies = [
  "nom",
  "num-bigint 0.4.4",
  "num-traits",
- "sha3 0.10.6",
+ "sha3 0.10.6 (git+https://github.com/RustCrypto/hashes?tag=sha3-v0.10.6)",
  "smallvec",
  "structopt",
  "thiserror",
+ "zkevm_opcode_defs 1.3.2",
+]
+
+[[package]]
+name = "zkevm_circuits"
+version = "1.4.0"
+source = "git+https://github.com/matter-labs/era-zkevm_circuits.git?branch=main#4fba537ccecc238e2da9c80844dc8c185e42466f"
+dependencies = [
+ "arrayvec 0.7.4",
+ "bincode",
+ "boojum",
+ "cs_derive 0.1.0 (git+https://github.com/matter-labs/era-boojum.git?branch=main)",
+ "derivative",
+ "hex",
+ "itertools 0.10.5",
+ "rand 0.4.6",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "smallvec",
  "zkevm_opcode_defs 1.3.2",
 ]
 
@@ -8508,21 +8706,21 @@ dependencies = [
  "bitflags 1.3.2",
  "ethereum-types 0.14.1",
  "lazy_static",
- "sha2 0.10.6",
+ "sha2 0.10.8",
 ]
 
 [[package]]
 name = "zkevm_opcode_defs"
 version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zkevm_opcode_defs.git?branch=v1.3.2#c7ab62f4c60b27dfc690c3ab3efb5fff1ded1a25"
+source = "git+https://github.com/matter-labs/era-zkevm_opcode_defs.git?branch=v1.3.2#dffacadeccdfdbff4bc124d44c595c4a6eae5013"
 dependencies = [
- "bitflags 2.4.0",
- "blake2 0.10.6",
+ "bitflags 2.4.1",
+ "blake2 0.10.6 (git+https://github.com/RustCrypto/hashes.git?rev=1f727ce37ff40fa0cce84eb8543a45bdd3ca4a4e)",
  "ethereum-types 0.14.1",
  "k256 0.11.6",
  "lazy_static",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3 0.10.6 (git+https://github.com/RustCrypto/hashes.git?rev=7a187e934c1f6c68e4b4e5cf37541b7a0d64d303)",
 ]
 
 [[package]]
@@ -8548,8 +8746,31 @@ dependencies = [
  "sync_vm",
  "test-log",
  "tracing",
- "zk_evm 1.3.3",
- "zkevm-assembly 1.3.2",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3)",
+ "zkevm-assembly",
+]
+
+[[package]]
+name = "zkevm_test_harness"
+version = "1.4.0"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#43aeb53d7d9c909508a98f9fc140edff0e9d2357"
+dependencies = [
+ "bincode",
+ "circuit_definitions",
+ "codegen 0.2.0",
+ "crossbeam 0.8.2",
+ "derivative",
+ "env_logger 0.10.0",
+ "hex",
+ "rand 0.4.6",
+ "rayon",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "structopt",
+ "test-log",
+ "tracing",
+ "zkevm-assembly",
 ]
 
 [[package]]
@@ -8576,7 +8797,7 @@ dependencies = [
 [[package]]
 name = "zksync_basic_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "serde",
  "serde_json",
@@ -8586,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "zksync_circuit_breaker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8607,9 +8828,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "zksync_commitment_utils"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+dependencies = [
+ "zkevm_test_harness 1.4.0",
+ "zksync_types",
+ "zksync_utils",
+]
+
+[[package]]
 name = "zksync_config"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -8628,7 +8859,7 @@ dependencies = [
 [[package]]
 name = "zksync_contracts"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "envy",
  "ethabi 18.0.0",
@@ -8642,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "zksync_core"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "actix-cors",
  "actix-rt",
@@ -8678,9 +8909,10 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "vise",
  "vlog",
- "vm",
  "zksync_circuit_breaker",
+ "zksync_commitment_utils",
  "zksync_config",
  "zksync_contracts",
  "zksync_dal",
@@ -8695,6 +8927,7 @@ dependencies = [
  "zksync_queued_job_processor",
  "zksync_state",
  "zksync_storage",
+ "zksync_system_constants",
  "zksync_types",
  "zksync_utils",
  "zksync_verification_key_generator_and_server",
@@ -8704,10 +8937,10 @@ dependencies = [
 [[package]]
 name = "zksync_crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "base64 0.13.1",
- "blake2 0.10.6",
+ "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "once_cell",
  "serde",
@@ -8719,7 +8952,7 @@ dependencies = [
 [[package]]
 name = "zksync_dal"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -8736,9 +8969,9 @@ dependencies = [
  "tokio",
  "tracing",
  "vise",
- "zksync_config",
  "zksync_contracts",
  "zksync_health_check",
+ "zksync_system_constants",
  "zksync_types",
  "zksync_utils",
 ]
@@ -8746,7 +8979,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_client"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8766,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_signer"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "async-trait",
  "hex",
@@ -8785,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "zksync_health_check"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -8798,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "zksync_mempool"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "tracing",
  "zksync_types",
@@ -8807,7 +9040,7 @@ dependencies = [
 [[package]]
 name = "zksync_merkle_tree"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "leb128",
  "once_cell",
@@ -8823,7 +9056,7 @@ dependencies = [
 [[package]]
 name = "zksync_mini_merkle_tree"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -8833,7 +9066,7 @@ dependencies = [
 [[package]]
 name = "zksync_object_store"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8851,7 +9084,7 @@ dependencies = [
 [[package]]
 name = "zksync_prover_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8871,7 +9104,7 @@ dependencies = [
 [[package]]
 name = "zksync_queued_job_processor"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8883,7 +9116,7 @@ dependencies = [
 [[package]]
 name = "zksync_state"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
@@ -8900,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "zksync_storage"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "num_cpus",
  "once_cell",
@@ -8910,11 +9143,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "zksync_system_constants"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+dependencies = [
+ "anyhow",
+ "bigdecimal",
+ "hex",
+ "num 0.3.1",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "url",
+ "zksync_basic_types",
+ "zksync_contracts",
+ "zksync_utils",
+]
+
+[[package]]
 name = "zksync_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
- "blake2 0.10.6",
+ "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
  "codegen 0.1.0",
  "ethereum-types 0.12.1",
@@ -8929,19 +9180,19 @@ dependencies = [
  "serde_with",
  "strum 0.24.1",
  "thiserror",
- "zk_evm 1.3.3",
- "zkevm_test_harness",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc1)",
+ "zkevm_test_harness 1.3.3",
  "zksync_basic_types",
- "zksync_config",
  "zksync_contracts",
  "zksync_mini_merkle_tree",
+ "zksync_system_constants",
  "zksync_utils",
 ]
 
 [[package]]
 name = "zksync_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -8956,14 +9207,14 @@ dependencies = [
  "tokio",
  "tracing",
  "vlog",
- "zk_evm 1.3.3",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc1)",
  "zksync_basic_types",
 ]
 
 [[package]]
 name = "zksync_verification_key_generator_and_server"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8983,7 +9234,7 @@ dependencies = [
 [[package]]
 name = "zksync_web3_decl"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e1deecd697e488831de3133e7507cc1cdb06a141#e1deecd697e488831de3133e7507cc1cdb06a141"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -9015,6 +9266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "zstd"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+dependencies = [
+ "zstd-safe 7.0.0",
+]
+
+[[package]]
 name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9031,6 +9291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.8"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -11,15 +11,15 @@ categories = ["cryptography"]
 publish = false # We don't want to publish our binaries.
 
 [dependencies]
-zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e1deecd697e488831de3133e7507cc1cdb06a141" }
-zksync_core = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e1deecd697e488831de3133e7507cc1cdb06a141" }
-vm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e1deecd697e488831de3133e7507cc1cdb06a141" }
-zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e1deecd697e488831de3133e7507cc1cdb06a141" }
-zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e1deecd697e488831de3133e7507cc1cdb06a141" }
-zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e1deecd697e488831de3133e7507cc1cdb06a141" }
-zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e1deecd697e488831de3133e7507cc1cdb06a141" }
-zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e1deecd697e488831de3133e7507cc1cdb06a141" }
-
+zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+zksync_core = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+sha3 = "0.10.6"
 
 
 openssl-sys = { version = "0.9", features = ["vendored"] }
@@ -57,3 +57,6 @@ tempdir = "0.3.7"
 maplit = "1.0.2"
 zksync-web3-rs = "0.1.1"
 ethers = { version = "2.0.4", features = ["rustls"] }
+
+[patch.crates-io]
+sha3 = { git = "https://github.com/RustCrypto/hashes", tag = "sha3-v0.10.6" }

--- a/src/bootloader_debug.rs
+++ b/src/bootloader_debug.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
-use once_cell::sync::OnceCell;
 use multivm::vm_virtual_blocks::{
-    constants::BOOTLOADER_HEAP_PAGE,
-    VmExecutionStopReason, BootloaderState, ExecutionEndTracer, ExecutionProcessing, HistoryMode, VmTracer, ZkSyncVmState, SimpleMemory, DynTracer};
+    constants::BOOTLOADER_HEAP_PAGE, BootloaderState, DynTracer, ExecutionEndTracer,
+    ExecutionProcessing, HistoryMode, SimpleMemory, VmExecutionStopReason, VmTracer, ZkSyncVmState,
+};
+use once_cell::sync::OnceCell;
 use zksync_basic_types::U256;
 use zksync_state::WriteStorage;
 
@@ -101,12 +102,9 @@ fn load_debug_slot<H: HistoryMode>(memory: &SimpleMemory<H>, slot: usize) -> U25
         .value
 }
 
-impl<H: HistoryMode> ExecutionEndTracer<H> for BootloaderDebugTracer {
-    // Implement the methods required by ExecutionEndTracer here
-}
+impl<H: HistoryMode> ExecutionEndTracer<H> for BootloaderDebugTracer {}
 
-impl<S: WriteStorage, H: HistoryMode> VmTracer<S, H> for BootloaderDebugTracer {
-}
+impl<S: WriteStorage, H: HistoryMode> VmTracer<S, H> for BootloaderDebugTracer {}
 
 impl BootloaderDebug {
     pub fn load_from_memory<H: HistoryMode>(

--- a/src/bootloader_debug.rs
+++ b/src/bootloader_debug.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
 
 use once_cell::sync::OnceCell;
-use vm::{
-    constants::BOOTLOADER_HEAP_PAGE, BootloaderState, DynTracer, ExecutionEndTracer,
-    ExecutionProcessing, HistoryMode, SimpleMemory, VmExecutionResultAndLogs,
-    VmExecutionStopReason, VmTracer, ZkSyncVmState,
-};
+use multivm::vm_virtual_blocks::{
+    constants::BOOTLOADER_HEAP_PAGE,
+    VmExecutionStopReason, BootloaderState, ExecutionEndTracer, ExecutionProcessing, HistoryMode, VmTracer, ZkSyncVmState, SimpleMemory, DynTracer};
 use zksync_basic_types::U256;
 use zksync_state::WriteStorage;
 
@@ -84,8 +82,6 @@ pub struct BootloaderDebugTracer {
 
 impl<S, H: HistoryMode> DynTracer<S, H> for BootloaderDebugTracer {}
 
-impl<H: HistoryMode> ExecutionEndTracer<H> for BootloaderDebugTracer {}
-
 impl<S: WriteStorage, H: HistoryMode> ExecutionProcessing<S, H> for BootloaderDebugTracer {
     fn after_vm_execution(
         &mut self,
@@ -105,8 +101,11 @@ fn load_debug_slot<H: HistoryMode>(memory: &SimpleMemory<H>, slot: usize) -> U25
         .value
 }
 
+impl<H: HistoryMode> ExecutionEndTracer<H> for BootloaderDebugTracer {
+    // Implement the methods required by ExecutionEndTracer here
+}
+
 impl<S: WriteStorage, H: HistoryMode> VmTracer<S, H> for BootloaderDebugTracer {
-    fn save_results(&mut self, _result: &mut VmExecutionResultAndLogs) {}
 }
 
 impl BootloaderDebug {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -5,14 +5,9 @@ use crate::{
 };
 use itertools::Itertools;
 use jsonrpc_core::{BoxFuture, Result};
+use multivm::vm_virtual_blocks::{constants::ETH_CALL_GAS_LIMIT, CallTracer, HistoryDisabled, Vm};
 use once_cell::sync::OnceCell;
 use std::sync::{Arc, RwLock};
-use multivm::vm_virtual_blocks::{
-    constants::{ 
-        ETH_CALL_GAS_LIMIT,
-},
-    CallTracer, HistoryDisabled, Vm,
-};
 use zksync_basic_types::H256;
 use zksync_core::api_server::web3::backend_jsonrpc::{
     error::into_jsrpc_error, namespaces::debug::DebugNamespaceT,
@@ -203,7 +198,10 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> DebugNamespaceT
 
             let call_tracer_result = Arc::new(OnceCell::default());
             let tracer = CallTracer::new(call_tracer_result.clone(), HistoryDisabled);
-            let tx_result = vm.inspect(vec![Box::new(tracer)], multivm::interface::VmExecutionMode::OneTx);
+            let tx_result = vm.inspect(
+                vec![Box::new(tracer)],
+                multivm::interface::VmExecutionMode::OneTx,
+            );
 
             let call_traces = if only_top {
                 vec![]

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -7,7 +7,12 @@ use itertools::Itertools;
 use jsonrpc_core::{BoxFuture, Result};
 use once_cell::sync::OnceCell;
 use std::sync::{Arc, RwLock};
-use vm::{constants::ETH_CALL_GAS_LIMIT, CallTracer, HistoryDisabled, TxExecutionMode, Vm};
+use multivm::vm_virtual_blocks::{
+    constants::{ 
+        ETH_CALL_GAS_LIMIT,
+},
+    CallTracer, HistoryDisabled, Vm,
+};
 use zksync_basic_types::H256;
 use zksync_core::api_server::web3::backend_jsonrpc::{
     error::into_jsrpc_error, namespaces::debug::DebugNamespaceT,
@@ -169,7 +174,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> DebugNamespaceT
                 }
             };
 
-            let execution_mode = TxExecutionMode::EthCall;
+            let execution_mode = multivm::interface::TxExecutionMode::EthCall;
             let storage = StorageView::new(&inner.fork_storage).to_rc_ptr();
 
             let bootloader_code = inner.system_contracts.contracts_for_l2_call();
@@ -198,7 +203,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> DebugNamespaceT
 
             let call_tracer_result = Arc::new(OnceCell::default());
             let tracer = CallTracer::new(call_tracer_result.clone(), HistoryDisabled);
-            let tx_result = vm.inspect(vec![Box::new(tracer)], vm::VmExecutionMode::OneTx);
+            let tx_result = vm.inspect(vec![Box::new(tracer)], multivm::interface::VmExecutionMode::OneTx);
 
             let call_traces = if only_top {
                 vec![]

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use crate::fork::block_on;
 use zksync_basic_types::H160;
 
-use vm::VmExecutionResultAndLogs;
+use multivm::interface::VmExecutionResultAndLogs;
 use zksync_types::{vm_trace::Call, StorageLogQuery, StorageLogQueryType, VmEvent};
 
 use lazy_static::lazy_static;
@@ -201,8 +201,8 @@ pub fn print_vm_details(result: &VmExecutionResultAndLogs) {
     );
     tracing::info!("Contracts Used:       {}", result.statistics.contracts_used);
     match &result.result {
-        vm::ExecutionResult::Success { .. } => {}
-        vm::ExecutionResult::Revert { output } => {
+        multivm::interface::ExecutionResult::Success { .. } => {}
+        multivm::interface::ExecutionResult::Revert { output } => {
             tracing::info!("");
             tracing::info!(
                 "{}",
@@ -213,7 +213,7 @@ pub fn print_vm_details(result: &VmExecutionResultAndLogs) {
                 .on_red()
             );
         }
-        vm::ExecutionResult::Halt { reason } => {
+        multivm::interface::ExecutionResult::Halt { reason } => {
             tracing::info!("");
             tracing::info!("{}", format!("\n[!] Halt Reason:    {}", reason).on_red());
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -28,24 +28,20 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use multivm::vm_virtual_blocks::{
-    constants::{ 
-    BLOCK_GAS_LIMIT, BLOCK_OVERHEAD_PUBDATA, ETH_CALL_GAS_LIMIT, MAX_PUBDATA_PER_BLOCK
-},
-utils::{
-    fee::derive_base_fee_and_gas_per_pubdata,
-    l2_blocks::load_last_l2_block,
-    overhead::{derive_overhead, OverheadCoeficients},
-},
-    CallTracer, HistoryDisabled, Vm, VmTracer,
-};
 use multivm::interface::{
-    TxExecutionMode,
-    L1BatchEnv, SystemEnv,
-    ExecutionResult,
+    ExecutionResult, L1BatchEnv, L2BlockEnv, SystemEnv, TxExecutionMode, VmExecutionMode,
     VmExecutionResultAndLogs,
-    L2BlockEnv,
-    VmExecutionMode
+};
+use multivm::vm_virtual_blocks::{
+    constants::{
+        BLOCK_GAS_LIMIT, BLOCK_OVERHEAD_PUBDATA, ETH_CALL_GAS_LIMIT, MAX_PUBDATA_PER_BLOCK,
+    },
+    utils::{
+        fee::derive_base_fee_and_gas_per_pubdata,
+        l2_blocks::load_last_l2_block,
+        overhead::{derive_overhead, OverheadCoeficients},
+    },
+    CallTracer, HistoryDisabled, Vm, VmTracer,
 };
 use zksync_basic_types::{
     web3::{self, signing::keccak256},

--- a/src/system_contracts.rs
+++ b/src/system_contracts.rs
@@ -1,4 +1,4 @@
-use vm::TxExecutionMode;
+use multivm::interface::TxExecutionMode;
 use zksync_contracts::{
     read_playground_batch_bootloader_bytecode, read_proved_batch_bootloader_bytecode,
     read_sys_contract_bytecode, read_zbin_bytecode, BaseSystemContracts, ContractLanguage,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -15,11 +15,8 @@ use httptest::{
     Expectation, Server,
 };
 use itertools::Itertools;
+use multivm::interface::{ExecutionResult, VmExecutionResultAndLogs};
 use std::str::FromStr;
-use multivm::interface::{
-    VmExecutionResultAndLogs,
-    ExecutionResult
-};
 use zksync_basic_types::{H160, U64};
 use zksync_types::api::{BridgeAddresses, DebugCall, DebugCallType, Log};
 use zksync_types::{

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -16,7 +16,10 @@ use httptest::{
 };
 use itertools::Itertools;
 use std::str::FromStr;
-use vm::VmExecutionResultAndLogs;
+use multivm::interface::{
+    VmExecutionResultAndLogs,
+    ExecutionResult
+};
 use zksync_basic_types::{H160, U64};
 use zksync_types::api::{BridgeAddresses, DebugCall, DebugCallType, Log};
 use zksync_types::{
@@ -562,7 +565,7 @@ pub fn default_tx_execution_info() -> TxExecutionInfo {
         batch_number: Default::default(),
         miniblock_number: Default::default(),
         result: VmExecutionResultAndLogs {
-            result: vm::ExecutionResult::Success { output: vec![] },
+            result: ExecutionResult::Success { output: vec![] },
             logs: Default::default(),
             statistics: Default::default(),
             refunds: Default::default(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,8 +3,11 @@ use std::pin::Pin;
 
 use chrono::{DateTime, Utc};
 use futures::Future;
-use vm::{ExecutionResult, VmExecutionResultAndLogs};
-use vm::{HistoryDisabled, Vm};
+use multivm::interface::{ExecutionResult, VmExecutionResultAndLogs};
+use multivm::vm_latest::{
+    HistoryDisabled, Vm,
+    utils::fee::derive_base_fee_and_gas_per_pubdata
+};
 use zksync_basic_types::{U256, U64};
 use zksync_state::StorageView;
 use zksync_state::WriteStorage;
@@ -17,8 +20,6 @@ use zksync_web3_decl::error::Web3Error;
 
 use crate::node::create_empty_block;
 use crate::{fork::ForkSource, node::InMemoryNodeInner};
-use vm::utils::fee::derive_base_fee_and_gas_per_pubdata;
-
 use zksync_utils::{bytecode::hash_bytecode, bytes_to_be_words};
 
 pub(crate) trait IntoBoxedFuture: Sized + Send + 'static {
@@ -120,11 +121,11 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
 
             // init vm
             let system_env =
-                node.create_system_env(bootloader_code.clone(), vm::TxExecutionMode::VerifyExecute);
+                node.create_system_env(bootloader_code.clone(), multivm::interface::TxExecutionMode::VerifyExecute);
 
             let mut vm = Vm::new(batch_env, system_env, storage.clone(), HistoryDisabled);
 
-            vm.execute(vm::VmExecutionMode::Bootloader);
+            vm.execute(multivm::interface::VmExecutionMode::Bootloader);
 
             let bytecodes: HashMap<U256, Vec<U256>> = vm
                 .get_last_tx_compressed_bytecodes()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,10 +4,7 @@ use std::pin::Pin;
 use chrono::{DateTime, Utc};
 use futures::Future;
 use multivm::interface::{ExecutionResult, VmExecutionResultAndLogs};
-use multivm::vm_latest::{
-    HistoryDisabled, Vm,
-    utils::fee::derive_base_fee_and_gas_per_pubdata
-};
+use multivm::vm_latest::{utils::fee::derive_base_fee_and_gas_per_pubdata, HistoryDisabled, Vm};
 use zksync_basic_types::{U256, U64};
 use zksync_state::StorageView;
 use zksync_state::WriteStorage;
@@ -120,8 +117,10 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
             }
 
             // init vm
-            let system_env =
-                node.create_system_env(bootloader_code.clone(), multivm::interface::TxExecutionMode::VerifyExecute);
+            let system_env = node.create_system_env(
+                bootloader_code.clone(),
+                multivm::interface::TxExecutionMode::VerifyExecute,
+            );
 
             let mut vm = Vm::new(batch_env, system_env, storage.clone(), HistoryDisabled);
 

--- a/src/zks.rs
+++ b/src/zks.rs
@@ -603,8 +603,10 @@ mod tests {
         };
 
         let result = namespace.estimate_fee(mock_request).await.unwrap();
-
-        assert_eq!(result.gas_limit, U256::from(730662));
+        // Important: The gas value expectation is tied to a specific zksync-era dependency version.
+        // For the zksync-era commit hash `73a1e8ff564025d06e02c2689da238ae47bb10c3`, the anticipated gas value is 1086383.
+        // If the zksync-era dependency is updated, this expected gas value may need adjustment.
+        assert_eq!(result.gas_limit, U256::from(1086383));
         assert_eq!(result.max_fee_per_gas, U256::from(250000000));
         assert_eq!(result.max_priority_fee_per_gas, U256::from(0));
         assert_eq!(result.gas_per_pubdata_limit, U256::from(4080));


### PR DESCRIPTION
# What :computer: 
* Updates zksync-era deps to `73a1e8ff564025d06e02c2689da238ae47bb10c3` 
* Replaces `vm` with `multivm` 

# Why :hand:
* Downstream dependencies of era-test-node, mainly `era-revm` require latest changes in `multivm` 

# Evidence :camera:
![Screenshot 2023-10-23 at 7 48 28 AM](https://github.com/matter-labs/era-test-node/assets/29983536/02ea1387-28ce-4e13-b8b3-2024cee43d0e)

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

# Notes :memo:
 
