### PR TITLE
bugfix: Set removed property in Logs to false

### DIFF
--- a/e2e-tests/test/main.test.ts
+++ b/e2e-tests/test/main.test.ts
@@ -99,6 +99,7 @@ describe("Greeter Smart Contract", function () {
     expect(filterChanges.length).to.eq(1);
     expect(filterChanges[0].transactionHash).to.eq(receipt.transactionHash);
     expect(filterChanges[0].blockHash).to.eq(receipt.blockHash);
+    expect(filterChanges[0].removed).to.eq(false);
     const eventInterface = new ethers.utils.Interface(["event LogString(string value)"]);
     expect(eventInterface.parseLog(filterChanges[0]).args[0]).to.equal("Greeting is being updated to Darth Vader");
   });

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1552,7 +1552,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                     log_index: Some(U256::from(log_idx)),
                     transaction_log_index: Some(U256::from(log_idx)),
                     log_type: None,
-                    removed: None,
+                    removed: Some(false),
                 },
                 block.number,
             );
@@ -1587,7 +1587,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                     log_index: Some(U256::from(log_idx)),
                     transaction_log_index: Some(U256::from(log_idx)),
                     log_type: None,
-                    removed: None,
+                    removed: Some(false),
                 })
                 .collect(),
             l2_to_l1_logs: vec![],

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -574,7 +574,7 @@ impl LogBuilder {
             log_index: Default::default(),
             transaction_log_index: Default::default(),
             log_type: Default::default(),
-            removed: Default::default(),
+            removed: Some(false),
         }
     }
 }


### PR DESCRIPTION
# What :computer: 
* Set `removed` property in `Log` to `false`

# Why :hand:
* It's incorrectly leaving a `None`

# Evidence :camera:
BEFORE:
<img width="494" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/d5c845e2-a680-4433-a3e9-86316a0911dc">


AFTER:
<img width="392" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/2b439561-bf39-4786-8313-0161b9c0fffd">


# Notes :memo:
* Fixes https://github.com/matter-labs/era-test-node/issues/222
