### PR TITLE
feat: custom l1 price

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -234,6 +234,10 @@ struct Cli {
     show_gas_details: ShowGasDetails,
 
     #[arg(long)]
+    /// If provided, uses a custom value as the L1 gas price.
+    l1_gas_price: Option<u64>,
+
+    #[arg(long)]
     /// If provided, uses a custom value as the L2 gas price. If not provided the gas price will be
     /// inferred from the protocol version.
     l2_gas_price: Option<u64>,
@@ -393,6 +397,7 @@ async fn main() -> anyhow::Result<()> {
         fork_details,
         Some(observability),
         InMemoryNodeConfig {
+            l1_gas_price: opt.l1_gas_price,
             l2_fair_gas_price,
             show_calls: opt.show_calls,
             show_outputs: opt.show_outputs,

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,9 +232,10 @@ struct Cli {
     /// Show Gas details information
     show_gas_details: ShowGasDetails,
 
-    #[arg(long, default_value_t = DEFAULT_L2_GAS_PRICE)]
-    /// If provided, uses a custom value as the L2 gas price.
-    l2_gas_price: u64,
+    #[arg(long)]
+    /// If provided, uses a custom value as the L2 gas price. If not provided the gas price will be
+    /// inferred from the protocol version.
+    l2_gas_price: Option<u64>,
 
     #[arg(long)]
     /// If true, the tool will try to contact openchain to resolve the ABI & topic names.
@@ -360,11 +361,27 @@ async fn main() -> anyhow::Result<()> {
         DevSystemContracts::Local => system_contracts::Options::Local,
     };
 
+    // If L2 gas price has been supplied as an argument use that value,
+    // otherwise procure it from the fork source, or if that fails, use the
+    // `DEFAULT_L2_GAS_PRICE`.
+    let l2_fair_gas_price = opt.l2_gas_price.unwrap_or_else(|| {
+        if let Some(f) = &fork_details {
+            f.l2_fair_gas_price
+        } else {
+            DEFAULT_L2_GAS_PRICE
+        }
+    });
+
+    tracing::info!(
+        "Starting node with L2 gas price set to {}",
+        l2_fair_gas_price
+    );
+
     let node = InMemoryNode::new(
         fork_details,
         Some(observability),
         InMemoryNodeConfig {
-            l2_gas_price: opt.l2_gas_price,
+            l2_fair_gas_price,
             show_calls: opt.show_calls,
             show_outputs: opt.show_outputs,
             show_storage_logs: opt.show_storage_logs,

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -880,7 +880,7 @@ pub struct Snapshot {
 #[derive(Debug, Clone)]
 pub struct InMemoryNodeConfig {
     // The values to be used when calculating gas.
-    pub l2_gas_price: u64,
+    pub l2_fair_gas_price: u64,
     pub show_calls: ShowCalls,
     pub show_outputs: bool,
     pub show_storage_logs: ShowStorageLogs,
@@ -893,7 +893,7 @@ pub struct InMemoryNodeConfig {
 impl Default for InMemoryNodeConfig {
     fn default() -> Self {
         Self {
-            l2_gas_price: DEFAULT_L2_GAS_PRICE,
+            l2_fair_gas_price: DEFAULT_L2_GAS_PRICE,
             show_calls: Default::default(),
             show_outputs: Default::default(),
             show_storage_logs: Default::default(),
@@ -952,7 +952,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 current_miniblock_hash: f.l2_miniblock_hash,
                 fee_input_provider: TestNodeFeeInputProvider::new(
                     f.l1_gas_price,
-                    config.l2_gas_price,
+                    config.l2_fair_gas_price,
                 ),
                 tx_results: Default::default(),
                 blocks,
@@ -989,7 +989,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 current_miniblock_hash: block_hash,
                 fee_input_provider: TestNodeFeeInputProvider::new(
                     L1_GAS_PRICE,
-                    config.l2_gas_price,
+                    config.l2_fair_gas_price,
                 ),
                 tx_results: Default::default(),
                 blocks,
@@ -1887,6 +1887,7 @@ mod tests {
                 block_timestamp: 1002,
                 overwrite_chain_id: None,
                 l1_gas_price: 1000,
+                l2_fair_gas_price: DEFAULT_L2_GAS_PRICE,
             }),
             None,
             Default::default(),

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -941,7 +941,11 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
         observability: Option<Observability>,
         config: InMemoryNodeConfig,
     ) -> Self {
-        let default_l1_gas_price = if let Some(f) = &fork { f.l1_gas_price } else { DEFAULT_L1_GAS_PRICE };
+        let default_l1_gas_price = if let Some(f) = &fork {
+            f.l1_gas_price
+        } else {
+            DEFAULT_L1_GAS_PRICE
+        };
         let l1_gas_price = if let Some(custom_l1_gas_price) = config.l1_gas_price {
             tracing::info!(
                 "L1 gas price set to {} (overridden from {})",

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -74,7 +74,7 @@ pub const NON_FORK_FIRST_BLOCK_TIMESTAMP: u64 = 1_000;
 /// Network ID we use for the test node.
 pub const TEST_NODE_NETWORK_ID: u32 = 260;
 /// L1 Gas Price.
-pub const L1_GAS_PRICE: u64 = 50_000_000_000;
+pub const DEFAULT_L1_GAS_PRICE: u64 = 50_000_000_000;
 // TODO: for now, that's fine, as computation overhead is set to zero, but we may consider using calculated fee input everywhere.
 /// The default L2 Gas Price to be used if not supplied via the CLI argument.
 pub const DEFAULT_L2_GAS_PRICE: u64 = 25_000_000;
@@ -880,6 +880,7 @@ pub struct Snapshot {
 #[derive(Debug, Clone)]
 pub struct InMemoryNodeConfig {
     // The values to be used when calculating gas.
+    pub l1_gas_price: Option<u64>,
     pub l2_fair_gas_price: u64,
     pub show_calls: ShowCalls,
     pub show_outputs: bool,
@@ -893,6 +894,7 @@ pub struct InMemoryNodeConfig {
 impl Default for InMemoryNodeConfig {
     fn default() -> Self {
         Self {
+            l1_gas_price: None,
             l2_fair_gas_price: DEFAULT_L2_GAS_PRICE,
             show_calls: Default::default(),
             show_outputs: Default::default(),
@@ -939,6 +941,18 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
         observability: Option<Observability>,
         config: InMemoryNodeConfig,
     ) -> Self {
+        let default_l1_gas_price = if let Some(f) = &fork { f.l1_gas_price } else { DEFAULT_L1_GAS_PRICE };
+        let l1_gas_price = if let Some(custom_l1_gas_price) = config.l1_gas_price {
+            tracing::info!(
+                "L1 gas price set to {} (overridden from {})",
+                to_human_size(custom_l1_gas_price.into()),
+                to_human_size(default_l1_gas_price.into())
+            );
+            custom_l1_gas_price
+        } else {
+            default_l1_gas_price
+        };
+
         let inner = if let Some(f) = &fork {
             let mut block_hashes = HashMap::<u64, H256>::new();
             block_hashes.insert(f.l2_block.number.as_u64(), f.l2_block.hash);
@@ -951,7 +965,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 current_miniblock: f.l2_miniblock,
                 current_miniblock_hash: f.l2_miniblock_hash,
                 fee_input_provider: TestNodeFeeInputProvider::new(
-                    f.l1_gas_price,
+                    l1_gas_price,
                     config.l2_fair_gas_price,
                 ),
                 tx_results: Default::default(),
@@ -988,7 +1002,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 current_miniblock: 0,
                 current_miniblock_hash: block_hash,
                 fee_input_provider: TestNodeFeeInputProvider::new(
-                    L1_GAS_PRICE,
+                    l1_gas_price,
                     config.l2_fair_gas_price,
                 ),
                 tx_results: Default::default(),

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1016,8 +1016,10 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 create_empty_block(0, NON_FORK_FIRST_BLOCK_TIMESTAMP, 0, None),
             );
 
-            let mut fee_input_provider = TestNodeFeeInputProvider::default();
-            fee_input_provider.l1_gas_price = l1_gas_price;
+            let fee_input_provider = TestNodeFeeInputProvider {
+                l1_gas_price,
+                ..Default::default()
+            };
             InMemoryNodeInner {
                 current_timestamp: NON_FORK_FIRST_BLOCK_TIMESTAMP,
                 current_batch: 0,


### PR DESCRIPTION
# What :computer: 
Made the L1 price overridable from command line, in both forking and standalone mode.

# Why :hand:
Transactions succeed of fail depending on the node fees, and users/developers might want to experiment with that. 

# Evidence :camera:
Example (in replay mode):
```
$ ./target/release/era_test_node --show-calls=all --show-outputs --show-vm-details=all --resolve-hashes replay_tx sepolia-testnet 0xadf8319da65e377909e41a4806cb24eb7090cbdaf4521fad5084cfa933ce1849
10:31:45  INFO Creating fork from "https://sepolia.era.zksync.dev:443" L1 block: L1BatchNumber(8961) L2 block: 2386764 with timestamp 1715930527, L1 gas price 157087620156, L2 fair gas price 25000000 and protocol version: Some(Version24)
...
[!] Halt Reason:    virtual machine entered unexpected state. Please contact developers and provide transaction details that caused this error. Error description: Block.basefee is greater than max fee per gas
```
vs.

```
$ ./target/release/era_test_node --show-calls=all --show-outputs --show-vm-details=all --resolve-hashes --l1-gas-price=15708762015 replay_tx sepolia-testnet 0xadf8319da65e377909e41a4806cb24eb7090cbdaf4521fad5084cfa933ce1849
10:33:47  INFO Creating fork from "https://sepolia.era.zksync.dev:443" L1 block: L1BatchNumber(8961) L2 block: 2386764 with timestamp 1715930527, L1 gas price 157087620156, L2 fair gas price 25000000 and protocol version: Some(Version24)
10:33:47  INFO Starting node with L2 gas price set to 25_000_000
10:33:47  INFO L1 gas price set to 15_708_762_015 (overridden from 157_087_620_156)
...
10:33:51  INFO Transaction: SUCCESS
```