### PR TITLE
feat: Update event formatter and observability formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "era_test_node"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -2267,6 +2267,7 @@ dependencies = [
  "serde_json",
  "sha3 0.10.6 (git+https://github.com/RustCrypto/hashes?tag=sha3-v0.10.6)",
  "tempdir",
+ "time",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4924,6 +4925,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7554,6 +7564,8 @@ checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -38,7 +38,7 @@ clap = { version = "4.2.4", features = ["derive"] }
 reqwest = { version = "0.11", features = ["blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 tracing = { version = "0.1.26", features = ["log"] }
-tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "time", "json"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "time", "json", "local-time"] }
 colored = "2.0"
 lazy_static = "1.4"
 eyre = "0.6"
@@ -50,6 +50,7 @@ itertools = "0.10.5"
 rustc-hash = "1.1.0"
 indexmap = "2.0.1"
 chrono = { version = "0.4.31", default-features = false }
+time = "0.3.30"
 
 [dev-dependencies]
 httptest = "0.15.4"

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -2,7 +2,7 @@
 use crate::{node::ShowCalls, resolver};
 
 use colored::Colorize;
-use hex;
+
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::str;
@@ -97,7 +97,7 @@ pub fn print_event(event: &VmEvent, resolve_hashes: bool) {
                         "  Data (String):".truecolor(128, 128, 128),
                         v.to_string()
                     );
-                },
+                }
                 Err(_) => {
                     let hex_str = hex::encode(&event.value);
                     let display_str = if hex_str.len() > 200 {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -103,7 +103,7 @@ pub fn print_event(event: &VmEvent, resolve_hashes: bool) {
                     let display_str = if hex_str.len() > 200 {
                         format!("{}...", &hex_str[..200])
                     } else {
-                        format!("{}", &hex_str)
+                        (&hex_str).to_string()
                     };
 
                     tracing::info!(

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -2,8 +2,10 @@
 use crate::{node::ShowCalls, resolver};
 
 use colored::Colorize;
+use hex;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::str;
 
 use crate::fork::block_on;
 use zksync_basic_types::H160;
@@ -74,12 +76,46 @@ pub fn print_event(event: &VmEvent, resolve_hashes: bool) {
         }
 
         tracing::info!(
-            "{} {}",
+            "{}",
             address_to_human_readable(event.address)
                 .map(|x| format!("{:42}", x.blue()))
-                .unwrap_or(format!("{:42}", format!("{:?}", event.address).blue())),
-            tt.join(", ")
+                .unwrap_or(format!("{:42}", format!("{:?}", event.address).blue()))
         );
+
+        tracing::info!("{}", "  Topics:".truecolor(128, 128, 128));
+        for indexed_topic in &tt {
+            tracing::info!("    {}", indexed_topic);
+        }
+
+        if event.value.is_empty() {
+            tracing::info!("{}", "  Data: EMPTY".truecolor(128, 128, 128));
+        } else {
+            match str::from_utf8(&event.value) {
+                Ok(v) => {
+                    tracing::info!(
+                        "{} {}",
+                        "  Data (String):".truecolor(128, 128, 128),
+                        v.to_string()
+                    );
+                },
+                Err(_) => {
+                    let hex_str = hex::encode(&event.value);
+                    let display_str = if hex_str.len() > 200 {
+                        format!("{}...", &hex_str[..200])
+                    } else {
+                        format!("{}", &hex_str)
+                    };
+
+                    tracing::info!(
+                        "{} 0x{}",
+                        "  Data (Hex):".truecolor(128, 128, 128),
+                        display_str
+                    );
+                }
+            };
+        }
+
+        tracing::info!("");
     });
 }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -103,7 +103,7 @@ pub fn print_event(event: &VmEvent, resolve_hashes: bool) {
                     let display_str = if hex_str.len() > 200 {
                         format!("{}...", &hex_str[..200])
                     } else {
-                        (&hex_str).to_string()
+                        hex_str.to_string()
                     };
 
                     tracing::info!(

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1461,7 +1461,6 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
         };
 
         tracing::info!("");
-        tracing::info!("");
 
         let bytecodes = vm
             .get_last_tx_compressed_bytecodes()

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -4,7 +4,7 @@ use std::{fs::File, sync::Mutex};
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::{
-    filter::LevelFilter, layer::SubscriberExt, reload, util::SubscriberInitExt, EnvFilter, Layer,
+    filter::LevelFilter, layer::SubscriberExt, reload, util::SubscriberInitExt, EnvFilter,
     Registry,
 };
 
@@ -63,13 +63,31 @@ impl Observability {
             format!("{log_level_filter}").to_lowercase()
         ))?;
         let (filter, reload_handle) = reload::Layer::new(filter);
+
+        let timer_format = time::format_description::parse(
+            "[hour]:[minute]:[second]",
+        )
+        .expect("Cataplum");
+        let time_offset =
+            time::UtcOffset::current_local_offset().unwrap_or_else(|_| time::UtcOffset::UTC);
+        let timer = tracing_subscriber::fmt::time::OffsetTime::new(time_offset, timer_format);
+
         tracing_subscriber::registry()
+            .with(filter)
+            .with(tracing_subscriber::fmt::layer().event_format(tracing_subscriber::fmt::format()
+                .compact()
+                .with_timer(timer.clone())
+                .with_target(false)
+            ))
             .with(
-                filter.and_then(tracing_subscriber::fmt::layer()).and_then(
-                    tracing_subscriber::fmt::layer()
-                        .with_writer(Mutex::new(log_file))
-                        .with_ansi(false),
-                ),
+                tracing_subscriber::fmt::layer()
+                    .event_format(tracing_subscriber::fmt::format()
+                        .compact()
+                        .with_timer(timer.clone())
+                        .with_target(false)
+                    )
+                    .with_writer(Mutex::new(log_file))
+                    .with_ansi(false)
             )
             .init();
 

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -4,8 +4,7 @@ use std::{fs::File, sync::Mutex};
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::{
-    filter::LevelFilter, layer::SubscriberExt, reload, util::SubscriberInitExt, EnvFilter,
-    Registry,
+    filter::LevelFilter, layer::SubscriberExt, reload, util::SubscriberInitExt, EnvFilter, Registry,
 };
 
 /// Log filter level for the node.
@@ -64,30 +63,31 @@ impl Observability {
         ))?;
         let (filter, reload_handle) = reload::Layer::new(filter);
 
