### PR TITLE
fix: hide multivm log warnings and traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "era_test_node"
-version = "0.1.0-alpha.24"
+version = "0.1.0-alpha.25"
 dependencies = [
  "anyhow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "0.1.0-alpha.24"
+version = "0.1.0-alpha.25"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,7 +324,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Initialize the tracing subscriber
     let observability = Observability::init(
-        vec!["era_test_node".into(), "multivm".into()],
+        vec!["era_test_node".into()],
         log_level_filter,
         log_file,
     )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,11 +203,8 @@ async fn main() -> anyhow::Result<()> {
     let log_file = File::create(config.log.file_path)?;
 
     // Initialize the tracing subscriber
-    let observability = Observability::init(
-        vec!["era_test_node".into()],
-        log_level_filter,
-        log_file,
-    )?;
+    let observability =
+        Observability::init(vec!["era_test_node".into()], log_level_filter, log_file)?;
 
     // Use `Command::Run` as default.
     let command = opt.command.as_ref().unwrap_or(&Command::Run);

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -62,7 +62,6 @@ impl Observability {
             .map(|x| format!("{}={}", x, log_level_filter.to_string().to_lowercase()))
             .collect::<Vec<String>>()
             .join(",");
-        println!("{}", joined_filter);
         let filter = Self::parse_filter(&joined_filter)?;
         let (filter, reload_handle) = reload::Layer::new(filter);
 

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -57,7 +57,11 @@ impl Observability {
         log_file: File,
     ) -> Result<Self, anyhow::Error> {
         let joined_filter = binary_names
-            .join(format!("={},", log_level_filter.to_string().to_lowercase()).as_str());
+            .iter()
+            .map(|x| format!("{}={}", x, log_level_filter.to_string().to_lowercase()))
+            .collect::<Vec<String>>()
+            .join(",");
+        println!("{}", joined_filter);
         let filter = Self::parse_filter(&joined_filter)?;
         let (filter, reload_handle) = reload::Layer::new(filter);
 


### PR DESCRIPTION
# What :computer: 
* Fix log filter to work with multiple targets
* Remove `multivm` from log filter
* Update version number for upcoming release

# Why :hand:
* Multiple targets were not having the `=info` log level applied as expected on start-up, so TRACE logs were showing for `multivm` target
* Warning logs are being thrown with an un-actionable message of `0x function_selector` which is confusing and could have end users believe that something is wrong when there's not
* Expect to release `0.1.0-alpha.25` today

# Evidence :camera:
Running `era_test_node` now only have `era_test_node=info` logs:
```bash
$ era_test_node 
14:32:46  INFO Starting network with chain id: L2ChainId(260)
14:32:46  INFO 
14:32:46  INFO Rich Accounts
14:32:46  INFO =============
14:32:46  INFO Account #0: 0xBC989fDe9e54cAd2aB4392Af6dF60f04873A033A (1_000_000_000_000 ETH)
14:32:46  INFO Private Key: 0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e
14:32:46  INFO Mnemonic: mass wild lava ripple clog cabbage witness shell unable tribe rubber enter
14:32:46  INFO 
14:32:46  INFO Account #1: 0x55bE1B079b53962746B2e86d12f158a41DF294A6 (1_000_000_000_000 ETH)
14:32:46  INFO Private Key: 0x509ca2e9e6acf0ba086477910950125e698d4ea70fa6f63e000c5a22bda9361c
14:32:46  INFO Mnemonic: crumble clutch mammal lecture lazy broken nominee visit gentle gather gym erupt
14:32:46  INFO 
14:32:46  INFO Account #2: 0xCE9e6063674DC585F6F3c7eaBe82B9936143Ba6C (1_000_000_000_000 ETH)
14:32:46  INFO Private Key: 0x71781d3a358e7a65150e894264ccc594993fbc0ea12d69508a340bc1d4f5bfbc
14:32:46  INFO Mnemonic: illegal okay stereo tattoo between alien road nuclear blind wolf champion regular
14:32:46  INFO 
14:32:46  INFO Account #3: 0xd986b0cB0D1Ad4CCCF0C4947554003fC0Be548E9 (1_000_000_000_000 ETH)
14:32:46  INFO Private Key: 0x379d31d4a7031ead87397f332aab69ef5cd843ba3898249ca1046633c0c7eefe
14:32:46  INFO Mnemonic: point donor practice wear alien abandon frozen glow they practice raven shiver
14:32:46  INFO 
14:32:46  INFO Account #4: 0x87d6ab9fE5Adef46228fB490810f0F5CB16D6d04 (1_000_000_000_000 ETH)
14:32:46  INFO Private Key: 0x105de4e75fe465d075e1daae5647a02e3aad54b8d23cf1f70ba382b9f9bee839
14:32:46  INFO Mnemonic: giraffe organ club limb install nest journey client chunk settle slush copy
14:32:46  INFO 
14:32:46  INFO Account #5: 0x78cAD996530109838eb016619f5931a03250489A (1_000_000_000_000 ETH)
14:32:46  INFO Private Key: 0x7becc4a46e0c3b512d380ca73a4c868f790d1055a7698f38fb3ca2b2ac97efbb
14:32:46  INFO Mnemonic: awful organ version habit giraffe amused wire table begin gym pistol clean
14:32:46  INFO 
14:32:46  INFO Account #6: 0xc981b213603171963F81C687B9fC880d33CaeD16 (1_000_000_000_000 ETH)
14:32:46  INFO Private Key: 0xe0415469c10f3b1142ce0262497fe5c7a0795f0cbfd466a6bfa31968d0f70841
14:32:46  INFO Mnemonic: exotic someone fall kitten salute nerve chimney enlist pair display over inside
14:32:46  INFO 
14:32:46  INFO Account #7: 0x42F3dc38Da81e984B92A95CBdAAA5fA2bd5cb1Ba (1_000_000_000_000 ETH)
14:32:46  INFO Private Key: 0x4d91647d0a8429ac4433c83254fb9625332693c848e578062fe96362f32bfe91
14:32:46  INFO Mnemonic: catch tragic rib twelve buffalo also gorilla toward cost enforce artefact slab
14:32:46  INFO 
14:32:46  INFO Account #8: 0x64F47EeD3dC749d13e49291d46Ea8378755fB6DF (1_000_000_000_000 ETH)
14:32:46  INFO Private Key: 0x41c9f9518aa07b50cb1c0cc160d45547f57638dd824a8d85b5eb3bf99ed2bdeb
14:32:46  INFO Mnemonic: arrange price fragile dinner device general vital excite penalty monkey major faculty
14:32:46  INFO 
14:32:46  INFO Account #9: 0xe2b8Cb53a43a56d4d2AB6131C81Bd76B86D3AFe5 (1_000_000_000_000 ETH)
14:32:46  INFO Private Key: 0xb0680d66303a0163a19294f1ef8c95cd69a9d7902a4aca99c05f3e134e68a11a
14:32:46  INFO Mnemonic: increase pulp sing wood guilt cement satoshi tiny forum nuclear sudden thank
14:32:46  INFO 
14:32:46  INFO ========================================
14:32:46  INFO   Node is ready at 127.0.0.1:8011
14:32:46  INFO ========================================
```
