### PR TITLE
chore: Incremented toml version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "0.1.0-alpha.21"
+version = "0.1.0-alpha.23"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"


### PR DESCRIPTION
# What :computer: 
Incremented version from `"0.1.0-alpha.21"` to `"0.1.0-alpha.23"`.

# Why :hand:
- To have a release that includes [these changes](https://github.com/matter-labs/era-test-node/pull/289)
- Version 22 has already been released