### PR TITLE
fix: Fix the memory position for bootloader debug information

### DIFF
--- a/src/bootloader_debug.rs
+++ b/src/bootloader_debug.rs
@@ -13,9 +13,12 @@ use zksync_state::WriteStorage;
 /// debugger was enabled.
 const DEBUG_START_SENTINEL: u64 = 1337;
 
-const MAX_MEMORY_BYTES: usize = usize::pow(2, 24);
+// Taken from bootloader.yul (MAX_MEM_SIZE)
+const MAX_MEMORY_BYTES: usize = 24_000_000;
 
-const MAX_TRANSACTIONS: usize = 1024;
+// Taken from Systemconfig.json
+const MAX_TRANSACTIONS: usize = 10000;
+
 const RESULTS_BYTES_OFFSET: usize = MAX_MEMORY_BYTES - MAX_TRANSACTIONS * 32;
 
 const VM_HOOKS_PARAMS: usize = 2;


### PR DESCRIPTION
# What :computer: 
* Fixed the detailed gas computation - after the most recent release, the bootloader memory layout has changed and it we didn't update it.

# Evidence :camera:
<img width="695" alt="image" src="https://github.com/matter-labs/era-test-node/assets/128217157/a05e7e36-d01f-420b-b422-3338a8262bf7">