-        let timer_format = time::format_description::parse(
-            "[hour]:[minute]:[second]",
-        )
-        .expect("Cataplum");
-        let time_offset =
-            time::UtcOffset::current_local_offset().unwrap_or_else(|_| time::UtcOffset::UTC);
+        let timer_format =
+            time::format_description::parse("[hour]:[minute]:[second]").expect("Cataplum");
+        let time_offset = time::UtcOffset::current_local_offset().unwrap_or(time::UtcOffset::UTC);
         let timer = tracing_subscriber::fmt::time::OffsetTime::new(time_offset, timer_format);
 
         tracing_subscriber::registry()
             .with(filter)
-            .with(tracing_subscriber::fmt::layer().event_format(tracing_subscriber::fmt::format()
-                .compact()
-                .with_timer(timer.clone())
-                .with_target(false)
-            ))
             .with(
-                tracing_subscriber::fmt::layer()
-                    .event_format(tracing_subscriber::fmt::format()
+                tracing_subscriber::fmt::layer().event_format(
+                    tracing_subscriber::fmt::format()
                         .compact()
                         .with_timer(timer.clone())
-                        .with_target(false)
+                        .with_target(false),
+                ),
+            )
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .event_format(
+                        tracing_subscriber::fmt::format()
+                            .compact()
+                            .with_timer(timer.clone())
+                            .with_target(false),
                     )
                     .with_writer(Mutex::new(log_file))
-                    .with_ansi(false)
+                    .with_ansi(false),
             )
             .init();
 


### PR DESCRIPTION
# What :computer: 
* Update events to display indexed topics on new lines
* Update events to display data
* Update the observability formatter to be compact (similar to the way it was before the tracing migration)

# Why :hand:
* Easier to read when there are more than 2 indexed topics (super common)
* This was not being displayed
* Better user experience during demos as it reduces the amount of text on the screen or in the logs

# Evidence :camera:
Starting a node (with new observability formatter)
<img width="606" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/082a794c-6d9d-4299-a0bc-4f5c334eda67">

Events are now updated
BEFORE
<img width="837" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/e9b13dd1-4964-4dd5-9ab7-54d8f145e857">

AFTER
<img width="839" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/52353e13-142c-4c0a-82ad-01b4b3e3f23f">

Examples of more events:
<img width="674" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/6737e8ca-73c6-4251-b272-30eb42447e51">


# Notes :memo:
* I know that I'm not parsing the ABI properly to display the data as a string... but it's better than nothing and we can have that as an easy GitHub Issue once this is merged
