### PR TITLE
chore: add rust toolchain for version mgt

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -19,7 +19,6 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2023-07-23
           components: rustfmt, clippy
 
       - uses: actions/setup-node@v3
@@ -43,8 +42,6 @@ jobs:
       
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly-2023-07-23
 
       - name: Build Code
         run: make all

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,17 +32,16 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly-2023-07-21
+
       - name: Setup Pages
         uses: actions/configure-pages@v3
 
       - name: Install mdbook
-        run: cargo +nightly install mdbook
+        run: cargo install mdbook
       - name: Generate rust docs
         run: |
           echo "Generating docs..."
-          cargo +nightly doc --no-deps
+          cargo doc --no-deps
       - name: Make index.html
         run: echo '<!DOCTYPE HTML>
           <html lang="en-US">

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,7 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly-2023-07-21
+        
       - name: Install target
         run: rustup target add ${{ matrix.arch }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,8 +23,6 @@ jobs:
 
     - name: Install Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: nightly-2023-07-21
     
     - name: Install cargo-nextest
       run: cargo install cargo-nextest

--- a/rust-toolchain.yaml
+++ b/rust-toolchain.yaml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2023-10-24"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
# What :computer: 
* Adds toolchain.yaml to manage rust nightly version
* Updates workflows accordingly

# Why :hand:
* If we are using nightly its best we manage the version being used to prevent inconsistency in builds / clippy errors
* Shouldn't need to specify nightly version if toolchain.yaml is being used

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
