### PR TITLE
fix: L2 gas price change

### DIFF
--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -30,13 +30,13 @@ describe("zks_estimateFee", function () {
     // Act
     const response: Fee = await provider.send("zks_estimateFee", [transaction]);
     // Assert
-    expect(ethers.BigNumber.from(response.gas_limit)).to.eql(ethers.BigNumber.from("5448356"), "Unexpected gas_limit");
+    expect(ethers.BigNumber.from(response.gas_limit)).to.eql(ethers.BigNumber.from("7203486"), "Unexpected gas_limit");
     expect(ethers.BigNumber.from(response.gas_per_pubdata_limit)).to.eql(
-      ethers.BigNumber.from("37500"),
+      ethers.BigNumber.from("50000"),
       "Unexpected gas_per_pubdata_limit"
     );
     expect(ethers.BigNumber.from(response.max_fee_per_gas)).to.eql(
-      ethers.BigNumber.from("50000000"),
+      ethers.BigNumber.from("37500000"),
       "Unexpected max_fee_per_gas"
     );
     expect(ethers.BigNumber.from(response.max_priority_fee_per_gas)).to.eql(

--- a/src/node/eth.rs
+++ b/src/node/eth.rs
@@ -2226,7 +2226,7 @@ mod tests {
             .await
             .expect("failed getting filter changes")
         {
-            FilterChanges::Logs(result) => assert_eq!(2, result.len()),
+            FilterChanges::Logs(result) => assert_eq!(3, result.len()),
             changes => panic!("unexpected filter changes: {:?}", changes),
         }
 

--- a/src/node/fee_model.rs
+++ b/src/node/fee_model.rs
@@ -4,7 +4,7 @@ use zksync_types::fee_model::{FeeModelConfigV2, FeeParams, FeeParamsV2};
 use zksync_types::L1_GAS_PER_PUBDATA_BYTE;
 
 pub const CONFIG: FeeModelConfigV2 = FeeModelConfigV2 {
-    minimal_l2_gas_price: 50_000_000,
+    minimal_l2_gas_price: 20_000_000,
     compute_overhead_part: 0.0,
     pubdata_overhead_part: 1.0,
     batch_overhead_l1_gas: 800000,

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -79,8 +79,8 @@ pub const TEST_NODE_NETWORK_ID: u32 = 260;
 /// L1 Gas Price.
 pub const L1_GAS_PRICE: u64 = 50_000_000_000;
 // TODO: for now, that's fine, as computation overhead is set to zero, but we may consider using calculated fee input everywhere.
-/// L2 Gas Price (0.05 gwei).
-pub const L2_GAS_PRICE: u64 = 50_000_000;
+/// L2 Gas Price.
+pub const L2_GAS_PRICE: u64 = 25_000_000;
 /// L1 Gas Price Scale Factor for gas estimation.
 pub const ESTIMATE_GAS_PRICE_SCALE_FACTOR: f64 = 1.5;
 /// Acceptable gas overestimation limit.

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1897,10 +1897,10 @@ mod tests {
             hex::decode("bbf55335").unwrap(), // keccak selector for "transact_retrieve1()"
             Nonce(1),
             Fee {
-                gas_limit: U256::from(815563),
+                gas_limit: U256::from(4_000_000),
                 max_fee_per_gas: U256::from(250_000_000),
                 max_priority_fee_per_gas: U256::from(250_000_000),
-                gas_per_pubdata_limit: U256::from(25000),
+                gas_per_pubdata_limit: U256::from(50000),
             },
             U256::from(0),
             zksync_basic_types::L2ChainId::from(260),

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -447,10 +447,10 @@ mod tests {
             vec![],
             Nonce(0),
             Fee {
-                gas_limit: U256::from(1_000_000),
+                gas_limit: U256::from(100_000_000),
                 max_fee_per_gas: U256::from(50_000_000),
                 max_priority_fee_per_gas: U256::from(50_000_000),
-                gas_per_pubdata_limit: U256::from(25000),
+                gas_per_pubdata_limit: U256::from(50000),
             },
             to_impersonate,
             U256::one(),

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -590,10 +590,10 @@ mod tests {
 
         let result = node.estimate_fee(mock_request).await.unwrap();
 
-        assert_eq!(result.gas_limit, U256::from(6793236));
-        assert_eq!(result.max_fee_per_gas, U256::from(50000000));
+        assert_eq!(result.gas_limit, U256::from(8970736));
+        assert_eq!(result.max_fee_per_gas, U256::from(37500000));
         assert_eq!(result.max_priority_fee_per_gas, U256::from(0));
-        assert_eq!(result.gas_per_pubdata_limit, U256::from(37500));
+        assert_eq!(result.gas_per_pubdata_limit, U256::from(50000));
     }
 
     #[tokio::test]

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -373,7 +373,7 @@ impl Default for TransactionBuilder {
         Self {
             tx_hash: H256::repeat_byte(0x01),
             from_account_private_key: K256PrivateKey::from_bytes(H256::random()).unwrap(),
-            gas_limit: U256::from(2_000_000),
+            gas_limit: U256::from(4_000_000),
             max_fee_per_gas: U256::from(50_000_000),
             max_priority_fee_per_gas: U256::from(50_000_000),
         }
@@ -414,7 +414,7 @@ impl TransactionBuilder {
                 gas_limit: self.gas_limit,
                 max_fee_per_gas: self.max_fee_per_gas,
                 max_priority_fee_per_gas: self.max_priority_fee_per_gas,
-                gas_per_pubdata_limit: U256::from(25000),
+                gas_per_pubdata_limit: U256::from(50000),
             },
             U256::from(1),
             L2ChainId::from(260),

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -512,7 +512,7 @@ pub fn deploy_contract<T: ForkSource + std::fmt::Debug + Clone>(
         data.to_vec(),
         nonce,
         Fee {
-            gas_limit: U256::from(92511299),
+            gas_limit: U256::from(400_000_000),
             max_fee_per_gas: U256::from(50_000_000),
             max_priority_fee_per_gas: U256::from(50_000_000),
             gas_per_pubdata_limit: U256::from(50000),


### PR DESCRIPTION
# What :computer:
Halved `L2_GAS_PRICE` to 25000000 and changed the fee model to match.

# Why :hand:
Replaying some Sepolia transactions didn't work with the original value.

# Evidence :camera:
Both unit and e2e tests pass.
