### PR TITLE
chore: Update zksync-era dependency to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "era_test_node"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -4593,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "multivm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "hex",
@@ -4603,7 +4603,7 @@ dependencies = [
  "tracing",
  "vise",
  "zk_evm 1.3.1",
- "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc1)",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zksync_contracts",
  "zksync_state",
  "zksync_system_constants",
@@ -5686,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "prometheus_exporter"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "metrics",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "vlog"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "chrono",
  "sentry",
@@ -8606,7 +8606,7 @@ dependencies = [
 [[package]]
 name = "zk_evm"
 version = "1.3.3"
-source = "git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc1#fe8215a7047d24430ad470cf15a19bedb4d6ba0b"
+source = "git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2#fbee20f5bac7d6ca3e22ae69b2077c510a07de4e"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -8797,7 +8797,7 @@ dependencies = [
 [[package]]
 name = "zksync_basic_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8807,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "zksync_circuit_breaker"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "zksync_commitment_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "zkevm_test_harness 1.4.0",
  "zksync_types",
@@ -8840,7 +8840,7 @@ dependencies = [
 [[package]]
 name = "zksync_config"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -8859,7 +8859,7 @@ dependencies = [
 [[package]]
 name = "zksync_contracts"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "envy",
  "ethabi 18.0.0",
@@ -8873,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "zksync_core"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "actix-cors",
  "actix-rt",
@@ -8937,7 +8937,7 @@ dependencies = [
 [[package]]
 name = "zksync_crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "base64 0.13.1",
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8952,7 +8952,7 @@ dependencies = [
 [[package]]
 name = "zksync_dal"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -8961,6 +8961,7 @@ dependencies = [
  "itertools 0.10.5",
  "num 0.3.1",
  "once_cell",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sqlx",
@@ -8968,6 +8969,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "url",
  "vise",
  "zksync_contracts",
  "zksync_health_check",
@@ -8979,7 +8981,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_client"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8999,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_signer"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "async-trait",
  "hex",
@@ -9018,7 +9020,7 @@ dependencies = [
 [[package]]
 name = "zksync_health_check"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -9031,7 +9033,7 @@ dependencies = [
 [[package]]
 name = "zksync_mempool"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "tracing",
  "zksync_types",
@@ -9040,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "zksync_merkle_tree"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "leb128",
  "once_cell",
@@ -9051,12 +9053,13 @@ dependencies = [
  "zksync_crypto",
  "zksync_storage",
  "zksync_types",
+ "zksync_utils",
 ]
 
 [[package]]
 name = "zksync_mini_merkle_tree"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -9066,7 +9069,7 @@ dependencies = [
 [[package]]
 name = "zksync_object_store"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9084,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "zksync_prover_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9104,7 +9107,7 @@ dependencies = [
 [[package]]
 name = "zksync_queued_job_processor"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9116,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "zksync_state"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
@@ -9133,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "zksync_storage"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "num_cpus",
  "once_cell",
@@ -9145,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "zksync_system_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -9163,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "zksync_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
@@ -9180,7 +9183,7 @@ dependencies = [
  "serde_with",
  "strum 0.24.1",
  "thiserror",
- "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc1)",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zkevm_test_harness 1.3.3",
  "zksync_basic_types",
  "zksync_contracts",
@@ -9192,7 +9195,7 @@ dependencies = [
 [[package]]
 name = "zksync_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -9207,14 +9210,14 @@ dependencies = [
  "tokio",
  "tracing",
  "vlog",
- "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc1)",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zksync_basic_types",
 ]
 
 [[package]]
 name = "zksync_verification_key_generator_and_server"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9234,7 +9237,7 @@ dependencies = [
 [[package]]
 name = "zksync_web3_decl"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=73a1e8ff564025d06e02c2689da238ae47bb10c3#73a1e8ff564025d06e02c2689da238ae47bb10c3"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=80273264a9512bc1e6f1d1f4372107f9167260b1#80273264a9512bc1e6f1d1f4372107f9167260b1"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -11,14 +11,14 @@ categories = ["cryptography"]
 publish = false # We don't want to publish our binaries.
 
 [dependencies]
-zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-zksync_core = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+zksync_core = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
 sha3 = "0.10.6"
 
 

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -68,6 +68,12 @@ impl ReadStorage for &InMemoryStorage {
     fn load_factory_dep(&mut self, hash: H256) -> Option<Vec<u8>> {
         self.factory_deps.get(&hash).cloned()
     }
+
+    fn get_enumeration_index(&mut self, _key: &StorageKey) -> Option<u64> {
+        // TODO: Update this file to use proper enumeration index value once it's exposed for forks via API
+        //       This should happen as the migration of Boojum completes
+        Some(0_u64)
+    }
 }
 
 impl ReadStorage for InMemoryStorage {
@@ -81,6 +87,10 @@ impl ReadStorage for InMemoryStorage {
 
     fn load_factory_dep(&mut self, hash: H256) -> Option<Vec<u8>> {
         (&*self).load_factory_dep(hash)
+    }
+
+    fn get_enumeration_index(&mut self, key: &StorageKey) -> Option<u64> {
+        (&*self).get_enumeration_index(key)
     }
 }
 
@@ -103,6 +113,9 @@ pub trait ReadStorage: fmt::Debug {
         let code_key = get_known_code_key(bytecode_hash);
         self.read_value(&code_key) != H256::zero()
     }
+
+    /// Retrieves the enumeration index for a given `key`.
+    fn get_enumeration_index(&mut self, key: &StorageKey) -> Option<u64>;
 }
 
 /// Functionality to write to the VM storage in a batch.

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -148,6 +148,12 @@ impl<S: ForkSource> ForkStorage<S> {
             local_storage
         }
     }
+
+    /// Retrieves the enumeration index for a given `key`.
+    fn get_enumeration_index_internal(&self, _key: &StorageKey) -> Option<u64> {
+        // TODO: Update this file to use proper enumeration index value once it's exposed for forks via API
+        Some(0_u64)
+    }
 }
 
 impl<S: std::fmt::Debug + ForkSource> ReadStorage for ForkStorage<S> {
@@ -163,6 +169,10 @@ impl<S: std::fmt::Debug + ForkSource> ReadStorage for ForkStorage<S> {
     fn read_value(&mut self, key: &StorageKey) -> zksync_types::StorageValue {
         self.read_value_internal(key)
     }
+
+    fn get_enumeration_index(&mut self, key: &StorageKey) -> Option<u64> {
+        self.get_enumeration_index_internal(key)
+    }
 }
 
 impl<S: std::fmt::Debug + ForkSource> ReadStorage for &ForkStorage<S> {
@@ -177,6 +187,10 @@ impl<S: std::fmt::Debug + ForkSource> ReadStorage for &ForkStorage<S> {
 
     fn load_factory_dep(&mut self, hash: H256) -> Option<Vec<u8>> {
         self.load_factory_dep_internal(hash)
+    }
+
+    fn get_enumeration_index(&mut self, key: &StorageKey) -> Option<u64> {
+        self.get_enumeration_index_internal(key)
     }
 }
 

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -305,6 +305,7 @@ const SUPPORTED_VERSIONS: &[ProtocolVersionId] = &[
     ProtocolVersionId::Version14,
     ProtocolVersionId::Version15,
     ProtocolVersionId::Version16,
+    ProtocolVersionId::Version17,
 ];
 
 pub fn supported_protocol_versions(version: ProtocolVersionId) -> bool {


### PR DESCRIPTION
# What :computer: 
* Update `zksync-era` dependency to commit hash with `Version17`
* Add `get_enumeration_index` to Storage (hard-coded to 0 for now)
* Add `Version17` as supported version for HttpForkSource
* Increase cargo version

# Why :hand:
* To fix `era_test_node fork mainnet` and `era_test_node fork testnet`
* These values were added and required for Boojum upgrade
* `Version17` is now supported from upstream forks
* Upcoming release (with these fixes) will be `v0.1.0-alpha.10`

# Evidence :camera:
Unit/E2E Tests Pass (See CI builds for PR)

`era_test_node fork mainnet` works:
<img width="987" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/29ab4620-ab17-4413-a4a9-f903185b518c">

`era_test_node fork testnet` works:
<img width="987" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/c420aaa5-0c64-4b9e-a9b9-7222896a4359">
