### PR TITLE
feat: added hardhat_setNextBlockBaseFeePerGas

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -105,7 +105,7 @@ The `status` options are:
 | `HARDHAT` | `hardhat_setCoinbase` | `NOT IMPLEMENTED` | Sets the coinbase address |
 | `HARDHAT` | `hardhat_setLoggingEnabled` | `NOT IMPLEMENTED` | Enables or disables logging in Hardhat Network |
 | `HARDHAT` | `hardhat_setMinGasPrice` | `NOT IMPLEMENTED` | Sets the minimum gas price |
-| `HARDHAT` | `hardhat_setNextBlockBaseFeePerGas` | `NOT IMPLEMENTED` | Sets the base fee per gas for the next block |
+| [`HARDHAT`](#hardhat-namespace) | [`hardhat_setNextBlockBaseFeePerGas`](#hardhat_setnextblockbasefeepergas) | `SUPPORTED` | Sets the base fee per gas for the next block |
 | `HARDHAT` | `hardhat_setPrevRandao` | `NOT IMPLEMENTED` | Sets the PREVRANDAO value of the next block |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setNonce`](#hardhat_setnonce) | `SUPPORTED` | Sets the nonce of a given account |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setStorageAt`](#hardhat_setstorageat) | `SUPPORTED` | Sets the storage value at a given key for a given account |

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -105,7 +105,7 @@ The `status` options are:
 | `HARDHAT` | `hardhat_setCoinbase` | `NOT IMPLEMENTED` | Sets the coinbase address |
 | `HARDHAT` | `hardhat_setLoggingEnabled` | `NOT IMPLEMENTED` | Enables or disables logging in Hardhat Network |
 | `HARDHAT` | `hardhat_setMinGasPrice` | `NOT IMPLEMENTED` | Sets the minimum gas price |
-| [`HARDHAT`](#hardhat-namespace) | [`hardhat_setNextBlockBaseFeePerGas`](#hardhat_setnextblockbasefeepergas) | `SUPPORTED` | Sets the base fee per gas for the next block |
+| [`HARDHAT`](#hardhat-namespace) | `hardhat_setNextBlockBaseFeePerGas` | `SUPPORTED` | Sets the base fee per gas for the next block |
 | `HARDHAT` | `hardhat_setPrevRandao` | `NOT IMPLEMENTED` | Sets the PREVRANDAO value of the next block |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setNonce`](#hardhat_setnonce) | `SUPPORTED` | Sets the nonce of a given account |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setStorageAt`](#hardhat_setstorageat) | `SUPPORTED` | Sets the storage value at a given key for a given account |

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -105,7 +105,7 @@ The `status` options are:
 | `HARDHAT` | `hardhat_setCoinbase` | `NOT IMPLEMENTED` | Sets the coinbase address |
 | `HARDHAT` | `hardhat_setLoggingEnabled` | `NOT IMPLEMENTED` | Enables or disables logging in Hardhat Network |
 | `HARDHAT` | `hardhat_setMinGasPrice` | `NOT IMPLEMENTED` | Sets the minimum gas price |
-| [`HARDHAT`](#hardhat-namespace) | `hardhat_setNextBlockBaseFeePerGas` | `SUPPORTED` | Sets the base fee per gas for the next block |
+| [`HARDHAT`](#hardhat-namespace) | [`hardhat_setNextBlockBaseFeePerGas`](#hardhat_setnextblockbasefeepergas) | `SUPPORTED` | Sets the base fee per gas for the next block |
 | `HARDHAT` | `hardhat_setPrevRandao` | `NOT IMPLEMENTED` | Sets the PREVRANDAO value of the next block |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setNonce`](#hardhat_setnonce) | `SUPPORTED` | Sets the nonce of a given account |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setStorageAt`](#hardhat_setstorageat) | `SUPPORTED` | Sets the storage value at a given key for a given account |
@@ -1498,6 +1498,36 @@ curl --request POST \
       "params": [
         "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
         "0x1337"
+      ]
+  }'
+```
+
+### hardhat_setNextBlockBaseFeePerGas
+
+[source](src/node/hardhat.rs)
+
+Sets the L1 fee per gas for the following transactions.
+
+#### Arguments
+
++ `base_fee_per_gas: U256` - The new L1 gas price
+
+#### Status
+
+`SUPPORTED`
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+      "id": "1",
+      "method": "hardhat_setNextBlockBaseFeePerGas",
+      "params": [
+        "0x12d687"
       ]
   }'
 ```

--- a/e2e-tests/test/hardhat-apis.test.ts
+++ b/e2e-tests/test/hardhat-apis.test.ts
@@ -64,6 +64,24 @@ describe("hardhat_mine", function () {
   });
 });
 
+describe("hardhat_setNextBlockBaseFeePerGas", function () {
+  it("should allow setting the next block's base fee per gas", async function () {
+    // Arrange
+    const price = "0x12d687";
+
+    // Act
+    const previous = await provider.send("eth_getBlockByNumber", ["latest", false]);
+    await provider.send("hardhat_setNextBlockBaseFeePerGas", [price]);
+    await provider.send("hardhat_mine");
+    const latest = await provider.send("eth_getBlockByNumber", ["latest", false]);
+    await provider.send("hardhat_setNextBlockBaseFeePerGas", [previous.baseFeePerGas]);
+
+    // Assert
+    expect(previous.baseFeePerGas).to.not.equal(price);
+    expect(latest.baseFeePerGas).to.equal(price);
+  });
+});
+
 describe("hardhat_impersonateAccount & hardhat_stopImpersonatingAccount", function () {
   it("Should allow transfers of funds without knowing the Private Key", async function () {
     // Arrange

--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -30,6 +30,8 @@ describe("zks_estimateFee", function () {
     // Act
     const response: Fee = await provider.send("zks_estimateFee", [transaction]);
     // Assert
+    // values might differ depending on whether the test runs
+    // standalone, or as part of the full suite
     expect(ethers.BigNumber.from(response.gas_limit).toNumber()).to.be.within(3606743, 5868728, "Unexpected gas_limit");
     expect(ethers.BigNumber.from(response.gas_per_pubdata_limit)).to.eql(
       ethers.BigNumber.from("50000"),

--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -30,14 +30,16 @@ describe("zks_estimateFee", function () {
     // Act
     const response: Fee = await provider.send("zks_estimateFee", [transaction]);
     // Assert
-    expect(ethers.BigNumber.from(response.gas_limit).toNumber())
-      .to.be.within(3606743, 5868728, "Unexpected gas_limit");
+    expect(ethers.BigNumber.from(response.gas_limit).toNumber()).to.be.within(3606743, 5868728, "Unexpected gas_limit");
     expect(ethers.BigNumber.from(response.gas_per_pubdata_limit)).to.eql(
       ethers.BigNumber.from("50000"),
       "Unexpected gas_per_pubdata_limit"
     );
-    expect(ethers.BigNumber.from(response.max_fee_per_gas).toNumber())
-      .to.be.within(25500297, 37500000, "Unexpected max_fee_per_gas");
+    expect(ethers.BigNumber.from(response.max_fee_per_gas).toNumber()).to.be.within(
+      25500297,
+      37500000,
+      "Unexpected max_fee_per_gas"
+    );
     expect(ethers.BigNumber.from(response.max_priority_fee_per_gas)).to.eql(
       ethers.BigNumber.from("0"),
       "Unexpected max_priority_fee_per_gas"

--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -30,15 +30,14 @@ describe("zks_estimateFee", function () {
     // Act
     const response: Fee = await provider.send("zks_estimateFee", [transaction]);
     // Assert
-    expect(ethers.BigNumber.from(response.gas_limit)).to.eql(ethers.BigNumber.from("3606743"), "Unexpected gas_limit");
+    expect(ethers.BigNumber.from(response.gas_limit).toNumber())
+      .to.be.within(3606743, 5868728, "Unexpected gas_limit");
     expect(ethers.BigNumber.from(response.gas_per_pubdata_limit)).to.eql(
       ethers.BigNumber.from("50000"),
       "Unexpected gas_per_pubdata_limit"
     );
-    expect(ethers.BigNumber.from(response.max_fee_per_gas)).to.eql(
-      ethers.BigNumber.from("37500000"),
-      "Unexpected max_fee_per_gas"
-    );
+    expect(ethers.BigNumber.from(response.max_fee_per_gas).toNumber())
+      .to.be.within(25500297, 37500000, "Unexpected max_fee_per_gas");
     expect(ethers.BigNumber.from(response.max_priority_fee_per_gas)).to.eql(
       ethers.BigNumber.from("0"),
       "Unexpected max_priority_fee_per_gas"

--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -30,16 +30,13 @@ describe("zks_estimateFee", function () {
     // Act
     const response: Fee = await provider.send("zks_estimateFee", [transaction]);
     // Assert
-    // values might differ depending on whether the test runs
-    // standalone, or as part of the full suite
-    expect(ethers.BigNumber.from(response.gas_limit).toNumber()).to.be.within(3606743, 5868728, "Unexpected gas_limit");
+    expect(ethers.BigNumber.from(response.gas_limit)).to.eql(ethers.BigNumber.from("3606743"), "Unexpected gas_limit");
     expect(ethers.BigNumber.from(response.gas_per_pubdata_limit)).to.eql(
       ethers.BigNumber.from("50000"),
       "Unexpected gas_per_pubdata_limit"
     );
-    expect(ethers.BigNumber.from(response.max_fee_per_gas).toNumber()).to.be.within(
-      25500297,
-      37500000,
+    expect(ethers.BigNumber.from(response.max_fee_per_gas)).to.eql(
+      ethers.BigNumber.from("37500000"),
       "Unexpected max_fee_per_gas"
     );
     expect(ethers.BigNumber.from(response.max_priority_fee_per_gas)).to.eql(

--- a/src/namespaces/hardhat.rs
+++ b/src/namespaces/hardhat.rs
@@ -131,4 +131,16 @@ pub trait HardhatNamespaceT {
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "hardhat_setStorageAt")]
     fn set_storage_at(&self, address: Address, slot: U256, value: U256) -> RpcResult<bool>;
+
+    /// Directly modifies the L1 gas price.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_fee_per_gas` - The new L1 gas price.
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
+    #[rpc(name = "hardhat_setNextBlockBaseFeePerGas")]
+    fn set_next_block_base_fee_per_gas(&self, base_fee_per_gas: U256) -> RpcResult<bool>;
 }

--- a/src/node/hardhat.rs
+++ b/src/node/hardhat.rs
@@ -82,4 +82,13 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> HardhatNam
             })
             .into_boxed_future()
     }
+
+    fn set_next_block_base_fee_per_gas(&self, base_fee_per_gas: U256) -> RpcResult<bool> {
+        self.set_next_block_base_fee_per_gas(base_fee_per_gas)
+            .map_err(|err| {
+                tracing::error!("failed setting fee: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -97,6 +97,7 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
     node: &mut InMemoryNodeInner<S>,
     num_blocks: u64,
     interval_ms: u64,
+    base_fee_per_gas: u64,
 ) -> Result<(), anyhow::Error> {
     // build and insert new blocks
     for i in 0..num_blocks {
@@ -155,6 +156,7 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
             block_ctx.timestamp,
             block_ctx.batch,
             None,
+            U256::from(base_fee_per_gas),
         );
 
         node.block_hashes.insert(block.number.as_u64(), block.hash);
@@ -403,7 +405,7 @@ mod tests {
 
         {
             let mut writer = inner.write().expect("failed acquiring write lock");
-            mine_empty_blocks(&mut writer, 1, 1000).unwrap();
+            mine_empty_blocks(&mut writer, 1, 1000, 0).unwrap();
         }
 
         let reader = inner.read().expect("failed acquiring reader");
@@ -437,7 +439,7 @@ mod tests {
 
         {
             let mut writer = inner.write().expect("failed acquiring write lock");
-            mine_empty_blocks(&mut writer, 2, 1000).unwrap();
+            mine_empty_blocks(&mut writer, 2, 1000, 0).unwrap();
         }
 
         let reader = inner.read().expect("failed acquiring reader");
@@ -480,7 +482,7 @@ mod tests {
 
         {
             let mut writer = inner.write().expect("failed acquiring write lock");
-            mine_empty_blocks(&mut writer, 2, 1000).unwrap();
+            mine_empty_blocks(&mut writer, 2, 1000, 0).unwrap();
         }
 
         {


### PR DESCRIPTION
# What :computer: 
Implemented the `hardhat_setNextBlockBaseFeePerGas` API.

# Why :hand:
Requested in https://github.com/matter-labs/era-test-node/issues/150 .

# Evidence :camera:
Added an e2e test, which passes:
```
  hardhat_setNextBlockBaseFeePerGas
    ✔ should allow setting the next block's base fee per gas
```
