### PR TITLE
feat: Added detailed information on amount of pubdata per write

### DIFF
--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -75,7 +75,7 @@ pub const TEST_NODE_NETWORK_ID: u32 = 260;
 /// L1 Gas Price.
 pub const L1_GAS_PRICE: u64 = 50_000_000_000;
 /// L2 Gas Price (0.25 gwei).
-pub const L2_GAS_PRICE: u64 = 190_000_000;
+pub const L2_GAS_PRICE: u64 = 250_000_000;
 /// L1 Gas Price Scale Factor for gas estimation.
 pub const ESTIMATE_GAS_L1_GAS_PRICE_SCALE_FACTOR: f64 = 1.2;
 /// The max possible number of gas that `eth_estimateGas` is allowed to overestimate.

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -167,6 +167,7 @@ pub enum ShowStorageLogs {
     None,
     Read,
     Write,
+    Paid,
     All,
 }
 
@@ -178,9 +179,10 @@ impl FromStr for ShowStorageLogs {
             "none" => Ok(ShowStorageLogs::None),
             "read" => Ok(ShowStorageLogs::Read),
             "write" => Ok(ShowStorageLogs::Write),
+            "paid" => Ok(ShowStorageLogs::Paid),
             "all" => Ok(ShowStorageLogs::All),
             _ => Err(format!(
-                "Unknown ShowStorageLogs value {} - expected one of none|read|write|all.",
+                "Unknown ShowStorageLogs value {} - expected one of none|read|write|paid|all.",
                 s
             )),
         }

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -6,6 +6,7 @@ use crate::{
     filters::EthFilters,
     fork::{ForkDetails, ForkSource, ForkStorage},
     formatter,
+    node::storage_logs::print_storage_logs_details,
     observability::Observability,
     system_contracts::{self, SystemContracts},
     utils::{
@@ -74,7 +75,7 @@ pub const TEST_NODE_NETWORK_ID: u32 = 260;
 /// L1 Gas Price.
 pub const L1_GAS_PRICE: u64 = 50_000_000_000;
 /// L2 Gas Price (0.25 gwei).
-pub const L2_GAS_PRICE: u64 = 250_000_000;
+pub const L2_GAS_PRICE: u64 = 190_000_000;
 /// L1 Gas Price Scale Factor for gas estimation.
 pub const ESTIMATE_GAS_L1_GAS_PRICE_SCALE_FACTOR: f64 = 1.2;
 /// The max possible number of gas that `eth_estimateGas` is allowed to overestimate.
@@ -1372,32 +1373,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
         }
 
         if inner.show_storage_logs != ShowStorageLogs::None {
-            tracing::info!("");
-            tracing::info!("┌──────────────────┐");
-            tracing::info!("│   STORAGE LOGS   │");
-            tracing::info!("└──────────────────┘");
-        }
-
-        for log_query in &tx_result.logs.storage_logs {
-            match inner.show_storage_logs {
-                ShowStorageLogs::Write => {
-                    if matches!(
-                        log_query.log_type,
-                        StorageLogQueryType::RepeatedWrite | StorageLogQueryType::InitialWrite
-                    ) {
-                        formatter::print_logs(log_query);
-                    }
-                }
-                ShowStorageLogs::Read => {
-                    if log_query.log_type == StorageLogQueryType::Read {
-                        formatter::print_logs(log_query);
-                    }
-                }
-                ShowStorageLogs::All => {
-                    formatter::print_logs(log_query);
-                }
-                _ => {}
-            }
+            print_storage_logs_details(&inner.show_storage_logs, &tx_result);
         }
 
         if inner.show_vm_details != ShowVMDetails::None {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -8,6 +8,7 @@ mod hardhat;
 mod in_memory;
 mod in_memory_ext;
 mod net;
+mod storage_logs;
 mod web3;
 mod zks;
 

--- a/src/node/storage_logs.rs
+++ b/src/node/storage_logs.rs
@@ -1,0 +1,36 @@
+use crate::formatter;
+
+use super::ShowStorageLogs;
+use multivm::vm_latest::VmExecutionResultAndLogs;
+use zksync_types::StorageLogQueryType;
+
+pub fn print_storage_logs_details(
+    show_storage_logs: &ShowStorageLogs,
+    result: &VmExecutionResultAndLogs,
+) {
+    tracing::info!("");
+    tracing::info!("┌──────────────────┐");
+    tracing::info!("│   STORAGE LOGS   │");
+    tracing::info!("└──────────────────┘");
+    for log_query in &result.logs.storage_logs {
+        match show_storage_logs {
+            ShowStorageLogs::Write => {
+                if matches!(
+                    log_query.log_type,
+                    StorageLogQueryType::RepeatedWrite | StorageLogQueryType::InitialWrite
+                ) {
+                    formatter::print_logs(log_query);
+                }
+            }
+            ShowStorageLogs::Read => {
+                if log_query.log_type == StorageLogQueryType::Read {
+                    formatter::print_logs(log_query);
+                }
+            }
+            ShowStorageLogs::All => {
+                formatter::print_logs(log_query);
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/node/storage_logs.rs
+++ b/src/node/storage_logs.rs
@@ -1,8 +1,65 @@
-use crate::formatter;
+use std::collections::HashMap;
+
+use crate::formatter::{self, PubdataBytesInfo};
 
 use super::ShowStorageLogs;
 use multivm::vm_latest::VmExecutionResultAndLogs;
-use zksync_types::StorageLogQueryType;
+use zksync_basic_types::AccountTreeId;
+use zksync_types::{
+    utils::storage_key_for_eth_balance,
+    writes::{
+        compression::compress_with_best_strategy, BYTES_PER_DERIVED_KEY,
+        BYTES_PER_ENUMERATION_INDEX,
+    },
+    StorageKey, StorageLogQuery, StorageLogQueryType, BOOTLOADER_ADDRESS, SYSTEM_CONTEXT_ADDRESS,
+};
+use zksync_utils::u256_to_h256;
+
+fn is_storage_key_free(key: &StorageKey) -> bool {
+    key.address() == &SYSTEM_CONTEXT_ADDRESS
+        || *key == storage_key_for_eth_balance(&BOOTLOADER_ADDRESS)
+}
+
+fn compute_and_update_pubdata_cost(
+    cost_paid: &mut HashMap<StorageKey, u32>,
+    log_query: &StorageLogQuery,
+) -> PubdataBytesInfo {
+    let storage_key = StorageKey::new(
+        AccountTreeId::new(log_query.log_query.address),
+        u256_to_h256(log_query.log_query.key),
+    );
+
+    if is_storage_key_free(&storage_key) {
+        PubdataBytesInfo::FreeSlot
+    } else {
+        // how many bytes it takes after compression.
+        let compressed_value_size = compress_with_best_strategy(
+            log_query.log_query.read_value,
+            log_query.log_query.written_value,
+        )
+        .len() as u32;
+
+        let final_pubdata_cost = if log_query.log_type == StorageLogQueryType::InitialWrite {
+            (BYTES_PER_DERIVED_KEY as u32) + compressed_value_size
+        } else {
+            (BYTES_PER_ENUMERATION_INDEX as u32) + compressed_value_size
+        };
+
+        let result = match cost_paid.get(&storage_key).copied() {
+            Some(already_paid) => {
+                let to_pay = final_pubdata_cost.saturating_sub(already_paid);
+                if to_pay > 0 {
+                    PubdataBytesInfo::AdditionalPayment(to_pay, final_pubdata_cost)
+                } else {
+                    PubdataBytesInfo::PaidAlready
+                }
+            }
+            None => PubdataBytesInfo::Paid(final_pubdata_cost),
+        };
+        cost_paid.insert(storage_key, final_pubdata_cost);
+        result
+    }
+}
 
 pub fn print_storage_logs_details(
     show_storage_logs: &ShowStorageLogs,
@@ -12,24 +69,47 @@ pub fn print_storage_logs_details(
     tracing::info!("┌──────────────────┐");
     tracing::info!("│   STORAGE LOGS   │");
     tracing::info!("└──────────────────┘");
+
+    let mut cost_paid = HashMap::<StorageKey, u32>::default();
+
     for log_query in &result.logs.storage_logs {
+        let pubdata_bytes_info = if matches!(
+            log_query.log_type,
+            StorageLogQueryType::RepeatedWrite | StorageLogQueryType::InitialWrite
+        ) {
+            Some(compute_and_update_pubdata_cost(&mut cost_paid, log_query))
+        } else {
+            None
+        };
+
         match show_storage_logs {
             ShowStorageLogs::Write => {
                 if matches!(
                     log_query.log_type,
                     StorageLogQueryType::RepeatedWrite | StorageLogQueryType::InitialWrite
                 ) {
-                    formatter::print_logs(log_query);
+                    formatter::print_logs(log_query, pubdata_bytes_info);
+                }
+            }
+            ShowStorageLogs::Paid => {
+                // Show only the logs that incur any cost.
+                if pubdata_bytes_info
+                    .as_ref()
+                    .map(|x| x.does_cost())
+                    .unwrap_or_default()
+                {
+                    formatter::print_logs(log_query, pubdata_bytes_info);
                 }
             }
             ShowStorageLogs::Read => {
                 if log_query.log_type == StorageLogQueryType::Read {
-                    formatter::print_logs(log_query);
+                    formatter::print_logs(log_query, pubdata_bytes_info);
                 }
             }
             ShowStorageLogs::All => {
-                formatter::print_logs(log_query);
+                formatter::print_logs(log_query, pubdata_bytes_info);
             }
+
             _ => {}
         }
     }


### PR DESCRIPTION
# What :computer: 
* Display detailed information on how many pubdata bytes does each write cost
* added "paid" option to --show-storage-logs to see only the writes that cost pubdata

# Why :hand:
* The cost of pubdata is in many cases the highest cost related to the transaction
* with boojum release, we use pubdata compression, so each slot might use between 6 and 64 bytes - so it is important for users to see how much they have to pay - and this would also be a good signal for them to see where they can save.


# Evidence :camera:
![image](https://github.com/matter-labs/era-test-node/assets/128217157/38c13701-ad40-40eb-8500-8654e4bed0c6)

