### PR TITLE
feat: Implement web3_clientVersion

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -111,6 +111,7 @@ The `status` options are:
 | [`NETWORK`](#network-namespace) | [`net_version`](#net_version) | `SUPPORTED` | Returns the current network id <br />_(default is `260`)_ |
 | [`NETWORK`](#network-namespace) | [`net_peerCount`](#net_peercount) | `SUPPORTED` | Returns the number of peers currently connected to the client <br/>_(hard-coded to `0`)_ |
 | [`NETWORK`](#network-namespace) | [`net_listening`](#net_listening) | `SUPPORTED` | Returns `true` if the client is actively listening for network connections <br />_(hard-coded to `false`)_ |
+| [`WEB3`](#web3-namespace) | [`web3_clientVersion`](#web3_clientversion) | `SUPPORTED` | Returns `zkSync/v2.0` |
 | [`ZKS`](#zks-namespace) | [`zks_estimateFee`](#zks_estimateFee) | `SUPPORTED` | Gets the Fee estimation data for a given Request |
 | `ZKS` | `zks_estimateGasL1ToL2` | `NOT IMPLEMENTED` | Estimate of the gas required for a L1 to L2 transaction |
 | [`ZKS`](#zks-namespace) | [`zks_getAllAccountBalances`](#zks_getallaccountbalances) | `SUPPORTED` | Returns all balances for confirmed tokens given by an account address |
@@ -1706,6 +1707,35 @@ curl --request POST \
   --url http://localhost:8011/ \
   --header 'content-type: application/json' \
   --data '{"jsonrpc": "2.0","id": "1","method": "evm_revert","params": ["0x1"]}'
+```
+
+## `WEB3 NAMESPACE`
+
+### `web3_clientVersion`
+
+[source](src/node/web3.rs)
+
+Returns the client version
+
+#### Arguments
+
++ _NONE_
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "web3_clientVersion"
+  }'
 ```
 
 ## `ZKS NAMESPACE`

--- a/e2e-tests/test/evm-apis.test.ts
+++ b/e2e-tests/test/evm-apis.test.ts
@@ -102,13 +102,12 @@ describe("evm_snapshot", function () {
     expect(await greeter.greet()).to.eq("Hi");
 
     // Act
-    const snapshotId1 = await provider.send("evm_snapshot", []);
-    const snapshotId2 = await provider.send("evm_snapshot", []);
+    const snapshotId1: string = await provider.send("evm_snapshot", []);
+    const snapshotId2: string = await provider.send("evm_snapshot", []);
 
     // Assert
     expect(await greeter.greet()).to.eq("Hi");
-    expect(BigNumber.from(snapshotId1).toString()).to.eq("1");
-    expect(BigNumber.from(snapshotId2).toString()).to.eq("2");
+    expect(BigNumber.from(snapshotId2).toString()).to.eq(BigNumber.from(snapshotId1).add(1).toString());
   });
 });
 

--- a/e2e-tests/test/web3-apis.test.ts
+++ b/e2e-tests/test/web3-apis.test.ts
@@ -1,0 +1,17 @@
+import { expect } from "chai";
+import { getTestProvider } from "../helpers/utils";
+
+const provider = getTestProvider();
+
+describe("web3_clientVersion", function () {
+  it("Should return zkSync/v2.0", async function () {
+    // Arrange
+    const expectedClientVersion = "zkSync/v2.0";
+
+    // Act
+    const response: string = await provider.send("web3_clientVersion", []);
+
+    // Assert
+    expect(response).to.equal(expectedClientVersion);
+  });
+});

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -301,6 +301,10 @@ pub struct ForkDetails<S> {
 }
 
 const SUPPORTED_VERSIONS: &[ProtocolVersionId] = &[
+    ProtocolVersionId::Version9,
+    ProtocolVersionId::Version10,
+    ProtocolVersionId::Version11,
+    ProtocolVersionId::Version12,
     ProtocolVersionId::Version13,
     ProtocolVersionId::Version14,
     ProtocolVersionId::Version15,

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -700,8 +700,8 @@ mod tests {
                 "result": {
                     "l1Erc20DefaultBridge": format!("{:#x}", input_bridge_addresses.l1_erc20_default_bridge),
                     "l2Erc20DefaultBridge": format!("{:#x}", input_bridge_addresses.l2_erc20_default_bridge),
-                    "l1WethBridge": format!("{:#x}", input_bridge_addresses.l1_weth_bridge.clone().unwrap()),
-                    "l2WethBridge": format!("{:#x}", input_bridge_addresses.l2_weth_bridge.clone().unwrap())
+                    "l1WethBridge": format!("{:#x}", input_bridge_addresses.l1_weth_bridge.unwrap()),
+                    "l2WethBridge": format!("{:#x}", input_bridge_addresses.l2_weth_bridge.unwrap())
                 },
                 "id": 0
             }),

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ use zksync_basic_types::{H160, H256};
 
 use crate::namespaces::{
     ConfigurationApiNamespaceT, DebugNamespaceT, EthNamespaceT, EvmNamespaceT, HardhatNamespaceT,
-    NetNamespaceT, ZksNamespaceT,
+    NetNamespaceT, ZksNamespaceT, Web3NamespaceT
 };
 
 /// List of wallets (address, private key) that we seed with tokens at start.
@@ -105,6 +105,7 @@ async fn build_json_http<
         let mut io = MetaIoHandler::with_middleware(LoggingMiddleware::new(log_level_filter));
 
         io.extend_with(NetNamespaceT::to_delegate(node.clone()));
+        io.extend_with(Web3NamespaceT::to_delegate(node.clone()));
         io.extend_with(ConfigurationApiNamespaceT::to_delegate(node.clone()));
         io.extend_with(DebugNamespaceT::to_delegate(node.clone()));
         io.extend_with(EthNamespaceT::to_delegate(node.clone()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ use zksync_basic_types::{H160, H256};
 
 use crate::namespaces::{
     ConfigurationApiNamespaceT, DebugNamespaceT, EthNamespaceT, EvmNamespaceT, HardhatNamespaceT,
-    NetNamespaceT, ZksNamespaceT, Web3NamespaceT
+    NetNamespaceT, Web3NamespaceT, ZksNamespaceT,
 };
 
 /// List of wallets (address, private key) that we seed with tokens at start.

--- a/src/namespaces/mod.rs
+++ b/src/namespaces/mod.rs
@@ -2,6 +2,7 @@ mod config;
 mod evm;
 mod hardhat;
 mod net;
+mod web3;
 
 use zksync_core::api_server::web3::backend_jsonrpc::namespaces::{debug, eth, zks};
 
@@ -11,6 +12,7 @@ pub use eth::EthNamespaceT;
 pub use evm::EvmNamespaceT;
 pub use hardhat::HardhatNamespaceT;
 pub use net::NetNamespaceT;
+pub use web3::Web3NamespaceT;
 pub use zks::ZksNamespaceT;
 
 pub type Result<T> = jsonrpc_core::Result<T>;

--- a/src/namespaces/web3.rs
+++ b/src/namespaces/web3.rs
@@ -1,0 +1,9 @@
+use jsonrpc_derive::rpc;
+
+use crate::namespaces::Result;
+
+#[rpc]
+pub trait Web3NamespaceT {
+    #[rpc(name = "web3_clientVersion", returns = "String")]
+    fn web3_client_version(&self) -> Result<String>;
+}

--- a/src/node/debug.rs
+++ b/src/node/debug.rs
@@ -256,7 +256,7 @@ mod tests {
         );
         let secondary_deployed_address = deployed_address_create(from_account, U256::zero());
         testing::deploy_contract(
-            &node,
+            node,
             H256::repeat_byte(0x1),
             private_key,
             secondary_bytecode,
@@ -271,7 +271,7 @@ mod tests {
         );
         let primary_deployed_address = deployed_address_create(from_account, U256::one());
         testing::deploy_contract(
-            &node,
+            node,
             H256::repeat_byte(0x1),
             private_key,
             primary_bytecode,
@@ -306,7 +306,7 @@ mod tests {
 
         // check that the call was successful
         let output =
-            ethers::abi::decode(&[ParamType::Uint(256)], &trace.output.0.as_slice()).unwrap();
+            ethers::abi::decode(&[ParamType::Uint(256)], trace.output.0.as_slice()).unwrap();
         assert_eq!(output[0], Token::Uint(U256::from(84)));
 
         // find the call to primary contract in the trace

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -9,5 +9,6 @@ mod in_memory;
 mod in_memory_ext;
 mod net;
 mod zks;
+mod web3;
 
 pub use in_memory::*;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -8,7 +8,7 @@ mod hardhat;
 mod in_memory;
 mod in_memory_ext;
 mod net;
-mod zks;
 mod web3;
+mod zks;
 
 pub use in_memory::*;

--- a/src/node/web3.rs
+++ b/src/node/web3.rs
@@ -1,6 +1,6 @@
 use crate::{
     fork::ForkSource,
-    namespaces::{Web3NamespaceT, Result},
+    namespaces::{Result, Web3NamespaceT},
     node::InMemoryNode,
 };
 

--- a/src/node/web3.rs
+++ b/src/node/web3.rs
@@ -1,0 +1,13 @@
+use crate::{
+    fork::ForkSource,
+    namespaces::{Web3NamespaceT, Result},
+    node::InMemoryNode,
+};
+
+impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> Web3NamespaceT
+    for InMemoryNode<S>
+{
+    fn web3_client_version(&self) -> Result<String> {
+        Ok("zkSync/v2.0".to_string())
+    }
+}

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -814,8 +814,8 @@ mod tests {
                 "result": {
                     "l1Erc20DefaultBridge": format!("{:#x}", input_bridge_addresses.l1_erc20_default_bridge),
                     "l2Erc20DefaultBridge": format!("{:#x}", input_bridge_addresses.l2_erc20_default_bridge),
-                    "l1WethBridge": format!("{:#x}", input_bridge_addresses.l1_weth_bridge.clone().unwrap()),
-                    "l2WethBridge": format!("{:#x}", input_bridge_addresses.l2_weth_bridge.clone().unwrap())
+                    "l1WethBridge": format!("{:#x}", input_bridge_addresses.l1_weth_bridge.unwrap()),
+                    "l2WethBridge": format!("{:#x}", input_bridge_addresses.l2_weth_bridge.unwrap())
                 },
                 "id": 0
             }),

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -790,3 +790,14 @@ content-type: application/json
     "method": "config_setLogging",
     "params": ["era_test_node=info,hyper=debug"]
 }
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "web3_clientVersion",
+    "params": []
+}


### PR DESCRIPTION
# What :computer: 
* Implement `web3_clientVersion`
* Fix test for `evm_snapshot`
* Add `fork` support for `Version9`, `Version10`, `Version11`, and `Version12`

# Why :hand:
* This is necessary for some hardhat plugins
* The test was flaky/failing when being run more than once
* These versions are supported and shouldn't error out with `fork` or `replay_tx`

# Evidence :camera:
E2E tests pass
<img width="203" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/e3496145-5b95-42cd-91f6-aa23c74c79d6">

# Notes :memo:
* This fixes https://github.com/matter-labs/era-test-node/issues/188 and https://github.com/matter-labs/era-test-node/issues/211
