### PR TITLE
feat: get block returns null for non existing blocks

### DIFF
--- a/src/node/eth.rs
+++ b/src/node/eth.rs
@@ -223,7 +223,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> EthNamespa
 
                     Ok(Some(block))
                 }
-                None => Err(into_jsrpc_error(Web3Error::NoBlock)),
+                None => Ok(None),
             }
         })
     }
@@ -451,7 +451,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> EthNamespa
 
                     Ok(Some(block))
                 }
-                None => Err(into_jsrpc_error(Web3Error::NoBlock)),
+                None => Ok(None),
             }
         })
     }
@@ -1365,13 +1365,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_block_by_hash_produces_no_block_error_for_non_existing_block() {
+    async fn test_get_block_by_hash_returns_none_for_non_existing_block() {
         let node = InMemoryNode::<HttpForkSource>::default();
 
-        let expected_err = into_jsrpc_error(Web3Error::NoBlock);
-        let result = node.get_block_by_hash(H256::repeat_byte(0x01), false).await;
+        let result = node
+            .get_block_by_hash(H256::repeat_byte(0x01), false)
+            .await
+            .expect("failed fetching block by hash");
 
-        assert_eq!(expected_err, result.unwrap_err());
+        assert!(result.is_none());
     }
 
     #[tokio::test]
@@ -1514,15 +1516,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_block_by_number_produces_no_block_error_for_non_existing_block() {
+    async fn test_get_block_by_number_returns_none_for_non_existing_block() {
         let node = InMemoryNode::<HttpForkSource>::default();
 
-        let expected_err = into_jsrpc_error(Web3Error::NoBlock);
         let result = node
             .get_block_by_number(BlockNumber::Number(U64::from(42)), false)
-            .await;
+            .await
+            .expect("failed fetching block by number");
 
-        assert_eq!(expected_err, result.unwrap_err());
+        assert!(result.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
# What :computer: 
Change `eth_getBlockByNumber` and `eth_getBlockByHash` to return `null` for non existing block.

# Why :hand:
According to Ethereum [JSON RPC spec](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbyhash) these methods should return `null` when no block was found.

> Returns
> Object - A block object, or null when no block was found:

Since the test node doesn't fully follow the standard for these methods and throws an error instead of returning a `null` result, Block Explorer interprets it as an error and retries the request. This may also occur with other tools.

L1 and L2 networks return `null` for non existing blocks as expected.

# Evidence :camera:

```
% curl http://127.0.0.1:8011 \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_getBlockByNumber","params":["0x123",false],"id":1,"jsonrpc":"2.0"}'
```
```
{"jsonrpc":"2.0","result":null,"id":1}
```
```
% curl http://127.0.0.1:8011 \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_getBlockByHash","params":["0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c",false],"id":1,"jsonrpc":"2.0"}'
```
```
{"jsonrpc":"2.0","result":null,"id":1}
```