### PR TITLE
feat: different scaling gas constants based on forked network

### DIFF
--- a/src/fork.rs
+++ b/src/fork.rs
@@ -56,6 +56,7 @@ where
 }
 
 /// The possible networks to fork from.
+#[derive(Debug, Clone)]
 pub enum ForkNetwork {
     Mainnet,
     SepoliaTestnet,

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -75,7 +75,7 @@ impl ForkNetwork {
         }
     }
 
-    /// Returns the local gas scale factors currently in ues by the upstream network.
+    /// Returns the local gas scale factors currently in use by the upstream network.
     pub fn local_gas_scale_factors(&self) -> (f64, f32) {
         match self {
             ForkNetwork::Mainnet => (1.5, 1.2),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use crate::cache::CacheConfig;
 use crate::node::{InMemoryNodeConfig, ShowGasDetails, ShowStorageLogs, ShowVMDetails};
 use crate::observability::Observability;
-use crate::utils::to_human_size;
 use clap::{Parser, Subcommand, ValueEnum};
 use colored::Colorize;
 use fork::{ForkDetails, ForkSource};
@@ -362,32 +361,21 @@ async fn main() -> anyhow::Result<()> {
         DevSystemContracts::Local => system_contracts::Options::Local,
     };
 
-    // If we're forking we set the price to be equal to that contained within
-    // `ForkDetails`. If not, we use the `DEFAULT_L2_GAS_PRICE` instead.
-    let mut l2_fair_gas_price = {
+    // If L2 gas price has been supplied as an argument use that value,
+    // otherwise procure it from the fork source, or if that fails, use the
+    // `DEFAULT_L2_GAS_PRICE`.
+    let l2_fair_gas_price = opt.l2_gas_price.unwrap_or_else(|| {
         if let Some(f) = &fork_details {
             f.l2_fair_gas_price
         } else {
             DEFAULT_L2_GAS_PRICE
         }
-    };
+    });
 
-    // If L2 gas price has been supplied as an argument, override the value
-    // procured previously.
-    match opt.l2_gas_price {
-        Some(l2_gas_price) => {
-            tracing::info!(
-                "Starting node with L2 gas price set to {} (overridden from {})",
-                to_human_size(l2_gas_price.into()),
-                to_human_size(l2_fair_gas_price.into())
-            );
-            l2_fair_gas_price = l2_gas_price;
-        }
-        None => tracing::info!(
-            "Starting node with L2 gas price set to {}",
-            to_human_size(l2_fair_gas_price.into())
-        ),
-    }
+    tracing::info!(
+        "Starting node with L2 gas price set to {}",
+        l2_fair_gas_price
+    );
 
     let node = InMemoryNode::new(
         fork_details,

--- a/src/node/fee_model.rs
+++ b/src/node/fee_model.rs
@@ -7,13 +7,24 @@ use zksync_types::L1_GAS_PER_PUBDATA_BYTE;
 pub struct TestNodeFeeInputProvider {
     pub l1_gas_price: u64,
     pub l2_gas_price: u64,
+    /// L1 Gas Price Scale Factor for gas estimation.
+    pub estimate_gas_price_scale_factor: f64,
+    /// The factor by which to scale the gasLimit.
+    pub estimate_gas_scale_factor: f32,
 }
 
 impl TestNodeFeeInputProvider {
-    pub fn new(l1_gas_price: u64, l2_gas_price: u64) -> Self {
+    pub fn new(
+        l1_gas_price: u64,
+        l2_gas_price: u64,
+        estimate_gas_price_scale_factor: f64,
+        estimate_gas_scale_factor: f32,
+    ) -> Self {
         Self {
             l1_gas_price,
             l2_gas_price,
+            estimate_gas_price_scale_factor,
+            estimate_gas_scale_factor,
         }
     }
 


### PR DESCRIPTION
# What :computer: 
- Introduces a new enum `ForkNetwork` encapsulating network local values.

# Why :hand:
Currently, the scaling gas estimation parameters are hardcoded [here](https://github.com/eqlabs/era-test-node/blob/7a4722fe741009a4a46247438bfa09680572a2dd/src/node/in_memory.rs#L79) and [here](https://github.com/eqlabs/era-test-node/blob/7a4722fe741009a4a46247438bfa09680572a2dd/src/node/in_memory.rs#L85). However, these should actually be dependant on the network we fork from. These values can not yet be fetched from a publicly available source and as such, this PR introduces a temporary measure for hardcoding different gas estimation constants for each valid network source.

# Evidence :camera:
1. Running the test node with `cargo run --release fork <NETWORK>`.
2. Sending the following request: 
```bash
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"zks_estimateFee","params":[{"from":"0x40609141Db628BeEE3BfAB8034Fc2D8278D0Cc78", "to": "0xBC989fDe9e54cAd2aB4392Af6dF60f04873A033A", "data":"0x06fdde03"}],"id":1}' http://localhost:8011
```
3. Observing the logged values (_note: `tracing::trace!` statements changed to `println!` for better clarity_) results in:

<img width="1369" alt="Screenshot 2024-06-17 at 12 53 05" src="https://github.com/matter-labs/era-test-node/assets/94441036/b49b410b-18ec-4dec-8c0d-2b39518cae4f">

_`mainnet`_

<img width="1369" alt="Screenshot 2024-06-17 at 12 51 45" src="https://github.com/matter-labs/era-test-node/assets/94441036/3ad0321e-f7a6-4df5-b160-f0e846427a29">

_`sepolia-testnet`_


<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
