### PR TITLE
chore: Add Rich Accounts with mnemonic phrases

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -64,8 +64,8 @@ The `status` options are:
 | [`ETH`](#eth-namespace) | [`eth_newBlockFilter`](#`eth_newblockfilter) | `SUPPORTED` | Creates a filter in the node, to notify when a new block arrives |
 | [`ETH`](#eth-namespace) | [`eth_newFilter`](#`eth_newfilter) | `SUPPORTED` | Creates a filter object, based on filter options, to notify when the state changes (logs) |
 | [`ETH`](#eth-namespace) | [`eth_newPendingTransactionFilter`](#`eth_newpendingtransactionfilter) | `SUPPORTED` | Creates a filter in the node, to notify when new pending transactions arrive |
-| [`ETH`](#eth-namespace)` | [`eth_protocolVersion`](#eth_protocolversion) | `SUPPORTED` | Returns the current ethereum protocol version |
-| `ETH` | `eth_sendTransaction` | `NOT IMPLEMENTED` | Creates new message call transaction or a contract creation, if the data field contains code |
+| [`ETH`](#eth-namespace) | [`eth_protocolVersion`](#eth_protocolversion) | `SUPPORTED` | Returns the current ethereum protocol version |
+| [`ETH`](#eth-namespace) | [`eth_sendTransaction`](#eth_sendtransaction) | `SUPPORTED` | Creates new message call transaction or a contract creation, if the data field contains code |
 | `ETH` | `eth_sign` | `NOT IMPLEMENTED` | The sign method calculates an Ethereum specific signature with: `sign(keccak256("\x19Ethereum Signed Message:\n" + message.length + message)))` |
 | `ETH` | `eth_signTransaction` | `NOT IMPLEMENTED` | Signs a transaction that can be submitted to the network at a later time using `eth_sendRawTransaction` |
 | `ETH` | `eth_signTypedData` | `NOT IMPLEMENTED` | Identical to `eth_signTypedData_v4` |
@@ -1389,6 +1389,34 @@ curl --request POST \
     "jsonrpc": "2.0",
     "id": "1",
     "method": "eth_protocolVersion"
+}'
+```
+
+### `eth_sendTransaction`
+
+[source](src/node/eth.rs)
+
+Creates new message call transaction or a contract creation, if the data field contains code.
+
+#### Arguments
+
++ `transaction: TransactionRequest`
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "eth_sendTransaction",
+    "params": ["..."]
 }'
 ```
 

--- a/e2e-tests/helpers/constants.ts
+++ b/e2e-tests/helpers/constants.ts
@@ -39,4 +39,44 @@ export const RichAccounts = [
     Account: "0xE90E12261CCb0F3F7976Ae611A29e84a6A85f424",
     PrivateKey: "0x3eb15da85647edd9a1159a4a13b9e7c56877c4eb33f614546d4db06a51868b1c",
   },
+  {
+    Account: "0xBC989fDe9e54cAd2aB4392Af6dF60f04873A033A",
+    PrivateKey: "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e",
+  },
+  {
+    Account: "0x55bE1B079b53962746B2e86d12f158a41DF294A6",
+    PrivateKey: "0x509ca2e9e6acf0ba086477910950125e698d4ea70fa6f63e000c5a22bda9361c",
+  },
+  {
+    Account: "0xCE9e6063674DC585F6F3c7eaBe82B9936143Ba6C",
+    PrivateKey: "0x71781d3a358e7a65150e894264ccc594993fbc0ea12d69508a340bc1d4f5bfbc",
+  },
+  {
+    Account: "0xd986b0cB0D1Ad4CCCF0C4947554003fC0Be548E9",
+    PrivateKey: "0x379d31d4a7031ead87397f332aab69ef5cd843ba3898249ca1046633c0c7eefe",
+  },
+  {
+    Account: "0x87d6ab9fE5Adef46228fB490810f0F5CB16D6d04",
+    PrivateKey: "0x105de4e75fe465d075e1daae5647a02e3aad54b8d23cf1f70ba382b9f9bee839",
+  },
+  {
+    Account: "0x78cAD996530109838eb016619f5931a03250489A",
+    PrivateKey: "0x7becc4a46e0c3b512d380ca73a4c868f790d1055a7698f38fb3ca2b2ac97efbb",
+  },
+  {
+    Account: "0xc981b213603171963F81C687B9fC880d33CaeD16",
+    PrivateKey: "0xe0415469c10f3b1142ce0262497fe5c7a0795f0cbfd466a6bfa31968d0f70841",
+  },
+  {
+    Account: "0x42F3dc38Da81e984B92A95CBdAAA5fA2bd5cb1Ba",
+    PrivateKey: "0x4d91647d0a8429ac4433c83254fb9625332693c848e578062fe96362f32bfe91",
+  },
+  {
+    Account: "0x64F47EeD3dC749d13e49291d46Ea8378755fB6DF",
+    PrivateKey: "0x41c9f9518aa07b50cb1c0cc160d45547f57638dd824a8d85b5eb3bf99ed2bdeb",
+  },
+  {
+    Account: "0xe2b8Cb53a43a56d4d2AB6131C81Bd76B86D3AFe5",
+    PrivateKey: "0xb0680d66303a0163a19294f1ef8c95cd69a9d7902a4aca99c05f3e134e68a11a",
+  },
 ] as const;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use crate::cache::CacheConfig;
 use crate::node::{InMemoryNodeConfig, ShowGasDetails, ShowStorageLogs, ShowVMDetails};
 use crate::observability::Observability;
 use clap::{Parser, Subcommand, ValueEnum};
+use colored::Colorize;
 use fork::{ForkDetails, ForkSource};
 use logging_middleware::LoggingMiddleware;
 use node::ShowCalls;
@@ -47,8 +48,8 @@ use crate::namespaces::{
     EvmNamespaceT, HardhatNamespaceT, NetNamespaceT, Web3NamespaceT, ZksNamespaceT,
 };
 
-/// List of wallets (address, private key) that we seed with tokens at start.
-pub const RICH_WALLETS: [(&str, &str); 10] = [
+/// List of legacy wallets (address, private key) that we seed with tokens at start.
+pub const LEGACY_RICH_WALLETS: [(&str, &str); 10] = [
     (
         "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
         "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110",
@@ -88,6 +89,60 @@ pub const RICH_WALLETS: [(&str, &str); 10] = [
     (
         "0xE90E12261CCb0F3F7976Ae611A29e84a6A85f424",
         "0x3eb15da85647edd9a1159a4a13b9e7c56877c4eb33f614546d4db06a51868b1c",
+    ),
+];
+
+/// List of wallets (address, private key, mnemonic) that we seed with tokens at start.
+pub const RICH_WALLETS: [(&str, &str, &str); 10] = [
+    (
+        "0xBC989fDe9e54cAd2aB4392Af6dF60f04873A033A",
+        "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e",
+        "mass wild lava ripple clog cabbage witness shell unable tribe rubber enter",
+    ),
+    (
+        "0x55bE1B079b53962746B2e86d12f158a41DF294A6",
+        "0x509ca2e9e6acf0ba086477910950125e698d4ea70fa6f63e000c5a22bda9361c",
+        "crumble clutch mammal lecture lazy broken nominee visit gentle gather gym erupt",
+    ),
+    (
+        "0xCE9e6063674DC585F6F3c7eaBe82B9936143Ba6C",
+        "0x71781d3a358e7a65150e894264ccc594993fbc0ea12d69508a340bc1d4f5bfbc",
+        "illegal okay stereo tattoo between alien road nuclear blind wolf champion regular",
+    ),
+    (
+        "0xd986b0cB0D1Ad4CCCF0C4947554003fC0Be548E9",
+        "0x379d31d4a7031ead87397f332aab69ef5cd843ba3898249ca1046633c0c7eefe",
+        "point donor practice wear alien abandon frozen glow they practice raven shiver",
+    ),
+    (
+        "0x87d6ab9fE5Adef46228fB490810f0F5CB16D6d04",
+        "0x105de4e75fe465d075e1daae5647a02e3aad54b8d23cf1f70ba382b9f9bee839",
+        "giraffe organ club limb install nest journey client chunk settle slush copy",
+    ),
+    (
+        "0x78cAD996530109838eb016619f5931a03250489A",
+        "0x7becc4a46e0c3b512d380ca73a4c868f790d1055a7698f38fb3ca2b2ac97efbb",
+        "awful organ version habit giraffe amused wire table begin gym pistol clean",
+    ),
+    (
+        "0xc981b213603171963F81C687B9fC880d33CaeD16",
+        "0xe0415469c10f3b1142ce0262497fe5c7a0795f0cbfd466a6bfa31968d0f70841",
+        "exotic someone fall kitten salute nerve chimney enlist pair display over inside",
+    ),
+    (
+        "0x42F3dc38Da81e984B92A95CBdAAA5fA2bd5cb1Ba",
+        "0x4d91647d0a8429ac4433c83254fb9625332693c848e578062fe96362f32bfe91",
+        "catch tragic rib twelve buffalo also gorilla toward cost enforce artefact slab",
+    ),
+    (
+        "0x64F47EeD3dC749d13e49291d46Ea8378755fB6DF",
+        "0x41c9f9518aa07b50cb1c0cc160d45547f57638dd824a8d85b5eb3bf99ed2bdeb",
+        "arrange price fragile dinner device general vital excite penalty monkey major faculty",
+    ),
+    (
+        "0xe2b8Cb53a43a56d4d2AB6131C81Bd76B86D3AFe5",
+        "0xb0680d66303a0163a19294f1ef8c95cd69a9d7902a4aca99c05f3e134e68a11a",
+        "increase pulp sing wood guilt cement satoshi tiny forum nuclear sudden thank",
     ),
 ];
 
@@ -313,14 +368,21 @@ async fn main() -> anyhow::Result<()> {
         let _ = node.apply_txs(transactions_to_replay);
     }
 
+    tracing::info!("");
     tracing::info!("Rich Accounts");
     tracing::info!("=============");
+    for (_, wallet) in LEGACY_RICH_WALLETS.iter().enumerate() {
+        let address = wallet.0;
+        node.set_rich_account(H160::from_str(address).unwrap());
+    }
     for (index, wallet) in RICH_WALLETS.iter().enumerate() {
         let address = wallet.0;
         let private_key = wallet.1;
+        let mnemonic_phrase = wallet.2;
         node.set_rich_account(H160::from_str(address).unwrap());
-        tracing::info!("Account #{}: {} (1_000_000_000_000 ETH)", index, address);
+        tracing::info!("Account #{}: {} ({})", index, address, "1_000_000_000_000 ETH".cyan());
         tracing::info!("Private Key: {}", private_key);
+        tracing::info!("Mnemonic: {}", &mnemonic_phrase.truecolor(128, 128, 128));
         tracing::info!("");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,7 +380,12 @@ async fn main() -> anyhow::Result<()> {
         let private_key = wallet.1;
         let mnemonic_phrase = wallet.2;
         node.set_rich_account(H160::from_str(address).unwrap());
-        tracing::info!("Account #{}: {} ({})", index, address, "1_000_000_000_000 ETH".cyan());
+        tracing::info!(
+            "Account #{}: {} ({})",
+            index,
+            address,
+            "1_000_000_000_000 ETH".cyan()
+        );
         tracing::info!("Private Key: {}", private_key);
         tracing::info!("Mnemonic: {}", &mnemonic_phrase.truecolor(128, 128, 128));
         tracing::info!("");


### PR DESCRIPTION
# What :computer: 
* Add rich accounts with mnemonic phrases
* Updated `SUPPORTED_APIS`

# Why :hand:
* Test suites commonly rely on mnemonic phrases with things like foundry
* Support is updated for `eth_sendTransaction`

# Evidence :camera:
This is what `era_test_node run` now looks like:
<img width="689" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/e61e61c2-0170-4ec9-aec5-27fbb2a0cb18">

E2E tests still pass 👍 
<img width="557" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/f7a24ba3-42f9-45e2-9e0e-4c914002739d">


# Notes :memo:
* I'm keeping the legacy rich wallets so that everything is still backwards compatible... I'm just not printing them out to the console
