### PR TITLE
fix: double gas limit, bootloader memory layout

### DIFF
--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -30,7 +30,7 @@ describe("zks_estimateFee", function () {
     // Act
     const response: Fee = await provider.send("zks_estimateFee", [transaction]);
     // Assert
-    expect(ethers.BigNumber.from(response.gas_limit)).to.eql(ethers.BigNumber.from("7203486"), "Unexpected gas_limit");
+    expect(ethers.BigNumber.from(response.gas_limit)).to.eql(ethers.BigNumber.from("3606743"), "Unexpected gas_limit");
     expect(ethers.BigNumber.from(response.gas_per_pubdata_limit)).to.eql(
       ethers.BigNumber.from("50000"),
       "Unexpected gas_per_pubdata_limit"

--- a/src/bootloader_debug.rs
+++ b/src/bootloader_debug.rs
@@ -14,14 +14,14 @@ use zksync_state::WriteStorage;
 const DEBUG_START_SENTINEL: u64 = 1337;
 
 // Taken from bootloader.yul (MAX_MEM_SIZE)
-const MAX_MEMORY_BYTES: usize = 30_000_000;
+const MAX_MEMORY_BYTES: usize = 63_800_000;
 
 // Taken from Systemconfig.json
 const MAX_TRANSACTIONS: usize = 10000;
 
 const RESULTS_BYTES_OFFSET: usize = MAX_MEMORY_BYTES - MAX_TRANSACTIONS * 32;
 
-const VM_HOOKS_PARAMS: usize = 2;
+const VM_HOOKS_PARAMS: usize = 3;
 
 const VM_HOOKS_START: usize = RESULTS_BYTES_OFFSET - (VM_HOOKS_PARAMS + 1) * 32;
 

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -665,9 +665,7 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
                 )))
             }
             ExecutionResult::Success { .. } => {
-                let full_gas_limit = match suggested_gas_limit
-                    .overflowing_add(suggested_gas_limit + overhead)
-                {
+                let full_gas_limit = match suggested_gas_limit.overflowing_add(overhead) {
                     (value, false) => value,
                     (_, true) => {
                         tracing::info!("{}", "Overflow when calculating gas estimation. We've exceeded the block gas limit by summing the following values:".red());
@@ -1366,8 +1364,8 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
     ) -> Result<L2TxResult, String> {
         let inner = self
             .inner
-            .write()
-            .map_err(|e| format!("Failed to acquire write lock: {}", e))?;
+            .read()
+            .map_err(|e| format!("Failed to acquire read lock: {}", e))?;
 
         let storage = StorageView::new(inner.fork_storage.clone()).into_rc_ptr();
 
@@ -1404,7 +1402,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             BootloaderDebugTracer {
                 result: bootloader_debug_result.clone(),
             }
-            .into_tracer_pointer(),
+                .into_tracer_pointer(),
         );
 
         let tx_result = vm.inspect(tracers.into(), VmExecutionMode::OneTx);
@@ -1438,13 +1436,13 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 "Use --show-gas-details flag or call config_setShowGasDetails to display more info"
             ),
             ShowGasDetails::All => {
-                if self
-                    .display_detailed_gas_info(bootloader_debug_result.get(), spent_on_pubdata)
-                    .is_err()
-                {
+                let info = self
+                    .display_detailed_gas_info(bootloader_debug_result.get(), spent_on_pubdata);
+                if info.is_err() {
                     tracing::info!(
-                        "{}",
-                        "!!! FAILED TO GET DETAILED GAS INFO !!!".to_owned().red()
+                        "{}\nError: {}",
+                        "!!! FAILED TO GET DETAILED GAS INFO !!!".to_owned().red(),
+                        info.unwrap_err()
                     );
                 }
             }
@@ -1900,7 +1898,7 @@ mod tests {
             vec![],
             true,
         )
-        .expect("transaction must pass with external storage");
+            .expect("transaction must pass with external storage");
     }
 
     #[tokio::test]
@@ -1944,7 +1942,7 @@ mod tests {
             None,
             Default::default(),
         )
-        .expect("failed signing tx");
+            .expect("failed signing tx");
         tx.common_data.transaction_type = TransactionType::LegacyTransaction;
         tx.set_input(vec![], H256::repeat_byte(0x2));
         let (_, result, ..) = node

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1402,7 +1402,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             BootloaderDebugTracer {
                 result: bootloader_debug_result.clone(),
             }
-                .into_tracer_pointer(),
+            .into_tracer_pointer(),
         );
 
         let tx_result = vm.inspect(tracers.into(), VmExecutionMode::OneTx);
@@ -1436,8 +1436,8 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 "Use --show-gas-details flag or call config_setShowGasDetails to display more info"
             ),
             ShowGasDetails::All => {
-                let info = self
-                    .display_detailed_gas_info(bootloader_debug_result.get(), spent_on_pubdata);
+                let info =
+                    self.display_detailed_gas_info(bootloader_debug_result.get(), spent_on_pubdata);
                 if info.is_err() {
                     tracing::info!(
                         "{}\nError: {}",
@@ -1898,7 +1898,7 @@ mod tests {
             vec![],
             true,
         )
-            .expect("transaction must pass with external storage");
+        .expect("transaction must pass with external storage");
     }
 
     #[tokio::test]
@@ -1942,7 +1942,7 @@ mod tests {
             None,
             Default::default(),
         )
-            .expect("failed signing tx");
+        .expect("failed signing tx");
         tx.common_data.transaction_type = TransactionType::LegacyTransaction;
         tx.set_input(vec![], H256::repeat_byte(0x2));
         let (_, result, ..) = node

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -590,7 +590,7 @@ mod tests {
 
         let result = node.estimate_fee(mock_request).await.unwrap();
 
-        assert_eq!(result.gas_limit, U256::from(8970736));
+        assert_eq!(result.gas_limit, U256::from(4490368));
         assert_eq!(result.max_fee_per_gas, U256::from(37500000));
         assert_eq!(result.max_priority_fee_per_gas, U256::from(0));
         assert_eq!(result.gas_per_pubdata_limit, U256::from(50000));


### PR DESCRIPTION
# What :computer: 
* Fix the gas limit being added to itself
* Fix bootloader memory layout (to match the most recent bootloader params)
* Fix mutex usage

# Why :hand:
* `--show-gas-details=all` was blocked by both bootloader and mutex issues
* double gas limit was blocking the deployment of larger contracts due to going over the block gas limit

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
