### PR TITLE
fix: Set transaction index to 0 in tx receipt

### DIFF
--- a/src/node/eth.rs
+++ b/src/node/eth.rs
@@ -515,7 +515,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> EthNamespa
                         nonce: U256::from(info.tx.common_data.nonce.0),
                         block_hash: Some(hash),
                         block_number: Some(U64::from(info.miniblock_number)),
-                        transaction_index: Some(U64::from(1)),
+                        transaction_index: Some(U64::from(0)),
                         from: Some(info.tx.initiator_account()),
                         to: Some(info.tx.recipient_account()),
                         value: info.tx.execute.value,


### PR DESCRIPTION
# What :computer: 

Changes transaction index from 1 to 0 in tx receipt.

# Why :hand:

Transaction indices should start from 0 ([example](https://etherscan.io/tx/0x0439cab7af5e6abbc572eafdc58ef65d832a7dcb2f3dcc36ab2182bc77f43ca1)).

# Evidence :camera:
From link above:
![image](https://github.com/matter-labs/era-test-node/assets/1890113/137df02e-173c-4a3e-9928-ed8691b77c01)