### PR TITLE
fix: updated constants used by BootloaderDebugTracer

### DIFF
--- a/src/bootloader_debug.rs
+++ b/src/bootloader_debug.rs
@@ -14,14 +14,14 @@ use zksync_state::WriteStorage;
 const DEBUG_START_SENTINEL: u64 = 1337;
 
 // Taken from bootloader.yul (MAX_MEM_SIZE)
-const MAX_MEMORY_BYTES: usize = 30_000_000;
+const MAX_MEMORY_BYTES: usize = 63800000;
 
 // Taken from Systemconfig.json
 const MAX_TRANSACTIONS: usize = 10000;
 
 const RESULTS_BYTES_OFFSET: usize = MAX_MEMORY_BYTES - MAX_TRANSACTIONS * 32;
 
-const VM_HOOKS_PARAMS: usize = 2;
+const VM_HOOKS_PARAMS: usize = 3;
 
 const VM_HOOKS_START: usize = RESULTS_BYTES_OFFSET - (VM_HOOKS_PARAMS + 1) * 32;
 

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1263,20 +1263,6 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 )
             );
 
-            {
-                let fee_model_config = self
-                    .inner
-                    .read()
-                    .expect("Failed to acquire reading lock")
-                    .fee_input_provider
-                    .get_fee_model_config();
-                tracing::info!(
-                    "Publishing full block costs the operator around {} l2 gas",
-                    to_human_size(
-                        bootloader_debug.gas_per_pubdata * fee_model_config.batch_overhead_l1_gas
-                    ),
-                );
-            }
             tracing::info!("Your transaction has contributed to filling up the block in the following way (we take the max contribution as the cost):");
             tracing::info!(
                 "  Length overhead:  {:>15}",


### PR DESCRIPTION
# What :computer: 
- Changed `MAX_MEMORY_BYTES` and `VM_HOOKS_PARAMS` to correspond to `MAX_MEM_SIZE()` and `VM_HOOK_PARAMS()` in https://github.com/matter-labs/era-contracts/blob/main/system-contracts/bootloader/bootloader.yul .
- Removed the call to `self.inner.read()` from `display_detailed_gas_info`.

# Why :hand:
- Since the parameters got out of sync, `BootloaderDebugTracer` was unable to load `BootloaderDebug`.
- Re-enabling the functionality exposed a deadlock in `display_detailed_gas_info`.

# Evidence :camera:
Running
```
./target/release/era_test_node --show-gas-details=all replay_tx sepolia-testnet 0x488c598ad0d6f1135bd61e5bce494be6b79a17deebd1d09a700da7dddde2efde
```

on the main branch produces
```
13:50:22  INFO Gas - Limit: 1_919_764 | Used: 968_051 | Refunded: 951_713
13:50:22  INFO !!! FAILED TO GET DETAILED GAS INFO !!!
```

while this branch has
```
13:48:37  INFO ┌─────────────────────────┐
13:48:37  INFO │       GAS DETAILS       │
13:48:37  INFO └─────────────────────────┘
13:48:37  INFO Gas - Limit: 1_919_764 | Used: 123_144 | Refunded: 951_713
13:48:37  INFO   WARNING: Refund by VM: 1_796_620, but operator refunded more: 951_713
13:48:37  INFO During execution published 0 bytes to L1, @50_000 each - in total 0 gas
13:48:37  INFO Out of 123_144 gas used, we spent:
13:48:37  INFO            24_070 gas (19%) for transaction setup
13:48:37  INFO             3_369 gas ( 2%) for bytecode preparation (decompression etc)
13:48:37  INFO            86_650 gas (70%) for account validation
13:48:37  INFO             9_055 gas ( 7%) for computations (opcodes)
```