### PR TITLE
feat: add parent hash linking for blocks

### DIFF
--- a/src/node/eth.rs
+++ b/src/node/eth.rs
@@ -490,7 +490,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> EthNamespa
                         from: Some(info.tx.initiator_account()),
                         to: Some(info.tx.recipient_account()),
                         value: info.tx.execute.value,
-                        gas_price: Default::default(),
+                        gas_price: Some(U256::from(0)),
                         gas: Default::default(),
                         input: input_data.data.into(),
                         v: Some(chain_id.into()),

--- a/src/node/eth.rs
+++ b/src/node/eth.rs
@@ -1375,17 +1375,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_node_run_has_genesis_block() {
+    async fn test_node_has_genesis_block() {
         let node = InMemoryNode::<HttpForkSource>::default();
 
         let block = node
             .get_block_by_number(BlockNumber::Latest, false)
             .await
-            .expect("failed fetching block by hash")
+            .expect("failed fetching block by number")
             .expect("no block");
 
         assert_eq!(0, block.number.as_u64());
         assert_eq!(compute_hash(0, H256::zero()), block.hash);
+    }
+
+    #[tokio::test]
+    async fn test_node_creates_genesis_block_with_hash_and_zero_parent_hash() {
+        let node = InMemoryNode::<HttpForkSource>::default();
+
+        let block = node
+            .get_block_by_hash(compute_hash(0, H256::zero()), false)
+            .await
+            .expect("failed fetching block by hash")
+            .expect("no block");
+
+        assert_eq!(block.parent_hash, H256::zero());
+    }
+
+    #[tokio::test]
+    async fn test_node_produces_blocks_with_parent_hash_links() {
+        let node = InMemoryNode::<HttpForkSource>::default();
+        testing::apply_tx(&node, H256::repeat_byte(0x01));
+
+        let genesis_block = node.get_block_by_number(BlockNumber::from(0), false)
+            .await
+            .expect("failed fetching block by number")
+            .expect("no block");
+        let first_block = node.get_block_by_number(BlockNumber::from(1), false)
+            .await
+            .expect("failed fetching block by number")
+            .expect("no block");
+        let second_block = node.get_block_by_number(BlockNumber::from(2), false)
+            .await
+            .expect("failed fetching block by number")
+            .expect("no block");
+
+        assert_eq!(genesis_block.hash, first_block.parent_hash);
+        assert_eq!(first_block.hash, second_block.parent_hash);
     }
 
     #[tokio::test]

--- a/src/node/eth.rs
+++ b/src/node/eth.rs
@@ -1406,15 +1406,18 @@ mod tests {
         let node = InMemoryNode::<HttpForkSource>::default();
         testing::apply_tx(&node, H256::repeat_byte(0x01));
 
-        let genesis_block = node.get_block_by_number(BlockNumber::from(0), false)
+        let genesis_block = node
+            .get_block_by_number(BlockNumber::from(0), false)
             .await
             .expect("failed fetching block by number")
             .expect("no block");
-        let first_block = node.get_block_by_number(BlockNumber::from(1), false)
+        let first_block = node
+            .get_block_by_number(BlockNumber::from(1), false)
             .await
             .expect("failed fetching block by number")
             .expect("no block");
-        let second_block = node.get_block_by_number(BlockNumber::from(2), false)
+        let second_block = node
+            .get_block_by_number(BlockNumber::from(2), false)
             .await
             .expect("failed fetching block by number")
             .expect("no block");
@@ -2577,11 +2580,11 @@ mod tests {
 
         let storage = inner.fork_storage.inner.read().unwrap();
         let expected_snapshot = Snapshot {
-            current_timestamp: inner.current_timestamp.clone(),
-            current_batch: inner.current_batch.clone(),
-            current_miniblock: inner.current_miniblock.clone(),
-            current_miniblock_hash: inner.current_miniblock_hash.clone(),
-            l1_gas_price: inner.l1_gas_price.clone(),
+            current_timestamp: inner.current_timestamp,
+            current_batch: inner.current_batch,
+            current_miniblock: inner.current_miniblock,
+            current_miniblock_hash: inner.current_miniblock_hash,
+            l1_gas_price: inner.l1_gas_price,
             tx_results: inner.tx_results.clone(),
             blocks: inner.blocks.clone(),
             block_hashes: inner.block_hashes.clone(),
@@ -2681,11 +2684,11 @@ mod tests {
         let expected_snapshot = {
             let storage = inner.fork_storage.inner.read().unwrap();
             Snapshot {
-                current_timestamp: inner.current_timestamp.clone(),
-                current_batch: inner.current_batch.clone(),
-                current_miniblock: inner.current_miniblock.clone(),
-                current_miniblock_hash: inner.current_miniblock_hash.clone(),
-                l1_gas_price: inner.l1_gas_price.clone(),
+                current_timestamp: inner.current_timestamp,
+                current_batch: inner.current_batch,
+                current_miniblock: inner.current_miniblock,
+                current_miniblock_hash: inner.current_miniblock_hash,
+                l1_gas_price: inner.l1_gas_price,
                 tx_results: inner.tx_results.clone(),
                 blocks: inner.blocks.clone(),
                 block_hashes: inner.block_hashes.clone(),
@@ -3019,7 +3022,7 @@ mod tests {
             .expect("no transaction");
 
         assert_eq!(input_tx_hash, actual_tx.hash);
-        assert_eq!(Some(U64::from(input_block_number)), actual_tx.block_number);
+        assert_eq!(Some(input_block_number), actual_tx.block_number);
     }
 
     #[tokio::test]
@@ -3045,7 +3048,7 @@ mod tests {
             TransactionResponseBuilder::new()
                 .set_hash(input_tx_hash)
                 .set_block_hash(input_block_hash)
-                .set_block_number(U64::from(input_block_number))
+                .set_block_number(input_block_number)
                 .build(),
         );
 

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -89,10 +89,16 @@ pub fn compute_hash(block_number: u64, tx_hash: H256) -> H256 {
     H256(keccak256(&digest))
 }
 
-pub fn create_empty_block<TX>(block_number: u64, timestamp: u64, batch: u32) -> Block<TX> {
+pub fn create_empty_block<TX>(block_number: u64, timestamp: u64, batch: u32, parent_block_hash: Option<H256>) -> Block<TX> {
     let hash = compute_hash(block_number, H256::zero());
+    let parent_hash = parent_block_hash.unwrap_or(if block_number == 0 {
+        H256::zero()
+    } else {
+        compute_hash(block_number - 1, H256::zero())
+    });
     Block {
         hash,
+        parent_hash,
         number: U64::from(block_number),
         timestamp: U256::from(timestamp),
         l1_batch_number: Some(U64::from(batch)),
@@ -900,11 +906,12 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             }
         } else {
             let mut block_hashes = HashMap::<u64, H256>::new();
-            block_hashes.insert(0, H256::zero());
+            let block_hash = compute_hash(0, H256::zero());
+            block_hashes.insert(0, block_hash);
             let mut blocks = HashMap::<H256, Block<TransactionVariant>>::new();
             blocks.insert(
-                H256::zero(),
-                create_empty_block(0, NON_FORK_FIRST_BLOCK_TIMESTAMP, 0),
+                block_hash,
+                create_empty_block(0, NON_FORK_FIRST_BLOCK_TIMESTAMP, 0, None),
             );
 
             InMemoryNodeInner {
@@ -1418,8 +1425,14 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
         transaction.block_hash = Some(*block_hash);
         transaction.block_number = Some(U64::from(inner.current_miniblock));
 
+        let parent_block_hash = inner
+            .block_hashes
+            .get(&(block_ctx.miniblock -1))
+            .unwrap().clone();
+
         let block = Block {
             hash,
+            parent_hash: parent_block_hash,
             number: U64::from(block_ctx.miniblock),
             timestamp: U256::from(batch_env.timestamp),
             l1_batch_number: Some(U64::from(batch_env.number.0)),
@@ -1535,6 +1548,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             l1_batch_number: block.l1_batch_number,
             from: l2_tx.initiator_account(),
             to: Some(l2_tx.recipient_account()),
+            root: Some(H256::zero()),
             cumulative_gas_used: Default::default(),
             gas_used: Some(l2_tx.common_data.fee.gas_limit - result.refunds.gas_refunded),
             contract_address: contract_address_from_tx_result(&result),
@@ -1586,8 +1600,9 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
         // we are adding one l2 block at the end of each batch (to handle things like remaining events etc).
         //  You can look at insert_fictive_l2_block function in VM to see how this fake block is inserted.
         let block_ctx = block_ctx.new_block();
+        let parent_block_hash = block.hash;
         let empty_block_at_end_of_batch =
-            create_empty_block(block_ctx.miniblock, block_ctx.timestamp, block_ctx.batch);
+            create_empty_block(block_ctx.miniblock, block_ctx.timestamp, block_ctx.batch, Some(parent_block_hash));
 
         inner.current_batch = inner.current_batch.saturating_add(1);
 

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -923,7 +923,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 current_timestamp: NON_FORK_FIRST_BLOCK_TIMESTAMP,
                 current_batch: 0,
                 current_miniblock: 0,
-                current_miniblock_hash: H256::zero(),
+                current_miniblock_hash: block_hash,
                 l1_gas_price: L1_GAS_PRICE,
                 tx_results: Default::default(),
                 blocks,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -153,7 +153,7 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
             )
         }
 
-        let block = create_empty_block(block_ctx.miniblock, block_ctx.timestamp, block_ctx.batch);
+        let block = create_empty_block(block_ctx.miniblock, block_ctx.timestamp, block_ctx.batch, None);
 
         node.block_hashes.insert(block.number.as_u64(), block.hash);
         node.blocks.insert(block.hash, block);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -153,7 +153,12 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
             )
         }
 
-        let block = create_empty_block(block_ctx.miniblock, block_ctx.timestamp, block_ctx.batch, None);
+        let block = create_empty_block(
+            block_ctx.miniblock,
+            block_ctx.timestamp,
+            block_ctx.batch,
+            None,
+        );
 
         node.block_hashes.insert(block.number.as_u64(), block.hash);
         node.blocks.insert(block.hash, block);


### PR DESCRIPTION
# What :computer: 
- Fixed issue with incorrect genesis block hash mapping. Genesis block has `hash = compute_hash(block_number, H256::zero())`, but in mapping just `H256::zero()` was used. So `get_block_by_hash(compute_hash(block_number, H256::zero()))` call didn't work, as mapping was incorrect.
- Added `parent_hash` link to each block pointing to previous block hash. Genesis block `parent_hash` points to `H256::zero()`.  For produced blocks previous block hash is used, for `create_empty_block` if `parent_hash` is not provided it generates `parent_hash` assuming previous block used the same hash generation method.
- Added default `0` value for `transaction.gas_price` and default `H256::zero()` value for `tx_receipt.root` as normally these fields should never be undefined.

# Why :hand:
- fixes `get_block_by_hash` API for genesis block.
- `parent_hash` was always set to zero hash, which is incorrect, also explorer requires `parent_hash` to function correctly.
- normally these fields should always be defined, so for now default values are still better then nothing, also explorer requires these fields to be set.

# Evidence :camera:
Genesis block:
<img width="865" alt="Screenshot 2023-10-31 at 23 39 30" src="https://github.com/matter-labs/era-test-node/assets/8478134/6070113d-76c5-4d4a-9dbf-9fb423c665bb">

First block, notice parent hash corresponds to the genesis block hash:
<img width="851" alt="Screenshot 2023-10-31 at 23 40 53" src="https://github.com/matter-labs/era-test-node/assets/8478134/2e1aa38e-9fb8-4f0d-8b5f-e3cf072f13d8">

Genesis block `get_block_by_hash` now works correctly:
<img width="848" alt="Screenshot 2023-10-31 at 23 42 02" src="https://github.com/matter-labs/era-test-node/assets/8478134/d3b2461a-a2ae-4f6b-b1f0-a2f792a0b605">

