### PR TITLE
fix: add missing version support and increase version in toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,7 +2017,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "era_test_node"
-version = "0.1.0-alpha.19"
+version = "0.1.0-alpha.21"
 dependencies = [
  "anyhow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "0.1.0-alpha.19"
+version = "0.1.0-alpha.21"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -334,6 +334,9 @@ const SUPPORTED_VERSIONS: &[ProtocolVersionId] = &[
     ProtocolVersionId::Version20,
     ProtocolVersionId::Version21,
     ProtocolVersionId::Version22,
+    ProtocolVersionId::Version23,
+    ProtocolVersionId::Version24,
+    ProtocolVersionId::Version25,
 ];
 
 pub fn supported_protocol_versions(version: ProtocolVersionId) -> bool {


### PR DESCRIPTION
# What :computer: 
* Add missing support for v23, v24, and v25
* Bump version in `cargo.toml` to upcoming release

# Why :hand:
* This is blocking `./era_test_node fork testnet`
* To match the version in GitHub Releases

# Evidence :camera:
Successful forking of testnet
<img width="1166" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/6b69eb60-24ab-422f-b6b4-8e7346fad961">

Successful forking of mainnet
<img width="1166" alt="image" src="https://github.com/matter-labs/era-test-node/assets/1890113/bd52c1dd-9357-430e-97d5-99c07ce8a548">

