### PR TITLE
feat: Treat 'run' as default command

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
           tar -xzf era_test_node-${{ matrix.os }}.tar.gz
           chmod +x era_test_node
           echo "Starting node in background"
-          ./era_test_node run 2>&1 | tee era_test_node_output.log &
+          ./era_test_node 2>&1 | tee era_test_node_output.log &
           echo "PID=$!" >> $GITHUB_ENV
 
       - name: Launch tests

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,7 +212,7 @@ enum DevSystemContracts {
 #[command(author = "Matter Labs", version, about = "Test Node", long_about = None)]
 struct Cli {
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
     #[arg(long, default_value = "8011")]
     /// Port to listen on - default: 8011
     port: u16,
@@ -335,7 +335,9 @@ async fn main() -> anyhow::Result<()> {
         },
     };
 
-    let fork_details = match &opt.command {
+    // Use `Command::Run` as default.
+    let command = opt.command.as_ref().unwrap_or(&Command::Run);
+    let fork_details = match &command {
         Command::Run => None,
         Command::Fork(fork) => {
             Some(ForkDetails::from_network(&fork.network, fork.fork_at, cache_config).await)
@@ -347,7 +349,7 @@ async fn main() -> anyhow::Result<()> {
 
     // If we're replaying the transaction, we need to sync to the previous block
     // and then replay all the transactions that happened in
-    let transactions_to_replay = if let Command::ReplayTx(replay_tx) = &opt.command {
+    let transactions_to_replay = if let Command::ReplayTx(replay_tx) = command {
         fork_details
             .as_ref()
             .unwrap()


### PR DESCRIPTION
# What :computer: 

Makes `era_test_node` treat `run` as the default subcommand.

# Why :hand:

Ergonomics and L1 compatibility. You can run `anvil` without any arguments, I'd expect `era_test_node` to do the same.

# Evidence :camera:


![image](https://github.com/matter-labs/era-test-node/assets/12111581/7b7ba60b-89fe-42fd-8f54-a573945da631)

