### PR TITLE
feat: procure l2 gas price when forking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -232,9 +232,10 @@ struct Cli {
     /// Show Gas details information
     show_gas_details: ShowGasDetails,
 
-    #[arg(long, default_value_t = DEFAULT_L2_GAS_PRICE)]
-    /// If provided, uses a custom value as the L2 gas price.
-    l2_gas_price: u64,
+    #[arg(long)]
+    /// If provided, uses a custom value as the L2 gas price. If not provided the gas price will be
+    /// inferred from the protocol version.
+    l2_gas_price: Option<u64>,
 
     #[arg(long)]
     /// If true, the tool will try to contact openchain to resolve the ABI & topic names.
@@ -360,11 +361,27 @@ async fn main() -> anyhow::Result<()> {
         DevSystemContracts::Local => system_contracts::Options::Local,
     };
 
+    // If L2 gas price has been supplied as an argument use that value,
+    // otherwise procure it from the fork source, or if that fails, use the
+    // `DEFAULT_L2_GAS_PRICE`.
+    let l2_fair_gas_price = opt.l2_gas_price.unwrap_or_else(|| {
+        if let Some(f) = &fork_details {
+            f.l2_fair_gas_price
+        } else {
+            DEFAULT_L2_GAS_PRICE
+        }
+    });
+
+    tracing::info!(
+        "Starting node with L2 gas price set to {}",
+        l2_fair_gas_price
+    );
+
     let node = InMemoryNode::new(
         fork_details,
         Some(observability),
         InMemoryNodeConfig {
-            l2_gas_price: opt.l2_gas_price,
+            l2_fair_gas_price,
             show_calls: opt.show_calls,
             show_outputs: opt.show_outputs,
             show_storage_logs: opt.show_storage_logs,

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -880,7 +880,7 @@ pub struct Snapshot {
 #[derive(Debug, Clone)]
 pub struct InMemoryNodeConfig {
     // The values to be used when calculating gas.
-    pub l2_gas_price: u64,
+    pub l2_fair_gas_price: u64,
     pub show_calls: ShowCalls,
     pub show_outputs: bool,
     pub show_storage_logs: ShowStorageLogs,
@@ -893,7 +893,7 @@ pub struct InMemoryNodeConfig {
 impl Default for InMemoryNodeConfig {
     fn default() -> Self {
         Self {
-            l2_gas_price: DEFAULT_L2_GAS_PRICE,
+            l2_fair_gas_price: DEFAULT_L2_GAS_PRICE,
             show_calls: Default::default(),
             show_outputs: Default::default(),
             show_storage_logs: Default::default(),
@@ -952,7 +952,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 current_miniblock_hash: f.l2_miniblock_hash,
                 fee_input_provider: TestNodeFeeInputProvider::new(
                     f.l1_gas_price,
-                    config.l2_gas_price,
+                    config.l2_fair_gas_price,
                 ),
                 tx_results: Default::default(),
                 blocks,
@@ -989,7 +989,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 current_miniblock_hash: block_hash,
                 fee_input_provider: TestNodeFeeInputProvider::new(
                     L1_GAS_PRICE,
-                    config.l2_gas_price,
+                    config.l2_fair_gas_price,
                 ),
                 tx_results: Default::default(),
                 blocks,
@@ -1887,6 +1887,7 @@ mod tests {
                 block_timestamp: 1002,
                 overwrite_chain_id: None,
                 l1_gas_price: 1000,
+                l2_fair_gas_price: DEFAULT_L2_GAS_PRICE,
             }),
             None,
             Default::default(),


### PR DESCRIPTION
# What :computer: 
- Automatically set the L2 fair gas price based on which network we're forking from.

# Why :hand:
Instead of having the L2 gas base price only as a constant/cli-argument, this PR introduces support for fetching the `l2_fair_gas_price` value within `BlockDetails`. This means that when forking from a network the base price will be adjusted automatically and no manual changing of the constant is necessary.

# Evidence :camera:
<img width="1369" alt="image" src="https://github.com/matter-labs/era-test-node/assets/94441036/fb1b06ea-bd31-4805-8745-b1c57b20584c">

_Forking from `sepolia-testnet`, the L2 gas price is set to `25_000_000`._

<img width="1369" alt="image" src="https://github.com/matter-labs/era-test-node/assets/94441036/74360602-e5cc-455b-8e23-81d5a9cf5fd2">

_Forking from `sepolia-testnet`, this time overriding the procured gas price with `--l2-gas-price=50000000`._

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
