### PR TITLE
chore: add rust toolchain for version mgt, make inner_tx pub

### DIFF
--- a/rust-toolchain.yaml
+++ b/rust-toolchain.yaml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-10-24"
+channel = "nightly-2023-07-23"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.yaml
+++ b/rust-toolchain.yaml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2023-10-24"
+components = ["rustfmt", "clippy"]

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1253,7 +1253,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
     }
 
     /// Executes the given L2 transaction and returns all the VM logs.
-    fn run_l2_tx_inner(
+    pub fn run_l2_tx_inner(
         &self,
         l2_tx: L2Tx,
         execution_mode: TxExecutionMode,


### PR DESCRIPTION
# What :computer: 
* Adds rust toolchain.yml
* Makes `run_l2_tx_inner` public

# Why :hand:
* Ensures everyone is using the same rust nightly given the instability and experimental features 
* `era-revm` is dependent on being able to call `run_l2_tx_inner`

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
