### PR TITLE
chore: Run clippy in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ rust-doc:
 lint:
 	cd e2e-tests && yarn && yarn lint && yarn fmt && yarn typecheck
 	cargo fmt --all -- --check
-	cargo clippy -p era_test_node -Zunstable-options -- -D warnings --allow clippy::unwrap_used
+	cargo clippy --tests -p era_test_node -Zunstable-options -- -D warnings --allow clippy::unwrap_used
 
 # Fix lint errors for Rust code
 lint-fix:

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -614,14 +614,14 @@ mod tests {
 
         let mut fork_storage = ForkStorage::new(Some(fork_details), &options);
 
-        assert_eq!(fork_storage.is_write_initial(&never_written_key), true);
-        assert_eq!(fork_storage.is_write_initial(&key_with_some_value), false);
+        assert!(fork_storage.is_write_initial(&never_written_key));
+        assert!(!fork_storage.is_write_initial(&key_with_some_value));
         // This is the current limitation of the sytem. In theory, this should return false - as the value was written, but we don't have the API to the
         // backend to get this information.
-        assert_eq!(fork_storage.is_write_initial(&key_with_value_0), true);
+        assert!(fork_storage.is_write_initial(&key_with_value_0));
 
         // But writing any value there in the local storage (even 0) - should make it non-initial write immediately.
         fork_storage.set_value(key_with_value_0, H256::zero());
-        assert_eq!(fork_storage.is_write_initial(&key_with_value_0), false);
+        assert!(!fork_storage.is_write_initial(&key_with_value_0));
     }
 }

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1795,6 +1795,23 @@ impl BlockContext {
     }
 }
 
+pub fn load_last_l1_batch<S: ReadStorage>(storage: StoragePtr<S>) -> Option<(u64, u64)> {
+    // Get block number and timestamp
+    let current_l1_batch_info_key = StorageKey::new(
+        AccountTreeId::new(SYSTEM_CONTEXT_ADDRESS),
+        SYSTEM_CONTEXT_BLOCK_INFO_POSITION,
+    );
+    let mut storage_ptr = storage.borrow_mut();
+    let current_l1_batch_info = storage_ptr.read_value(&current_l1_batch_info_key);
+    let (batch_number, batch_timestamp) = unpack_block_info(h256_to_u256(current_l1_batch_info));
+    let block_number = batch_number as u32;
+    if block_number == 0 {
+        // The block does not exist yet
+        return None;
+    }
+    Some((batch_number, batch_timestamp))
+}
+
 #[cfg(test)]
 mod tests {
     use ethabi::{Token, Uint};
@@ -1980,21 +1997,4 @@ mod tests {
             _ => panic!("invalid result {:?}", result.result),
         }
     }
-}
-
-pub fn load_last_l1_batch<S: ReadStorage>(storage: StoragePtr<S>) -> Option<(u64, u64)> {
-    // Get block number and timestamp
-    let current_l1_batch_info_key = StorageKey::new(
-        AccountTreeId::new(SYSTEM_CONTEXT_ADDRESS),
-        SYSTEM_CONTEXT_BLOCK_INFO_POSITION,
-    );
-    let mut storage_ptr = storage.borrow_mut();
-    let current_l1_batch_info = storage_ptr.read_value(&current_l1_batch_info_key);
-    let (batch_number, batch_timestamp) = unpack_block_info(h256_to_u256(current_l1_batch_info));
-    let block_number = batch_number as u32;
-    if block_number == 0 {
-        // The block does not exist yet
-        return None;
-    }
-    Some((batch_number, batch_timestamp))
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1051,7 +1051,6 @@ mod test {
 
         let actual_bytecode = storage
             .get_bytecode_by_hash(H256::repeat_byte(0x1))
-            .ok()
             .expect("failed getting bytecode")
             .expect("missing bytecode");
         assert_eq!(input_bytecode, actual_bytecode);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -311,6 +311,12 @@ pub fn internal_error(method_name: &'static str, error: impl fmt::Display) -> We
 //     Ok(Address::from(address.0))
 // }
 
+/// Converts `h256` value as BE into the u64
+pub fn h256_to_u64(value: H256) -> u64 {
+    let be_u64_bytes: [u8; 8] = value[24..].try_into().unwrap();
+    u64::from_be_bytes(be_u64_bytes)
+}
+
 #[cfg(test)]
 mod tests {
     use zksync_basic_types::{H256, U256};
@@ -511,10 +517,4 @@ mod tests {
             assert_eq!(U256::from(2002), tx_block_3.timestamp);
         }
     }
-}
-
-/// Converts `h256` value as BE into the u64
-pub fn h256_to_u64(value: H256) -> u64 {
-    let be_u64_bytes: [u8; 8] = value[24..].try_into().unwrap();
-    u64::from_be_bytes(be_u64_bytes)
 }


### PR DESCRIPTION
# What :computer: 

- Changes `make lint` so that it runs `clippy` for tests too.
- Fixes existing clippy warnings in test code.

# Why :hand:

It's harder to work with the project when you see unfixed warnings.

# Evidence :camera:

Self-evident.