### PR TITLE
fix: Include transaction type in the transaction receipt

### DIFF
--- a/e2e-tests/test/eth-apis.test.ts
+++ b/e2e-tests/test/eth-apis.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { Wallet } from "zksync-web3";
 import { getTestProvider } from "../helpers/utils";
 import { RichAccounts } from "../helpers/constants";
 import { ethers } from "ethers";
@@ -16,5 +17,32 @@ describe("eth_accounts", function () {
 
     // Assert
     expect(accounts).to.deep.equal(richAccounts);
+  });
+
+  it("Should have required fields in transaction receipt", async function () {
+    // Arrange
+    const wallet = new Wallet(RichAccounts[0].PrivateKey, provider);
+    const tx = await wallet.sendTransaction({
+      to: wallet.address,
+      value: ethers.utils.parseEther("3"),
+    });
+    const response = await tx.wait();
+    const txHash = response.transactionHash;
+
+    // Act
+    const receipt = await provider.send("eth_getTransactionReceipt", [txHash]);
+
+    // Assert
+    expect(receipt).to.have.property("blockHash");
+    expect(receipt).to.have.property("blockNumber");
+    expect(receipt).to.have.property("transactionHash");
+    expect(receipt).to.have.property("transactionIndex");
+    expect(receipt).to.have.property("from");
+    expect(receipt).to.have.property("to");
+    expect(receipt).to.have.property("cumulativeGasUsed");
+    expect(receipt).to.have.property("gasUsed");
+    expect(receipt).to.have.property("logs");
+    expect(receipt).to.have.property("logsBloom");
+    expect(receipt).to.have.property("type");
   });
 });

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1560,6 +1560,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
     /// Runs L2 transaction and commits it to a new block.
     pub fn run_l2_tx(&self, l2_tx: L2Tx, execution_mode: TxExecutionMode) -> Result<(), String> {
         let tx_hash = l2_tx.hash();
+        let transaction_type = l2_tx.common_data.transaction_type;
 
         tracing::info!("");
         tracing::info!("Validating {}", format!("{:?}", tx_hash).bold());
@@ -1672,7 +1673,8 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
                 U64::from(1)
             },
             effective_gas_price: Some(inner.fee_input_provider.l2_gas_price.into()),
-            ..Default::default()
+            transaction_type: Some((transaction_type as u32).into()),
+            logs_bloom: Default::default(),
         };
         let debug = create_debug_output(&l2_tx, &result, call_traces).expect("create debug output"); // OK to unwrap here as Halt is handled above
         inner.tx_results.insert(


### PR DESCRIPTION
# What :computer: 

Includes transaction type in the transaction receipts.

# Why :hand:

Some clients (e.g. `alloy`) expect this information to be present in the receipt.

# Evidence :camera:

I've added a test, but also manually checked with `alloy`: before this change getting the tx receipt was failing, but with this change it succeeds.