### PR TITLE
feat: dynamic fee model config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "era_test_node"
-version = "0.1.0-alpha.21"
+version = "0.1.0-alpha.23"
 dependencies = [
  "anyhow",
  "bigdecimal",

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -366,7 +366,7 @@ pub struct ForkDetails<S> {
     pub estimate_gas_price_scale_factor: f64,
     /// The factor by which to scale the gasLimit.
     pub estimate_gas_scale_factor: f32,
-    pub fee_params: FeeParams,
+    pub fee_params: Option<FeeParams>,
 }
 
 const SUPPORTED_VERSIONS: &[ProtocolVersionId] = &[
@@ -451,10 +451,7 @@ impl ForkDetails<HttpForkSource> {
 
         let (estimate_gas_price_scale_factor, estimate_gas_scale_factor) =
             network.local_gas_scale_factors();
-        let fee_params = client
-            .get_fee_params()
-            .await
-            .expect("Unable to get upstream fork");
+        let fee_params = client.get_fee_params().await.ok();
 
         ForkDetails {
             fork_source: HttpForkSource::new(url.to_owned(), cache_config),
@@ -571,7 +568,7 @@ impl<S: ForkSource> ForkDetails<S> {
 mod tests {
     use zksync_basic_types::{AccountTreeId, L1BatchNumber, H256};
     use zksync_state::ReadStorage;
-    use zksync_types::{api::TransactionVariant, fee_model::FeeParams, StorageKey};
+    use zksync_types::{api::TransactionVariant, StorageKey};
 
     use crate::{
         deps::InMemoryStorage,
@@ -612,7 +609,7 @@ mod tests {
             l2_fair_gas_price: DEFAULT_L2_GAS_PRICE,
             estimate_gas_price_scale_factor: DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
             estimate_gas_scale_factor: DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
-            fee_params: FeeParams::sensible_v1_default(),
+            fee_params: None,
         };
 
         let mut fork_storage = ForkStorage::new(Some(fork_details), &options);

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -19,6 +19,7 @@ use zksync_types::{
         Block, BlockDetails, BlockIdVariant, BlockNumber, BridgeAddresses, Transaction,
         TransactionDetails, TransactionVariant,
     },
+    fee_model::FeeParams,
     l2::L2Tx,
     url::SensitiveUrl,
     ProtocolVersionId, StorageKey,
@@ -308,6 +309,9 @@ pub trait ForkSource {
     /// Returns the block details for a given miniblock number.
     fn get_block_details(&self, miniblock: L2BlockNumber) -> eyre::Result<Option<BlockDetails>>;
 
+    /// Returns fee parameters for the give source.
+    fn get_fee_params(&self) -> eyre::Result<FeeParams>;
+
     /// Returns the  transaction count for a given block hash.
     fn get_block_transaction_count_by_hash(&self, block_hash: H256) -> eyre::Result<Option<U256>>;
 
@@ -362,6 +366,7 @@ pub struct ForkDetails<S> {
     pub estimate_gas_price_scale_factor: f64,
     /// The factor by which to scale the gasLimit.
     pub estimate_gas_scale_factor: f32,
+    pub fee_params: FeeParams,
 }
 
 const SUPPORTED_VERSIONS: &[ProtocolVersionId] = &[
@@ -446,6 +451,11 @@ impl ForkDetails<HttpForkSource> {
 
         let (estimate_gas_price_scale_factor, estimate_gas_scale_factor) =
             network.local_gas_scale_factors();
+        let fee_params = client
+            .get_fee_params()
+            .await
+            .expect("Unable to get upstream fork");
+
         ForkDetails {
             fork_source: HttpForkSource::new(url.to_owned(), cache_config),
             l1_block: l1_batch_number,
@@ -458,6 +468,7 @@ impl ForkDetails<HttpForkSource> {
             l2_fair_gas_price: block_details.base.l2_fair_gas_price,
             estimate_gas_price_scale_factor,
             estimate_gas_scale_factor,
+            fee_params,
         }
     }
     /// Create a fork from a given network at a given height.
@@ -560,7 +571,7 @@ impl<S: ForkSource> ForkDetails<S> {
 mod tests {
     use zksync_basic_types::{AccountTreeId, L1BatchNumber, H256};
     use zksync_state::ReadStorage;
-    use zksync_types::{api::TransactionVariant, StorageKey};
+    use zksync_types::{api::TransactionVariant, fee_model::FeeParams, StorageKey};
 
     use crate::{
         deps::InMemoryStorage,
@@ -601,6 +612,7 @@ mod tests {
             l2_fair_gas_price: DEFAULT_L2_GAS_PRICE,
             estimate_gas_price_scale_factor: DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
             estimate_gas_scale_factor: DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
+            fee_params: FeeParams::sensible_v1_default(),
         };
 
         let mut fork_storage = ForkStorage::new(Some(fork_details), &options);

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -286,6 +286,12 @@ impl ForkSource for HttpForkSource {
             .wrap_err("fork http client failed")
     }
 
+    /// Returns fee parameters for the give source.
+    fn get_fee_params(&self) -> eyre::Result<zksync_types::fee_model::FeeParams> {
+        let client = self.create_client();
+        block_on(async move { client.get_fee_params().await }).wrap_err("fork http client failed")
+    }
+
     /// Returns addresses of the default bridge contracts.
     fn get_bridge_contracts(&self) -> eyre::Result<BridgeAddresses> {
         if let Some(bridge_addresses) = self

--- a/src/node/fee_model.rs
+++ b/src/node/fee_model.rs
@@ -47,6 +47,17 @@ impl TestNodeFeeInputProvider {
         }
     }
 
+    pub fn from_estimate_scale_factors(
+        estimate_gas_price_scale_factor: f64,
+        estimate_gas_scale_factor: f32,
+    ) -> Self {
+        Self {
+            estimate_gas_price_scale_factor,
+            estimate_gas_scale_factor,
+            ..Default::default()
+        }
+    }
+
     pub fn get_fee_model_config(&self) -> FeeModelConfigV2 {
         FeeModelConfigV2 {
             minimal_l2_gas_price: self.l2_gas_price,

--- a/src/node/fee_model.rs
+++ b/src/node/fee_model.rs
@@ -3,10 +3,21 @@ use zksync_node_fee_model::BatchFeeModelInputProvider;
 use zksync_types::fee_model::{FeeModelConfigV2, FeeParams, FeeParamsV2};
 use zksync_types::L1_GAS_PER_PUBDATA_BYTE;
 
+use super::{
+    DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR, DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
+    DEFAULT_L2_GAS_PRICE, L1_GAS_PRICE,
+};
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct TestNodeFeeInputProvider {
     pub l1_gas_price: u64,
+    pub l1_pubdata_price: u64,
     pub l2_gas_price: u64,
+    pub compute_overhead_part: f64,
+    pub pubdata_overhead_part: f64,
+    pub batch_overhead_l1_gas: u64,
+    pub max_gas_per_batch: u64,
+    pub max_pubdata_per_batch: u64,
     /// L1 Gas Price Scale Factor for gas estimation.
     pub estimate_gas_price_scale_factor: f64,
     /// The factor by which to scale the gasLimit.
@@ -14,28 +25,36 @@ pub struct TestNodeFeeInputProvider {
 }
 
 impl TestNodeFeeInputProvider {
-    pub fn new(
-        l1_gas_price: u64,
-        l2_gas_price: u64,
+    pub fn from_fee_params_and_estimate_scale_factors(
+        fee_params: FeeParams,
         estimate_gas_price_scale_factor: f64,
         estimate_gas_scale_factor: f32,
     ) -> Self {
-        Self {
-            l1_gas_price,
-            l2_gas_price,
-            estimate_gas_price_scale_factor,
-            estimate_gas_scale_factor,
+        match fee_params {
+            FeeParams::V1(_) => todo!(),
+            FeeParams::V2(fee_params) => Self {
+                l1_gas_price: fee_params.l1_gas_price,
+                l1_pubdata_price: fee_params.l1_pubdata_price,
+                l2_gas_price: fee_params.config.minimal_l2_gas_price,
+                compute_overhead_part: fee_params.config.compute_overhead_part,
+                pubdata_overhead_part: fee_params.config.pubdata_overhead_part,
+                batch_overhead_l1_gas: fee_params.config.batch_overhead_l1_gas,
+                max_gas_per_batch: fee_params.config.max_gas_per_batch,
+                max_pubdata_per_batch: fee_params.config.max_pubdata_per_batch,
+                estimate_gas_price_scale_factor,
+                estimate_gas_scale_factor,
+            },
         }
     }
 
     pub fn get_fee_model_config(&self) -> FeeModelConfigV2 {
         FeeModelConfigV2 {
             minimal_l2_gas_price: self.l2_gas_price,
-            compute_overhead_part: 0.0,
-            pubdata_overhead_part: 1.0,
-            batch_overhead_l1_gas: 800000,
-            max_gas_per_batch: 200000000,
-            max_pubdata_per_batch: 100000,
+            compute_overhead_part: self.compute_overhead_part,
+            pubdata_overhead_part: self.pubdata_overhead_part,
+            batch_overhead_l1_gas: self.batch_overhead_l1_gas,
+            max_gas_per_batch: self.max_gas_per_batch,
+            max_pubdata_per_batch: self.max_pubdata_per_batch,
         }
     }
 }
@@ -46,7 +65,24 @@ impl BatchFeeModelInputProvider for TestNodeFeeInputProvider {
         FeeParams::V2(FeeParamsV2 {
             config: self.get_fee_model_config(),
             l1_gas_price: self.l1_gas_price,
-            l1_pubdata_price: self.l1_gas_price * L1_GAS_PER_PUBDATA_BYTE as u64,
+            l1_pubdata_price: self.l1_pubdata_price,
         })
+    }
+}
+
+impl Default for TestNodeFeeInputProvider {
+    fn default() -> Self {
+        Self {
+            l1_gas_price: L1_GAS_PRICE,
+            l1_pubdata_price: L1_GAS_PRICE * L1_GAS_PER_PUBDATA_BYTE as u64,
+            l2_gas_price: DEFAULT_L2_GAS_PRICE,
+            compute_overhead_part: 0.0,
+            pubdata_overhead_part: 1.0,
+            batch_overhead_l1_gas: 800000,
+            max_gas_per_batch: 200000000,
+            max_pubdata_per_batch: 100000,
+            estimate_gas_price_scale_factor: DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
+            estimate_gas_scale_factor: DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
+        }
     }
 }

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -954,12 +954,12 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 current_batch: f.l1_block.0,
                 current_miniblock: f.l2_miniblock,
                 current_miniblock_hash: f.l2_miniblock_hash,
-                fee_input_provider: TestNodeFeeInputProvider::new(
-                    f.l1_gas_price,
-                    config.l2_fair_gas_price,
-                    f.estimate_gas_price_scale_factor,
-                    f.estimate_gas_scale_factor,
-                ),
+                fee_input_provider:
+                    TestNodeFeeInputProvider::from_fee_params_and_estimate_scale_factors(
+                        f.fee_params,
+                        f.estimate_gas_price_scale_factor,
+                        f.estimate_gas_scale_factor,
+                    ),
                 tx_results: Default::default(),
                 blocks,
                 block_hashes,
@@ -993,12 +993,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 current_batch: 0,
                 current_miniblock: 0,
                 current_miniblock_hash: block_hash,
-                fee_input_provider: TestNodeFeeInputProvider::new(
-                    L1_GAS_PRICE,
-                    config.l2_fair_gas_price,
-                    DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
-                    DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
-                ),
+                fee_input_provider: TestNodeFeeInputProvider::default(),
                 tx_results: Default::default(),
                 blocks,
                 block_hashes,
@@ -1789,7 +1784,7 @@ impl BlockContext {
 mod tests {
     use ethabi::{Token, Uint};
     use zksync_basic_types::Nonce;
-    use zksync_types::{utils::deployed_address_create, K256PrivateKey};
+    use zksync_types::{fee_model::FeeParams, utils::deployed_address_create, K256PrivateKey};
 
     use super::*;
     use crate::{
@@ -1896,6 +1891,7 @@ mod tests {
                 overwrite_chain_id: None,
                 l1_gas_price: 1000,
                 l2_fair_gas_price: DEFAULT_L2_GAS_PRICE,
+                fee_params: FeeParams::sensible_v1_default(),
                 estimate_gas_price_scale_factor: DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
                 estimate_gas_scale_factor: DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
             }),

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -949,17 +949,20 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             let mut blocks = HashMap::<H256, Block<TransactionVariant>>::new();
             blocks.insert(f.l2_block.hash, f.l2_block.clone());
 
+            let mut fee_input_provider =
+                TestNodeFeeInputProvider::from_fee_params_and_estimate_scale_factors(
+                    f.fee_params,
+                    f.estimate_gas_price_scale_factor,
+                    f.estimate_gas_scale_factor,
+                );
+            fee_input_provider.l2_gas_price = config.l2_fair_gas_price;
+
             InMemoryNodeInner {
                 current_timestamp: f.block_timestamp,
                 current_batch: f.l1_block.0,
                 current_miniblock: f.l2_miniblock,
                 current_miniblock_hash: f.l2_miniblock_hash,
-                fee_input_provider:
-                    TestNodeFeeInputProvider::from_fee_params_and_estimate_scale_factors(
-                        f.fee_params,
-                        f.estimate_gas_price_scale_factor,
-                        f.estimate_gas_scale_factor,
-                    ),
+                fee_input_provider,
                 tx_results: Default::default(),
                 blocks,
                 block_hashes,

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -949,12 +949,18 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             let mut blocks = HashMap::<H256, Block<TransactionVariant>>::new();
             blocks.insert(f.l2_block.hash, f.l2_block.clone());
 
-            let mut fee_input_provider =
+            let mut fee_input_provider = if let Some(params) = f.fee_params {
                 TestNodeFeeInputProvider::from_fee_params_and_estimate_scale_factors(
-                    f.fee_params,
+                    params,
                     f.estimate_gas_price_scale_factor,
                     f.estimate_gas_scale_factor,
-                );
+                )
+            } else {
+                TestNodeFeeInputProvider::from_estimate_scale_factors(
+                    f.estimate_gas_price_scale_factor,
+                    f.estimate_gas_scale_factor,
+                )
+            };
             fee_input_provider.l2_gas_price = config.l2_fair_gas_price;
 
             InMemoryNodeInner {
@@ -1793,7 +1799,7 @@ impl BlockContext {
 mod tests {
     use ethabi::{Token, Uint};
     use zksync_basic_types::Nonce;
-    use zksync_types::{fee_model::FeeParams, utils::deployed_address_create, K256PrivateKey};
+    use zksync_types::{utils::deployed_address_create, K256PrivateKey};
 
     use super::*;
     use crate::{
@@ -1900,7 +1906,7 @@ mod tests {
                 overwrite_chain_id: None,
                 l1_gas_price: 1000,
                 l2_fair_gas_price: DEFAULT_L2_GAS_PRICE,
-                fee_params: FeeParams::sensible_v1_default(),
+                fee_params: None,
                 estimate_gas_price_scale_factor: DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
                 estimate_gas_scale_factor: DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
             }),

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -1212,6 +1212,31 @@ mod tests {
                 "id": 0
             }),
         );
+        mock_server.expect(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "zks_getFeeParams",
+            }),
+            serde_json::json!({
+              "jsonrpc": "2.0",
+              "result": {
+                "V2": {
+                  "config": {
+                    "minimal_l2_gas_price": 25000000,
+                    "compute_overhead_part": 0,
+                    "pubdata_overhead_part": 1,
+                    "batch_overhead_l1_gas": 800000,
+                    "max_gas_per_batch": 200000000,
+                    "max_pubdata_per_batch": 240000
+                  },
+                  "l1_gas_price": 46226388803u64,
+                  "l1_pubdata_price": 100780475095u64
+                }
+              },
+              "id": 2
+            }),
+        );
 
         let node = InMemoryNode::<HttpForkSource>::new(
             Some(ForkDetails::from_network(&mock_server.url(), Some(1), CacheConfig::None).await),

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -767,6 +767,10 @@ impl ForkSource for &ExternalStorage {
         todo!()
     }
 
+    fn get_fee_params(&self) -> eyre::Result<zksync_types::fee_model::FeeParams> {
+        todo!()
+    }
+
     fn get_block_transaction_count_by_hash(&self, _block_hash: H256) -> eyre::Result<Option<U256>> {
         todo!()
     }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -145,6 +145,32 @@ impl MockServer {
                 }
             }))),
         );
+        server.expect(
+            Expectation::matching(request::body(json_decoded(eq(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "zks_getFeeParams",
+            })))))
+            .respond_with(json_encoded(serde_json::json!(
+            {
+              "jsonrpc": "2.0",
+              "result": {
+                "V2": {
+                  "config": {
+                    "minimal_l2_gas_price": 25000000,
+                    "compute_overhead_part": 0,
+                    "pubdata_overhead_part": 1,
+                    "batch_overhead_l1_gas": 800000,
+                    "max_gas_per_batch": 200000000,
+                    "max_pubdata_per_batch": 240000
+                  },
+                  "l1_gas_price": 46226388803u64,
+                  "l1_pubdata_price": 100780475095u64
+                }
+              },
+              "id": 3
+            }))),
+        );
 
         MockServer { inner: server }
     }


### PR DESCRIPTION
# What :computer: 

- When forking from a network, adds a call to the RPC endpoint grabbing the current `FeeModel` configuration in use by the current protocol version at that network point.

# Why :hand:
- Currently L2 gas price and L1 gas price is automatically adjusted to appropriate levels, but the rest of the parameters in the fee model is not. This results in some transactions being executable while others are not.
- Closes #303.

# Evidence :camera:

Replaying the same transaction (`0xbbcf756e95b3b4024c85e188ce5801470e67b128dde1f95364c99e092ac46109`) on this branch and latest main (`93946cc`):

https://github.com/matter-labs/era-test-node/assets/94441036/296b717d-8a52-42ee-b6ac-0a38d85e15bd

_`feat/dynamic-fee-model-config`_

https://github.com/matter-labs/era-test-node/assets/94441036/51dccad0-1583-46d9-8918-00661d9ea02c

_`main`_

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
