### PR TITLE
fix: update trace logging to include bootloader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "era_test_node"
-version = "0.1.0-alpha.23"
+version = "0.1.0-alpha.24"
 dependencies = [
  "anyhow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "0.1.0-alpha.23"
+version = "0.1.0-alpha.24"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,7 +324,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Initialize the tracing subscriber
     let observability =
-        Observability::init(String::from("era_test_node"), log_level_filter, log_file)?;
+        Observability::init(vec!["era_test_node".into(), "multivm".into()], log_level_filter, log_file)?;
 
     if matches!(opt.dev_system_contracts, DevSystemContracts::Local) {
         if let Some(path) = env::var_os("ZKSYNC_HOME") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,8 +323,11 @@ async fn main() -> anyhow::Result<()> {
     let log_file = File::create(opt.log_file_path)?;
 
     // Initialize the tracing subscriber
-    let observability =
-        Observability::init(vec!["era_test_node".into(), "multivm".into()], log_level_filter, log_file)?;
+    let observability = Observability::init(
+        vec!["era_test_node".into(), "multivm".into()],
+        log_level_filter,
+        log_file,
+    )?;
 
     if matches!(opt.dev_system_contracts, DevSystemContracts::Local) {
         if let Some(path) = env::var_os("ZKSYNC_HOME") {

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -45,22 +45,19 @@ impl From<LogLevel> for LevelFilter {
 /// A sharable reference to the observability stack.
 #[derive(Debug, Default, Clone)]
 pub struct Observability {
-    binary_name: String,
+    binary_names: Vec<String>,
     reload_handle: Option<reload::Handle<EnvFilter, Registry>>,
 }
 
 impl Observability {
     /// Initialize the tracing subscriber.
     pub fn init(
-        binary_name: String,
+        binary_names: Vec<String>,
         log_level_filter: LevelFilter,
         log_file: File,
     ) -> Result<Self, anyhow::Error> {
-        let filter = Self::parse_filter(&format!(
-            "{}={}",
-            binary_name,
-            format!("{log_level_filter}").to_lowercase()
-        ))?;
+        let joined_filter = binary_names.join(format!("={},", log_level_filter.to_string().to_lowercase()).as_str());
+        let filter = Self::parse_filter(&joined_filter)?;
         let (filter, reload_handle) = reload::Layer::new(filter);
 
         let timer_format =
@@ -92,7 +89,7 @@ impl Observability {
             .init();
 
         Ok(Self {
-            binary_name,
+            binary_names,
             reload_handle: Some(reload_handle),
         })
     }
@@ -100,11 +97,10 @@ impl Observability {
     /// Set the log level for the binary.
     pub fn set_log_level(&self, level: LogLevel) -> Result<(), anyhow::Error> {
         let level = LevelFilter::from(level);
-        let new_filter = Self::parse_filter(&format!(
-            "{}={}",
-            self.binary_name,
-            format!("{level}").to_lowercase()
-        ))?;
+        let new_filter = Self::parse_filter(&self.binary_names
+            .join(
+                format!("={},", level.to_string().to_lowercase()).as_str()
+            ))?;
 
         if let Some(handle) = &self.reload_handle {
             handle.modify(|filter| *filter = new_filter)?;

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -56,7 +56,8 @@ impl Observability {
         log_level_filter: LevelFilter,
         log_file: File,
     ) -> Result<Self, anyhow::Error> {
-        let joined_filter = binary_names.join(format!("={},", log_level_filter.to_string().to_lowercase()).as_str());
+        let joined_filter = binary_names
+            .join(format!("={},", log_level_filter.to_string().to_lowercase()).as_str());
         let filter = Self::parse_filter(&joined_filter)?;
         let (filter, reload_handle) = reload::Layer::new(filter);
 
@@ -97,10 +98,11 @@ impl Observability {
     /// Set the log level for the binary.
     pub fn set_log_level(&self, level: LogLevel) -> Result<(), anyhow::Error> {
         let level = LevelFilter::from(level);
-        let new_filter = Self::parse_filter(&self.binary_names
-            .join(
-                format!("={},", level.to_string().to_lowercase()).as_str()
-            ))?;
+        let new_filter = Self::parse_filter(
+            &self
+                .binary_names
+                .join(format!("={},", level.to_string().to_lowercase()).as_str()),
+        )?;
 
         if let Some(handle) = &self.reload_handle {
             handle.modify(|filter| *filter = new_filter)?;

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -821,7 +821,7 @@ content-type: application/json
     "jsonrpc": "2.0",
     "id": "1",
     "method": "config_setLogging",
-    "params": ["era_test_node=info,hyper=debug"]
+    "params": ["era_test_node=trace,multivm=trace"]
 }
 
 ###


### PR DESCRIPTION
# What :computer: 
* Update trace logging to include `multivm`
* Updated the version number to match latest

# Why :hand:
* This allows for `TRACE` logs to include `debugLog` statements from the `bootloader.yul` code
* For consistency

# Evidence :camera:
Running `era_test_node --log trace` and having a simple test, you see the following console/log output:
```text
09:27:07 TRACE Bootloader transaction 0: userProvidedPubdataPrice: 50000
09:27:07 TRACE Bootloader transaction 0: gasPerPubdata: 50000
09:27:07 TRACE Bootloader transaction 0: txTotalGasLimit 80000000
09:27:07 TRACE Bootloader transaction 0: requiredOverhead 10000
09:27:07 TRACE Bootloader transaction 0: operatorOverheadForTransaction 10000
09:27:07 TRACE Bootloader transaction 0: gas() 4294953925
09:27:07 TRACE Bootloader transaction 0: gasToProvide 79975930
```
