### PR TITLE
feat: anvil API

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -22,9 +22,6 @@ The `status` options are:
 | `ANVIL` | `anvil_setBalance` | `SUPPORTED` | Modifies the balance of an account |
 | `ANVIL` | `anvil_setCode` | `SUPPORTED` | Sets the bytecode of a given account |
 | `ANVIL` | `anvil_setStorageAt` | `SUPPORTED` | Sets the storage value at a given key for a given account |
-
-| Namespace | API | <div style="width:130px">Status</div> | Description |
-| --- | --- | --- | --- |
 | [`CONFIG`](#config-namespace) | [`config_getShowCalls`](#config_getshowcalls) | `SUPPORTED` | Gets the current value of `show_calls` that's originally set with `--show-calls` option |
 | [`CONFIG`](#config-namespace) | [`config_getShowOutputs`](#config_getshowoutputs) | `SUPPORTED` | Gets the current value of `show_outputs` that's originally set with `--show-outputs` option |
 | [`CONFIG`](#config-namespace) | [`config_getCurrentTimestamp`](#config_getcurrenttimestamp) | `SUPPORTED` | Gets the value of `current_timestamp` for the node |
@@ -36,16 +33,10 @@ The `status` options are:
 | [`CONFIG`](#config-namespace) | [`config_setShowGasDetails`](#config_setshowgasdetails) | `SUPPORTED` | Updates `show_gas_details` to print more details about gas estimation and usage |
 | [`CONFIG`](#config-namespace) | [`config_setLogLevel`](#config_setloglevel) | `SUPPORTED` | Sets the logging level for the node and only displays the node logs. |
 | [`CONFIG`](#config-namespace) | [`config_setLogging`](#config_setlogging) | `SUPPORTED` | Sets the fine-tuned logging levels for the node and any of its dependencies |
-
-| Namespace | API | <div style="width:130px">Status</div> | Description |
-| --- | --- | --- | --- |
 | [`DEBUG`](#debug-namespace) | [`debug_traceCall`](#debug_tracecall) | `SUPPORTED` | Performs a call and returns structured traces of the execution |
 | [`DEBUG`](#debug-namespace) | [`debug_traceBlockByHash`](#debug_traceblockbyhash) | `SUPPORTED` | Returns structured traces for operations within the block of the specified block hash |
 | [`DEBUG`](#debug-namespace) | [`debug_traceBlockByNumber`](#debug_traceblockbynumber) | `SUPPORTED` | Returns structured traces for operations within the block of the specified block number |
 | [`DEBUG`](#debug-namespace) | [`debug_traceTransaction`](#debug_tracetransaction) | `SUPPORTED` | Returns a structured trace of the execution of the specified transaction |
-
-| Namespace | API | <div style="width:130px">Status</div> | Description |
-| --- | --- | --- | --- |
 | `ETH` | `eth_accounts` | `SUPPORTED` | Returns a list of addresses owned by client |
 | [`ETH`](#eth-namespace) | [`eth_chainId`](#eth_chainid) | `SUPPORTED` | Returns the currently configured chain id <br />_(default is `260`)_ |
 | `ETH` | `eth_coinbase` | `NOT IMPLEMENTED` | Returns the client coinbase address |
@@ -95,9 +86,6 @@ The `status` options are:
 | [`ETH`](#eth-namespace) | [`eth_syncing`](#eth_syncing) | `SUPPORTED` | Returns an object containing data about the sync status or `false` when not syncing |
 | [`ETH`](#eth-namespace) | [`eth_uninstallFilter`](#`eth_uninstallfilter) | `SUPPORTED` | Uninstalls a filter with given id |
 | `ETH` | `eth_unsubscribe` | `NOT IMPLEMENTED` | Cancel a subscription to a particular event |
-
-| Namespace | API | <div style="width:130px">Status</div> | Description |
-| --- | --- | --- | --- |
 | `EVM` | `evm_addAccount` | `NOT IMPLEMENTED` | Adds any arbitrary account |
 | [`EVM`](#evm-namespace) | [`evm_increaseTime`](#evm_increasetime) | `SUPPORTED` | Jump forward in time by the given amount of time, in seconds |
 | [`EVM`](#evm-namespace) | [`evm_mine`](#evm_mine) | `SUPPORTED` | Force a single block to be mined |
@@ -113,9 +101,6 @@ The `status` options are:
 | [`EVM`](#evm-namespace) | [`evm_setNextBlockTimestamp`](#evm_setnextblocktimestamp) | `SUPPORTED` | Works like `evm_increaseTime`, but takes the exact timestamp that you want in the next block, and increases the time accordingly |
 | [`EVM`](#evm-namespace) | [`evm_setTime`](#evm_settime) | `SUPPORTED` | Sets the internal clock time to the given timestamp |
 | [`EVM`](#evm-namespace) | [`evm_snapshot`](#evm_snapshot) | `SUPPORTED` | Snapshot the state of the blockchain at the current block |
-
-| Namespace | API | <div style="width:130px">Status</div> | Description |
-| --- | --- | --- | --- |
 | `HARDHAT` | `hardhat_addCompilationResult` | `NOT IMPLEMENTED` | Add information about compiled contracts |
 | `HARDHAT` | `hardhat_dropTransaction` | `NOT IMPLEMENTED` | Remove a transaction from the mempool |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_impersonateAccount`](#hardhat_impersonateaccount) | `SUPPORTED` | Impersonate an account |
@@ -133,19 +118,10 @@ The `status` options are:
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setNonce`](#hardhat_setnonce) | `SUPPORTED` | Sets the nonce of a given account |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setStorageAt`](#hardhat_setstorageat) | `SUPPORTED` | Sets the storage value at a given key for a given account |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_stopImpersonatingAccount`](#hardhat_stopimpersonatingaccount) | `SUPPORTED` | Stop impersonating an account after having previously used `hardhat_impersonateAccount` |
-
-| Namespace | API | <div style="width:130px">Status</div> | Description |
-| --- | --- | --- | --- |
 | [`NETWORK`](#network-namespace) | [`net_version`](#net_version) | `SUPPORTED` | Returns the current network id <br />_(default is `260`)_ |
 | [`NETWORK`](#network-namespace) | [`net_peerCount`](#net_peercount) | `SUPPORTED` | Returns the number of peers currently connected to the client <br/>_(hard-coded to `0`)_ |
 | [`NETWORK`](#network-namespace) | [`net_listening`](#net_listening) | `SUPPORTED` | Returns `true` if the client is actively listening for network connections <br />_(hard-coded to `false`)_ |
-
-| Namespace | API | <div style="width:130px">Status</div> | Description |
-| --- | --- | --- | --- |
 | [`WEB3`](#web3-namespace) | [`web3_clientVersion`](#web3_clientversion) | `SUPPORTED` | Returns `zkSync/v2.0` |
-
-| Namespace | API | <div style="width:130px">Status</div> | Description |
-| --- | --- | --- | --- |
 | [`ZKS`](#zks-namespace) | [`zks_estimateFee`](#zks_estimateFee) | `SUPPORTED` | Gets the Fee estimation data for a given Request |
 | `ZKS` | `zks_estimateGasL1ToL2` | `NOT IMPLEMENTED` | Estimate of the gas required for a L1 to L2 transaction |
 | [`ZKS`](#zks-namespace) | [`zks_getAllAccountBalances`](#zks_getallaccountbalances) | `SUPPORTED` | Returns all balances for confirmed tokens given by an account address |

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -22,6 +22,9 @@ The `status` options are:
 | `ANVIL` | `anvil_setBalance` | `SUPPORTED` | Modifies the balance of an account |
 | `ANVIL` | `anvil_setCode` | `SUPPORTED` | Sets the bytecode of a given account |
 | `ANVIL` | `anvil_setStorageAt` | `SUPPORTED` | Sets the storage value at a given key for a given account |
+
+| Namespace | API | <div style="width:130px">Status</div> | Description |
+| --- | --- | --- | --- |
 | [`CONFIG`](#config-namespace) | [`config_getShowCalls`](#config_getshowcalls) | `SUPPORTED` | Gets the current value of `show_calls` that's originally set with `--show-calls` option |
 | [`CONFIG`](#config-namespace) | [`config_getShowOutputs`](#config_getshowoutputs) | `SUPPORTED` | Gets the current value of `show_outputs` that's originally set with `--show-outputs` option |
 | [`CONFIG`](#config-namespace) | [`config_getCurrentTimestamp`](#config_getcurrenttimestamp) | `SUPPORTED` | Gets the value of `current_timestamp` for the node |
@@ -33,10 +36,16 @@ The `status` options are:
 | [`CONFIG`](#config-namespace) | [`config_setShowGasDetails`](#config_setshowgasdetails) | `SUPPORTED` | Updates `show_gas_details` to print more details about gas estimation and usage |
 | [`CONFIG`](#config-namespace) | [`config_setLogLevel`](#config_setloglevel) | `SUPPORTED` | Sets the logging level for the node and only displays the node logs. |
 | [`CONFIG`](#config-namespace) | [`config_setLogging`](#config_setlogging) | `SUPPORTED` | Sets the fine-tuned logging levels for the node and any of its dependencies |
+
+| Namespace | API | <div style="width:130px">Status</div> | Description |
+| --- | --- | --- | --- |
 | [`DEBUG`](#debug-namespace) | [`debug_traceCall`](#debug_tracecall) | `SUPPORTED` | Performs a call and returns structured traces of the execution |
 | [`DEBUG`](#debug-namespace) | [`debug_traceBlockByHash`](#debug_traceblockbyhash) | `SUPPORTED` | Returns structured traces for operations within the block of the specified block hash |
 | [`DEBUG`](#debug-namespace) | [`debug_traceBlockByNumber`](#debug_traceblockbynumber) | `SUPPORTED` | Returns structured traces for operations within the block of the specified block number |
 | [`DEBUG`](#debug-namespace) | [`debug_traceTransaction`](#debug_tracetransaction) | `SUPPORTED` | Returns a structured trace of the execution of the specified transaction |
+
+| Namespace | API | <div style="width:130px">Status</div> | Description |
+| --- | --- | --- | --- |
 | `ETH` | `eth_accounts` | `SUPPORTED` | Returns a list of addresses owned by client |
 | [`ETH`](#eth-namespace) | [`eth_chainId`](#eth_chainid) | `SUPPORTED` | Returns the currently configured chain id <br />_(default is `260`)_ |
 | `ETH` | `eth_coinbase` | `NOT IMPLEMENTED` | Returns the client coinbase address |
@@ -86,6 +95,9 @@ The `status` options are:
 | [`ETH`](#eth-namespace) | [`eth_syncing`](#eth_syncing) | `SUPPORTED` | Returns an object containing data about the sync status or `false` when not syncing |
 | [`ETH`](#eth-namespace) | [`eth_uninstallFilter`](#`eth_uninstallfilter) | `SUPPORTED` | Uninstalls a filter with given id |
 | `ETH` | `eth_unsubscribe` | `NOT IMPLEMENTED` | Cancel a subscription to a particular event |
+
+| Namespace | API | <div style="width:130px">Status</div> | Description |
+| --- | --- | --- | --- |
 | `EVM` | `evm_addAccount` | `NOT IMPLEMENTED` | Adds any arbitrary account |
 | [`EVM`](#evm-namespace) | [`evm_increaseTime`](#evm_increasetime) | `SUPPORTED` | Jump forward in time by the given amount of time, in seconds |
 | [`EVM`](#evm-namespace) | [`evm_mine`](#evm_mine) | `SUPPORTED` | Force a single block to be mined |
@@ -101,6 +113,9 @@ The `status` options are:
 | [`EVM`](#evm-namespace) | [`evm_setNextBlockTimestamp`](#evm_setnextblocktimestamp) | `SUPPORTED` | Works like `evm_increaseTime`, but takes the exact timestamp that you want in the next block, and increases the time accordingly |
 | [`EVM`](#evm-namespace) | [`evm_setTime`](#evm_settime) | `SUPPORTED` | Sets the internal clock time to the given timestamp |
 | [`EVM`](#evm-namespace) | [`evm_snapshot`](#evm_snapshot) | `SUPPORTED` | Snapshot the state of the blockchain at the current block |
+
+| Namespace | API | <div style="width:130px">Status</div> | Description |
+| --- | --- | --- | --- |
 | `HARDHAT` | `hardhat_addCompilationResult` | `NOT IMPLEMENTED` | Add information about compiled contracts |
 | `HARDHAT` | `hardhat_dropTransaction` | `NOT IMPLEMENTED` | Remove a transaction from the mempool |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_impersonateAccount`](#hardhat_impersonateaccount) | `SUPPORTED` | Impersonate an account |
@@ -118,10 +133,19 @@ The `status` options are:
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setNonce`](#hardhat_setnonce) | `SUPPORTED` | Sets the nonce of a given account |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setStorageAt`](#hardhat_setstorageat) | `SUPPORTED` | Sets the storage value at a given key for a given account |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_stopImpersonatingAccount`](#hardhat_stopimpersonatingaccount) | `SUPPORTED` | Stop impersonating an account after having previously used `hardhat_impersonateAccount` |
+
+| Namespace | API | <div style="width:130px">Status</div> | Description |
+| --- | --- | --- | --- |
 | [`NETWORK`](#network-namespace) | [`net_version`](#net_version) | `SUPPORTED` | Returns the current network id <br />_(default is `260`)_ |
 | [`NETWORK`](#network-namespace) | [`net_peerCount`](#net_peercount) | `SUPPORTED` | Returns the number of peers currently connected to the client <br/>_(hard-coded to `0`)_ |
 | [`NETWORK`](#network-namespace) | [`net_listening`](#net_listening) | `SUPPORTED` | Returns `true` if the client is actively listening for network connections <br />_(hard-coded to `false`)_ |
+
+| Namespace | API | <div style="width:130px">Status</div> | Description |
+| --- | --- | --- | --- |
 | [`WEB3`](#web3-namespace) | [`web3_clientVersion`](#web3_clientversion) | `SUPPORTED` | Returns `zkSync/v2.0` |
+
+| Namespace | API | <div style="width:130px">Status</div> | Description |
+| --- | --- | --- | --- |
 | [`ZKS`](#zks-namespace) | [`zks_estimateFee`](#zks_estimateFee) | `SUPPORTED` | Gets the Fee estimation data for a given Request |
 | `ZKS` | `zks_estimateGasL1ToL2` | `NOT IMPLEMENTED` | Estimate of the gas required for a L1 to L2 transaction |
 | [`ZKS`](#zks-namespace) | [`zks_getAllAccountBalances`](#zks_getallaccountbalances) | `SUPPORTED` | Returns all balances for confirmed tokens given by an account address |

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -14,14 +14,14 @@ The `status` options are:
 
 | Namespace | API | <div style="width:130px">Status</div> | Description |
 | --- | --- | --- | --- |
-| [`ANVIL`](#anvil-namespace) | [`anvil_setNonce`](#anvil_setnonce) | `SUPPORTED` | Sets the nonce of a given account |
-| [`ANVIL`](#anvil-namespace) | [`anvil_impersonateAccount`](#anvil_impersonateaccount) | `SUPPORTED` | Impersonate an account |
-| [`ANVIL`](#anvil-namespace) | [`anvil_stopImpersonatingAccount`](#anvil_stopimpersonatingaccount) | `SUPPORTED` | Stop impersonating an account after having previously used `anvil_impersonateAccount` |
-| [`ANVIL`](#anvil-namespace) | [`anvil_reset`](#anvil_reset) | `PARTIALLY` | Resets the state of the network; cannot revert to past block numbers, unless they're in a fork |
-| [`ANVIL`](#anvil-namespace) | [`anvil_mine`](#anvil_mine) | `SUPPORTED` | Mine any number of blocks at once, in constant time |
-| [`ANVIL`](#anvil-namespace) | [`anvil_setBalance`](#anvil_setbalance) | `SUPPORTED` | Modifies the balance of an account |
-| [`ANVIL`](#anvil-namespace) | [`anvil_setCode`](#anvil_setcode) | `SUPPORTED` | Sets the bytecode of a given account |
-| [`ANVIL`](#anvil-namespace) | [`anvil_setStorageAt`](#anvil_setstorageat) | `SUPPORTED` | Sets the storage value at a given key for a given account |
+| `ANVIL` | `anvil_setNonce` | `SUPPORTED` | Sets the nonce of a given account |
+| `ANVIL` | `anvil_impersonateAccount` | `SUPPORTED` | Impersonate an account |
+| `ANVIL` | `anvil_stopImpersonatingAccount` | `SUPPORTED` | Stop impersonating an account after having previously used `anvil_impersonateAccount` |
+| `ANVIL` | `anvil_reset` | `PARTIALLY` | Resets the state of the network; cannot revert to past block numbers, unless they're in a fork |
+| `ANVIL` | `anvil_mine` | `SUPPORTED` | Mine any number of blocks at once, in constant time |
+| `ANVIL` | `anvil_setBalance` | `SUPPORTED` | Modifies the balance of an account |
+| `ANVIL` | `anvil_setCode` | `SUPPORTED` | Sets the bytecode of a given account |
+| `ANVIL` | `anvil_setStorageAt` | `SUPPORTED` | Sets the storage value at a given key for a given account |
 | [`CONFIG`](#config-namespace) | [`config_getShowCalls`](#config_getshowcalls) | `SUPPORTED` | Gets the current value of `show_calls` that's originally set with `--show-calls` option |
 | [`CONFIG`](#config-namespace) | [`config_getShowOutputs`](#config_getshowoutputs) | `SUPPORTED` | Gets the current value of `show_outputs` that's originally set with `--show-outputs` option |
 | [`CONFIG`](#config-namespace) | [`config_getCurrentTimestamp`](#config_getcurrenttimestamp) | `SUPPORTED` | Gets the value of `current_timestamp` for the node |

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -85,7 +85,7 @@ The `status` options are:
 | [`EVM`](#evm-namespace) | [`evm_revert`](#evm_revert) | `SUPPORTED` | Revert the state of the blockchain to a previous snapshot |
 | `EVM` | `evm_setAccountBalance` | `NOT IMPLEMENTED` | Sets the given account's balance to the specified WEI value |
 | `EVM` | `evm_setAccountCode` | `NOT IMPLEMENTED` | Sets the given account's code to the specified data |
-| `EVM` | `evm_setAccountNonce` | `NOT IMPLEMENTED` | Sets the given account's nonce to the specified value |
+| [`EVM`](#evm-namespace) | [`evm_setAccountNonce`](#evm_setaccountnonce) | `SUPPORTED` | Sets the given account's nonce to the specified value |
 | `EVM` | `evm_setAccountStorageAt` | `NOT IMPLEMENTED` | Sets the given account's storage slot to the specified data |
 | `EVM` | `evm_setAutomine` | `NOT IMPLEMENTED` | Enables or disables the automatic mining of new blocks with each new transaction submitted to the network |
 | `EVM` | `evm_setBlockGasLimit` | `NOT IMPLEMENTED` | Sets the Block Gas Limit of the network |

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -14,6 +14,14 @@ The `status` options are:
 
 | Namespace | API | <div style="width:130px">Status</div> | Description |
 | --- | --- | --- | --- |
+| [`ANVIL`](#anvil-namespace) | [`anvil_setNonce`](#anvil_setnonce) | `SUPPORTED` | Sets the nonce of a given account |
+| [`ANVIL`](#anvil-namespace) | [`anvil_impersonateAccount`](#anvil_impersonateaccount) | `SUPPORTED` | Impersonate an account |
+| [`ANVIL`](#anvil-namespace) | [`anvil_stopImpersonatingAccount`](#anvil_stopimpersonatingaccount) | `SUPPORTED` | Stop impersonating an account after having previously used `anvil_impersonateAccount` |
+| [`ANVIL`](#anvil-namespace) | [`anvil_reset`](#anvil_reset) | `PARTIALLY` | Resets the state of the network; cannot revert to past block numbers, unless they're in a fork |
+| [`ANVIL`](#anvil-namespace) | [`anvil_mine`](#anvil_mine) | `SUPPORTED` | Mine any number of blocks at once, in constant time |
+| [`ANVIL`](#anvil-namespace) | [`anvil_setBalance`](#anvil_setbalance) | `SUPPORTED` | Modifies the balance of an account |
+| [`ANVIL`](#anvil-namespace) | [`anvil_setCode`](#anvil_setcode) | `SUPPORTED` | Sets the bytecode of a given account |
+| [`ANVIL`](#anvil-namespace) | [`anvil_setStorageAt`](#anvil_setstorageat) | `SUPPORTED` | Sets the storage value at a given key for a given account |
 | [`CONFIG`](#config-namespace) | [`config_getShowCalls`](#config_getshowcalls) | `SUPPORTED` | Gets the current value of `show_calls` that's originally set with `--show-calls` option |
 | [`CONFIG`](#config-namespace) | [`config_getShowOutputs`](#config_getshowoutputs) | `SUPPORTED` | Gets the current value of `show_outputs` that's originally set with `--show-outputs` option |
 | [`CONFIG`](#config-namespace) | [`config_getCurrentTimestamp`](#config_getcurrenttimestamp) | `SUPPORTED` | Gets the value of `current_timestamp` for the node |

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -1677,6 +1677,35 @@ curl --request POST \
 }'
 ```
 
+### `evm_setAccountNonce`
+
+[source](src/node/evm.rs)
+
+Modifies an account's nonce by overwriting it.
+The new nonce must be greater than the existing nonce.
+
+#### Arguments
+
++ `address: Address` - The `Address` whose nonce is to be changed
++ `nonce: U256` - The new nonce
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+      "id": "1",
+      "method": "evm_setAccountNonce",
+      "params": [
+        "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+        "0x1337"
+      ]
+  }'
+```
+
 ### `evm_increaseTime`
 
 [source](src/node/evm.rs)

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -14,7 +14,7 @@ The `status` options are:
 
 | Namespace | API | <div style="width:130px">Status</div> | Description |
 | --- | --- | --- | --- |
-| `ANVIL` | `anvil_setNonce` | `SUPPORTED` | Sets the nonce of a given account |
+| `ANVIL` | `anvil_setNonce` | `SUPPORTED` | Sets the nonce of an address.|
 | `ANVIL` | `anvil_impersonateAccount` | `SUPPORTED` | Impersonate an account |
 | `ANVIL` | `anvil_stopImpersonatingAccount` | `SUPPORTED` | Stop impersonating an account after having previously used `anvil_impersonateAccount` |
 | `ANVIL` | `anvil_reset` | `PARTIALLY` | Resets the state of the network; cannot revert to past block numbers, unless they're in a fork |

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { Wallet } from "zksync-web3";
+import { RichAccounts } from "../helpers/constants";
 import { getTestProvider } from "../helpers/utils";
 import { ethers } from "hardhat";
 
@@ -56,5 +57,32 @@ describe("anvil_mine", function () {
       startingTimestamp + (numberOfBlocks - 1) * intervalInSeconds * 1000 + 1,
       "Timestamp mismatch"
     );
+  });
+});
+
+describe("anvil_impersonateAccount & anvil_stopImpersonatingAccount", function () {
+  it("Should allow transfers of funds without knowing the Private Key", async function () {
+    // Arrange
+    const userWallet = Wallet.createRandom().connect(provider);
+    const beforeBalance = await provider.getBalance(RichAccounts[5].Account);
+
+    // Act
+    await provider.send("anvil_impersonateAccount", [RichAccounts[5].Account]);
+
+    const signer = await ethers.getSigner(RichAccounts[5].Account);
+    const tx = {
+      to: userWallet.address,
+      value: ethers.utils.parseEther("0.42"),
+    };
+
+    const recieptTx = await signer.sendTransaction(tx);
+    await recieptTx.wait();
+
+    await provider.send("anvil_stopImpersonatingAccount", [RichAccounts[5].Account]);
+
+    // Assert
+    expect((await userWallet.getBalance()).eq(ethers.utils.parseEther("0.42"))).to.true;
+    expect((await provider.getBalance(RichAccounts[5].Account)).eq(beforeBalance.sub(ethers.utils.parseEther("0.42"))))
+      .to.true;
   });
 });

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -97,7 +97,7 @@ describe("anvil_setCode", function () {
     const randomWallet = Wallet.createRandom();
     const address = randomWallet.address;
     const artifact = await deployer.loadArtifact("Return5");
-    const contractCode = [...ethers.utils.arrayify(artifact.deployedBytecode)];
+    const contractCode = artifact.deployedBytecode;
 
     // Act
     await provider.send("anvil_setCode", [address, contractCode]);
@@ -126,8 +126,8 @@ describe("anvil_setCode", function () {
 
       const address = "0x1000000000000000000000000000000000001111";
       const artifact = await deployer.loadArtifact("Return5");
-      const contractCode = [...ethers.utils.arrayify(artifact.deployedBytecode)];
-      const shortCode = contractCode.slice(0, contractCode.length - 1);
+      const contractCode = artifact.deployedBytecode;
+      const shortCode = contractCode.slice(0, contractCode.length - 2);
 
       // Act
       await provider.send("anvil_setCode", [address, shortCode]);
@@ -144,7 +144,7 @@ describe("anvil_setCode", function () {
     const greeter = await deployContract(deployer, "Greeter", ["Hi"]);
     expect(await greeter.greet()).to.eq("Hi");
     const artifact = await deployer.loadArtifact("Return5");
-    const newContractCode = [...ethers.utils.arrayify(artifact.deployedBytecode)];
+    const newContractCode = artifact.deployedBytecode;
 
     // Act
     await provider.send("anvil_setCode", [greeter.address, newContractCode]);

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -49,10 +49,7 @@ describe("anvil_mine", function () {
     const startingTimestamp: number = await provider.send("config_getCurrentTimestamp", []);
 
     // Act
-    await provider.send("anvil_mine", [
-      ethers.utils.hexlify(numberOfBlocks),
-      ethers.utils.hexlify(intervalInSeconds),
-    ]);
+    await provider.send("anvil_mine", [ethers.utils.hexlify(numberOfBlocks), ethers.utils.hexlify(intervalInSeconds)]);
 
     // Assert
     const latestBlock = await provider.getBlock("latest");

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -34,3 +34,27 @@ describe("anvil_setNonce", function () {
     expect(nonce).to.equal(newNonce);
   });
 });
+
+describe("anvil_mine", function () {
+  it("Should mine multiple blocks with a given interval", async function () {
+    // Arrange
+    const numberOfBlocks = 100;
+    const intervalInSeconds = 60;
+    const startingBlock = await provider.getBlock("latest");
+    const startingTimestamp: number = await provider.send("config_getCurrentTimestamp", []);
+
+    // Act
+    await provider.send("anvil_mine", [
+      ethers.utils.hexlify(numberOfBlocks),
+      ethers.utils.hexlify(intervalInSeconds),
+    ]);
+
+    // Assert
+    const latestBlock = await provider.getBlock("latest");
+    expect(latestBlock.number).to.equal(startingBlock.number + numberOfBlocks, "Block number mismatch");
+    expect(latestBlock.timestamp).to.equal(
+      startingTimestamp + (numberOfBlocks - 1) * intervalInSeconds * 1000 + 1,
+      "Timestamp mismatch"
+    );
+  });
+});

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -94,7 +94,7 @@ describe("anvil_setCode", function () {
     const wallet = new Wallet(RichAccounts[0].PrivateKey);
     const deployer = new Deployer(hre, wallet);
 
-    const randomWallet = Wallet.createRandom()
+    const randomWallet = Wallet.createRandom();
     const address = randomWallet.address;
     const artifact = await deployer.loadArtifact("Return5");
     const contractCode = [...ethers.utils.arrayify(artifact.deployedBytecode)];

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -1,8 +1,24 @@
 import { expect } from "chai";
 import { Wallet } from "zksync-web3";
 import { getTestProvider } from "../helpers/utils";
+import { ethers } from "hardhat";
 
 const provider = getTestProvider();
+
+describe("anvil_setBalance", function () {
+  it("Should update the balance of an account", async function () {
+    // Arrange
+    const userWallet = Wallet.createRandom().connect(provider);
+    const newBalance = ethers.utils.parseEther("42");
+
+    // Act
+    await provider.send("anvil_setBalance", [userWallet.address, newBalance._hex]);
+
+    // Assert
+    const balance = await userWallet.getBalance();
+    expect(balance.eq(newBalance)).to.true;
+  });
+});
 
 describe("anvil_setNonce", function () {
   it("Should update the nonce of an account", async function () {

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -65,12 +65,13 @@ describe("anvil_impersonateAccount & anvil_stopImpersonatingAccount", function (
   it("Should allow transfers of funds without knowing the Private Key", async function () {
     // Arrange
     const userWallet = Wallet.createRandom().connect(provider);
-    const beforeBalance = await provider.getBalance(RichAccounts[5].Account);
+    const richAccount = RichAccounts[5].Account;
+    const beforeBalance = await provider.getBalance(richAccount);
 
     // Act
-    await provider.send("anvil_impersonateAccount", [RichAccounts[5].Account]);
+    await provider.send("anvil_impersonateAccount", [richAccount]);
 
-    const signer = await ethers.getSigner(RichAccounts[5].Account);
+    const signer = await ethers.getSigner(richAccount);
     const tx = {
       to: userWallet.address,
       value: ethers.utils.parseEther("0.42"),
@@ -79,12 +80,11 @@ describe("anvil_impersonateAccount & anvil_stopImpersonatingAccount", function (
     const recieptTx = await signer.sendTransaction(tx);
     await recieptTx.wait();
 
-    await provider.send("anvil_stopImpersonatingAccount", [RichAccounts[5].Account]);
+    await provider.send("anvil_stopImpersonatingAccount", [richAccount]);
 
     // Assert
     expect((await userWallet.getBalance()).eq(ethers.utils.parseEther("0.42"))).to.true;
-    expect((await provider.getBalance(RichAccounts[5].Account)).eq(beforeBalance.sub(ethers.utils.parseEther("0.42"))))
-      .to.true;
+    expect((await provider.getBalance(richAccount)).eq(beforeBalance.sub(ethers.utils.parseEther("0.42")))).to.true;
   });
 });
 

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -1,0 +1,20 @@
+import { expect } from "chai";
+import { Wallet } from "zksync-web3";
+import { getTestProvider } from "../helpers/utils";
+
+const provider = getTestProvider();
+
+describe("anvil_setNonce", function () {
+  it("Should update the nonce of an account", async function () {
+    // Arrange
+    const userWallet = Wallet.createRandom().connect(provider);
+    const newNonce = 42;
+
+    // Act
+    await provider.send("anvil_setNonce", [userWallet.address, ethers.utils.hexlify(newNonce)]);
+
+    // Assert
+    const nonce = await userWallet.getNonce();
+    expect(nonce).to.equal(newNonce);
+  });
+});

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -94,7 +94,8 @@ describe("anvil_setCode", function () {
     const wallet = new Wallet(RichAccounts[0].PrivateKey);
     const deployer = new Deployer(hre, wallet);
 
-    const address = "0x1000000000000000000000000000000000001111";
+    const randomWallet = Wallet.createRandom()
+    const address = randomWallet.address;
     const artifact = await deployer.loadArtifact("Return5");
     const contractCode = [...ethers.utils.arrayify(artifact.deployedBytecode)];
 

--- a/e2e-tests/test/evm-apis.test.ts
+++ b/e2e-tests/test/evm-apis.test.ts
@@ -8,6 +8,21 @@ import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 
 const provider = getTestProvider();
 
+describe("evm_setAccountNonce", function () {
+  it("Should update the nonce of an account", async function () {
+    // Arrange
+    const userWallet = Wallet.createRandom().connect(provider);
+    const newNonce = 42;
+
+    // Act
+    await provider.send("evm_setAccountNonce", [userWallet.address, ethers.utils.hexlify(newNonce)]);
+
+    // Assert
+    const nonce = await userWallet.getNonce();
+    expect(nonce).to.equal(newNonce);
+  });
+});
+
 describe("evm_mine", function () {
   it("Should mine one block", async function () {
     // Arrange

--- a/e2e-tests/test/hardhat-apis.test.ts
+++ b/e2e-tests/test/hardhat-apis.test.ts
@@ -68,12 +68,12 @@ describe("hardhat_impersonateAccount & hardhat_stopImpersonatingAccount", functi
   it("Should allow transfers of funds without knowing the Private Key", async function () {
     // Arrange
     const userWallet = Wallet.createRandom().connect(provider);
-    const beforeBalance = await provider.getBalance(RichAccounts[0].Account);
+    const beforeBalance = await provider.getBalance(RichAccounts[5].Account);
 
     // Act
-    await provider.send("hardhat_impersonateAccount", [RichAccounts[0].Account]);
+    await provider.send("hardhat_impersonateAccount", [RichAccounts[5].Account]);
 
-    const signer = await ethers.getSigner(RichAccounts[0].Account);
+    const signer = await ethers.getSigner(RichAccounts[5].Account);
     const tx = {
       to: userWallet.address,
       value: ethers.utils.parseEther("0.42"),
@@ -82,9 +82,11 @@ describe("hardhat_impersonateAccount & hardhat_stopImpersonatingAccount", functi
     const recieptTx = await signer.sendTransaction(tx);
     await recieptTx.wait();
 
+    await provider.send("hardhat_stopImpersonatingAccount", [RichAccounts[5].Account]);
+
     // Assert
     expect((await userWallet.getBalance()).eq(ethers.utils.parseEther("0.42"))).to.true;
-    expect((await provider.getBalance(RichAccounts[0].Account)).eq(beforeBalance.sub(ethers.utils.parseEther("0.42"))))
+    expect((await provider.getBalance(RichAccounts[5].Account)).eq(beforeBalance.sub(ethers.utils.parseEther("0.42"))))
       .to.true;
   });
 });

--- a/e2e-tests/test/hardhat-apis.test.ts
+++ b/e2e-tests/test/hardhat-apis.test.ts
@@ -167,3 +167,27 @@ describe("hardhat_setCode", function () {
     expect(BigNumber.from(result).toNumber()).to.eq(5);
   });
 });
+
+describe("hardhat_setStorageAt", function () {
+  it("Should set storage at an address", async function () {
+    const wallet = new Wallet(RichAccounts[0].PrivateKey, provider);
+    const userWallet = Wallet.createRandom().connect(provider);
+    await wallet.sendTransaction({
+      to: userWallet.address,
+      value: ethers.utils.parseEther("3"),
+    });
+
+    const deployer = new Deployer(hre, userWallet);
+    const artifact = await deployer.loadArtifact("MyERC20");
+    const token = await deployer.deploy(artifact, ["MyToken", "MyToken", 18]);
+
+    const before = await provider.send("eth_getStorageAt", [token.address, "0x0", "latest"]);
+    expect(BigNumber.from(before).toNumber()).to.eq(0);
+
+    const value = ethers.utils.hexlify(ethers.utils.zeroPad("0x10", 32));
+    await provider.send("hardhat_setStorageAt", [token.address, "0x0", value]);
+
+    const after = await provider.send("eth_getStorageAt", [token.address, "0x0", "latest"]);
+    expect(BigNumber.from(after).toNumber()).to.eq(16);
+  });
+});

--- a/e2e-tests/test/main.test.ts
+++ b/e2e-tests/test/main.test.ts
@@ -71,7 +71,7 @@ describe("Greeter Smart Contract", function () {
     expect(setGreetingLog).not.to.equal(null);
 
     const eventInterface = new ethers.utils.Interface(["event LogString(string value)"]);
-    const parsedLog = eventInterface.parseLog(setGreetingLog);
+    const parsedLog = eventInterface.parseLog(setGreetingLog!);
     const parsedLogArg = parsedLog.args[0].toString();
     expect(parsedLogArg).to.equal("Greeting is being updated to Luke Skywalker");
   });

--- a/e2e-tests/test/main.test.ts
+++ b/e2e-tests/test/main.test.ts
@@ -62,8 +62,13 @@ describe("Greeter Smart Contract", function () {
 
     // Validate log is created
     expect(receipt.logs.length).to.greaterThanOrEqual(1);
-    const setGreetingLog = receipt.logs[0];
-    expect(setGreetingLog.address).to.equal(greeter.address);
+    var setGreetingLog = null;
+    for (var i = 0; (setGreetingLog == null) && (i < receipt.logs.length); ++i) {
+      if (receipt.logs[i].address == greeter.address) {
+        setGreetingLog = receipt.logs[i];
+      }
+    }
+    expect(setGreetingLog).not.to.equal(null);
 
     const eventInterface = new ethers.utils.Interface(["event LogString(string value)"]);
     expect(eventInterface.parseLog(setGreetingLog).args[0]).to.equal("Greeting is being updated to Luke Skywalker");
@@ -78,8 +83,17 @@ describe("Greeter Smart Contract", function () {
     const setGreetingTx = await greeter.setGreeting("Luke Skywalker");
     let receipt: TransactionReceipt = await setGreetingTx.wait();
 
+    expect(receipt.logs.length).to.greaterThanOrEqual(1);
+    var setGreetingLog = null;
+    for (var i = 0; (setGreetingLog == null) && (i < receipt.logs.length); ++i) {
+      if (receipt.logs[i].address == greeter.address) {
+        setGreetingLog = receipt.logs[i];
+      }
+    }
+    expect(setGreetingLog).not.to.equal(null);
+
     // Create filter
-    const topic = receipt.logs[0].topics[0];
+    const topic = setGreetingLog.topics[0];
     const filterId = await provider.send("eth_newFilter", [
       {
         fromBlock: "earliest",

--- a/e2e-tests/test/main.test.ts
+++ b/e2e-tests/test/main.test.ts
@@ -63,7 +63,7 @@ describe("Greeter Smart Contract", function () {
     // Validate log is created
     expect(receipt.logs.length).to.greaterThanOrEqual(1);
     var setGreetingLog = null;
-    for (var i = 0; (setGreetingLog == null) && (i < receipt.logs.length); ++i) {
+    for (var i = 0; setGreetingLog == null && i < receipt.logs.length; ++i) {
       if (receipt.logs[i].address == greeter.address) {
         setGreetingLog = receipt.logs[i];
       }
@@ -85,7 +85,7 @@ describe("Greeter Smart Contract", function () {
 
     expect(receipt.logs.length).to.greaterThanOrEqual(1);
     var setGreetingLog = null;
-    for (var i = 0; (setGreetingLog == null) && (i < receipt.logs.length); ++i) {
+    for (var i = 0; setGreetingLog == null && i < receipt.logs.length; ++i) {
       if (receipt.logs[i].address == greeter.address) {
         setGreetingLog = receipt.logs[i];
       }

--- a/e2e-tests/test/main.test.ts
+++ b/e2e-tests/test/main.test.ts
@@ -62,12 +62,7 @@ describe("Greeter Smart Contract", function () {
 
     // Validate log is created
     expect(receipt.logs.length).to.greaterThanOrEqual(1);
-    let setGreetingLog = null;
-    for (let i = 0; setGreetingLog == null && i < receipt.logs.length; ++i) {
-      if (receipt.logs[i].address == greeter.address) {
-        setGreetingLog = receipt.logs[i];
-      }
-    }
+    const setGreetingLog = receipt.logs.find((log) => log.address === greeter.address);
     expect(setGreetingLog).not.to.equal(null);
 
     const eventInterface = new ethers.utils.Interface(["event LogString(string value)"]);
@@ -86,12 +81,7 @@ describe("Greeter Smart Contract", function () {
     let receipt: TransactionReceipt = await setGreetingTx.wait();
 
     expect(receipt.logs.length).to.greaterThanOrEqual(1);
-    let setGreetingLog = null;
-    for (let i = 0; setGreetingLog == null && i < receipt.logs.length; ++i) {
-      if (receipt.logs[i].address == greeter.address) {
-        setGreetingLog = receipt.logs[i];
-      }
-    }
+    const setGreetingLog = receipt.logs.find((log) => log.address === greeter.address);
     expect(setGreetingLog).not.to.equal(null);
 
     // Create filter

--- a/e2e-tests/test/main.test.ts
+++ b/e2e-tests/test/main.test.ts
@@ -63,7 +63,7 @@ describe("Greeter Smart Contract", function () {
     // Validate log is created
     expect(receipt.logs.length).to.greaterThanOrEqual(1);
     let setGreetingLog = null;
-    for (var i = 0; setGreetingLog == null && i < receipt.logs.length; ++i) {
+    for (let i = 0; setGreetingLog == null && i < receipt.logs.length; ++i) {
       if (receipt.logs[i].address == greeter.address) {
         setGreetingLog = receipt.logs[i];
       }
@@ -85,7 +85,7 @@ describe("Greeter Smart Contract", function () {
 
     expect(receipt.logs.length).to.greaterThanOrEqual(1);
     let setGreetingLog = null;
-    for (var i = 0; setGreetingLog == null && i < receipt.logs.length; ++i) {
+    for (let i = 0; setGreetingLog == null && i < receipt.logs.length; ++i) {
       if (receipt.logs[i].address == greeter.address) {
         setGreetingLog = receipt.logs[i];
       }

--- a/e2e-tests/test/main.test.ts
+++ b/e2e-tests/test/main.test.ts
@@ -62,7 +62,7 @@ describe("Greeter Smart Contract", function () {
 
     // Validate log is created
     expect(receipt.logs.length).to.greaterThanOrEqual(1);
-    var setGreetingLog = null;
+    let setGreetingLog = null;
     for (var i = 0; setGreetingLog == null && i < receipt.logs.length; ++i) {
       if (receipt.logs[i].address == greeter.address) {
         setGreetingLog = receipt.logs[i];
@@ -84,7 +84,7 @@ describe("Greeter Smart Contract", function () {
     let receipt: TransactionReceipt = await setGreetingTx.wait();
 
     expect(receipt.logs.length).to.greaterThanOrEqual(1);
-    var setGreetingLog = null;
+    let setGreetingLog = null;
     for (var i = 0; setGreetingLog == null && i < receipt.logs.length; ++i) {
       if (receipt.logs[i].address == greeter.address) {
         setGreetingLog = receipt.logs[i];

--- a/e2e-tests/test/main.test.ts
+++ b/e2e-tests/test/main.test.ts
@@ -71,7 +71,9 @@ describe("Greeter Smart Contract", function () {
     expect(setGreetingLog).not.to.equal(null);
 
     const eventInterface = new ethers.utils.Interface(["event LogString(string value)"]);
-    expect(eventInterface.parseLog(setGreetingLog).args[0]).to.equal("Greeting is being updated to Luke Skywalker");
+    const parsedLog = eventInterface.parseLog(setGreetingLog);
+    const parsedLogArg = parsedLog.args[0].toString();
+    expect(parsedLogArg).to.equal("Greeting is being updated to Luke Skywalker");
   });
 
   it("Should filter event logs", async function () {
@@ -93,7 +95,7 @@ describe("Greeter Smart Contract", function () {
     expect(setGreetingLog).not.to.equal(null);
 
     // Create filter
-    const topic = setGreetingLog.topics[0];
+    const topic = setGreetingLog!.topics[0];
     const filterId = await provider.send("eth_newFilter", [
       {
         fromBlock: "earliest",

--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -30,16 +30,12 @@ describe("zks_estimateFee", function () {
     // Act
     const response: Fee = await provider.send("zks_estimateFee", [transaction]);
     // Assert
-    expect(ethers.BigNumber.from(response.gas_limit).toNumber()).to.be.within(3606743, 5868728, "Unexpected gas_limit");
+    expect(ethers.BigNumber.from(response.gas_limit).toNumber()).to.eql(4048728, "Unexpected gas_limit");
     expect(ethers.BigNumber.from(response.gas_per_pubdata_limit)).to.eql(
       ethers.BigNumber.from("50000"),
       "Unexpected gas_per_pubdata_limit"
     );
-    expect(ethers.BigNumber.from(response.max_fee_per_gas).toNumber()).to.be.within(
-      25500297,
-      37500000,
-      "Unexpected max_fee_per_gas"
-    );
+    expect(ethers.BigNumber.from(response.max_fee_per_gas).toNumber()).to.eql(37500000, "Unexpected max_fee_per_gas");
     expect(ethers.BigNumber.from(response.max_priority_fee_per_gas)).to.eql(
       ethers.BigNumber.from("0"),
       "Unexpected max_priority_fee_per_gas"

--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -30,13 +30,14 @@ describe("zks_estimateFee", function () {
     // Act
     const response: Fee = await provider.send("zks_estimateFee", [transaction]);
     // Assert
-    expect(ethers.BigNumber.from(response.gas_limit)).to.eql(ethers.BigNumber.from("3606743"), "Unexpected gas_limit");
+    expect(ethers.BigNumber.from(response.gas_limit).toNumber()).to.be.within(3606743, 5868728, "Unexpected gas_limit");
     expect(ethers.BigNumber.from(response.gas_per_pubdata_limit)).to.eql(
       ethers.BigNumber.from("50000"),
       "Unexpected gas_per_pubdata_limit"
     );
-    expect(ethers.BigNumber.from(response.max_fee_per_gas)).to.eql(
-      ethers.BigNumber.from("37500000"),
+    expect(ethers.BigNumber.from(response.max_fee_per_gas).toNumber()).to.be.within(
+      25500297,
+      37500000,
       "Unexpected max_fee_per_gas"
     );
     expect(ethers.BigNumber.from(response.max_priority_fee_per_gas)).to.eql(

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,9 @@ use jsonrpc_core::MetaIoHandler;
 use zksync_basic_types::H160;
 
 use crate::namespaces::{
-    ConfigurationApiNamespaceT, DebugNamespaceT, EthNamespaceT, EthTestNodeNamespaceT,
-    EvmNamespaceT, HardhatNamespaceT, NetNamespaceT, Web3NamespaceT, ZksNamespaceT,
+    AnvilNamespaceT, ConfigurationApiNamespaceT, DebugNamespaceT, EthNamespaceT,
+    EthTestNodeNamespaceT, EvmNamespaceT, HardhatNamespaceT, NetNamespaceT, Web3NamespaceT,
+    ZksNamespaceT,
 };
 
 /// List of legacy wallets (address, private key) that we seed with tokens at start.
@@ -165,6 +166,7 @@ async fn build_json_http<
         io.extend_with(DebugNamespaceT::to_delegate(node.clone()));
         io.extend_with(EthNamespaceT::to_delegate(node.clone()));
         io.extend_with(EthTestNodeNamespaceT::to_delegate(node.clone()));
+        io.extend_with(AnvilNamespaceT::to_delegate(node.clone()));
         io.extend_with(EvmNamespaceT::to_delegate(node.clone()));
         io.extend_with(HardhatNamespaceT::to_delegate(node.clone()));
         io.extend_with(ZksNamespaceT::to_delegate(node));

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -97,7 +97,7 @@ pub trait AnvilNamespaceT {
     ///
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "anvil_setCode")]
-    fn set_code(&self, address: Address, code: Vec<u8>) -> RpcResult<()>;
+    fn set_code(&self, address: Address, code: String) -> RpcResult<()>;
 
     /// Directly modifies the storage of a contract at a specified slot.
     ///

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -1,7 +1,7 @@
 use jsonrpc_derive::rpc;
 use zksync_basic_types::{Address, U256, U64};
 
-use super::RpcResult;
+use super::{ResetRequest, RpcResult};
 
 #[rpc]
 pub trait AnvilNamespaceT {
@@ -32,6 +32,18 @@ pub trait AnvilNamespaceT {
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "anvil_mine")]
     fn hardhat_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<bool>;
+
+    /// Reset the state of the network back to a fresh forked state, or disable forking.
+    ///
+    /// # Arguments
+    ///
+    /// * `reset_spec` - The requested state, defaults to resetting the current network.
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
+    #[rpc(name = "anvil_reset")]
+    fn reset_network(&self, reset_spec: Option<ResetRequest>) -> RpcResult<bool>;
 
     /// Era Test Node allows transactions impersonating specific account and contract addresses.
     /// To impersonate an account use this method, passing the address to impersonate as its parameter.

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -98,4 +98,18 @@ pub trait AnvilNamespaceT {
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "anvil_setCode")]
     fn set_code(&self, address: Address, code: Vec<u8>) -> RpcResult<()>;
+
+    /// Directly modifies the storage of a contract at a specified slot.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The contract address whose storage is to be modified.
+    /// * `slot` - The storage slot to modify.
+    /// * `value` - The value to be set at the specified slot.
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
+    #[rpc(name = "anvil_setStorageAt")]
+    fn set_storage_at(&self, address: Address, slot: U256, value: U256) -> RpcResult<bool>;
 }

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -17,4 +17,32 @@ pub trait AnvilNamespaceT {
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "anvil_setNonce")]
     fn set_nonce(&self, address: Address, balance: U256) -> RpcResult<bool>;
+
+    /// Era Test Node allows transactions impersonating specific account and contract addresses.
+    /// To impersonate an account use this method, passing the address to impersonate as its parameter.
+    /// After calling this method, any transactions with this sender will be executed without verification.
+    /// Multiple addresses can be impersonated at once.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The address to impersonate
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
+    #[rpc(name = "anvil_impersonateAccount")]
+    fn impersonate_account(&self, address: Address) -> RpcResult<bool>;
+
+    /// Use this method to stop impersonating an account after having previously used `anvil_impersonateAccount`
+    /// The method returns `true` if the account was being impersonated and `false` otherwise.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The address to stop impersonating.
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
+    #[rpc(name = "anvil_stopImpersonatingAccount")]
+    fn stop_impersonating_account(&self, address: Address) -> RpcResult<bool>;
 }

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -1,5 +1,5 @@
 use jsonrpc_derive::rpc;
-use zksync_basic_types::{Address, U256};
+use zksync_basic_types::{Address, U256, U64};
 
 use super::RpcResult;
 
@@ -17,6 +17,21 @@ pub trait AnvilNamespaceT {
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "anvil_setNonce")]
     fn set_nonce(&self, address: Address, balance: U256) -> RpcResult<bool>;
+
+    /// Sometimes you may want to advance the latest block number of the network by a large number of blocks.
+    /// One way to do this would be to call the evm_mine RPC method multiple times, but this is too slow if you want to mine thousands of blocks.
+    /// The hardhat_mine method can mine any number of blocks at once, in constant time. (It exhibits the same performance no matter how many blocks are mined.)
+    ///
+    /// # Arguments
+    ///
+    /// * `num_blocks` - The number of blocks to mine, defaults to 1
+    /// * `interval` - The interval between the timestamps of each block, in seconds, and it also defaults to 1
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
+    #[rpc(name = "anvil_mine")]
+    fn hardhat_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<bool>;
 
     /// Era Test Node allows transactions impersonating specific account and contract addresses.
     /// To impersonate an account use this method, passing the address to impersonate as its parameter.

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -44,7 +44,7 @@ pub trait AnvilNamespaceT {
     ///
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "anvil_mine")]
-    fn hardhat_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<bool>;
+    fn anvil_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<bool>;
 
     /// Reset the state of the network back to a fresh forked state, or disable forking.
     ///

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -33,7 +33,7 @@ pub trait AnvilNamespaceT {
 
     /// Sometimes you may want to advance the latest block number of the network by a large number of blocks.
     /// One way to do this would be to call the evm_mine RPC method multiple times, but this is too slow if you want to mine thousands of blocks.
-    /// The hardhat_mine method can mine any number of blocks at once, in constant time. (It exhibits the same performance no matter how many blocks are mined.)
+    /// The `anvil_mine` method can mine any number of blocks at once, in constant time. (It exhibits the same performance no matter how many blocks are mined.)
     ///
     /// # Arguments
     ///

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -5,6 +5,19 @@ use super::{ResetRequest, RpcResult};
 
 #[rpc]
 pub trait AnvilNamespaceT {
+    /// Sets the balance of the given address to the given balance.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The `Address` whose balance will be edited
+    /// * `balance` - The new balance to set for the given address, in wei
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
+    #[rpc(name = "anvil_setBalance")]
+    fn set_balance(&self, address: Address, balance: U256) -> RpcResult<bool>;
+
     /// Modifies an account's nonce by overwriting it.
     ///
     /// # Arguments

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -85,4 +85,17 @@ pub trait AnvilNamespaceT {
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "anvil_stopImpersonatingAccount")]
     fn stop_impersonating_account(&self, address: Address) -> RpcResult<bool>;
+
+    /// Modifies the bytecode stored at an account's address.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The address where the given code should be stored.
+    /// * `code` - The code to be stored.
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
+    #[rpc(name = "anvil_setCode")]
+    fn set_code(&self, address: Address, code: Vec<u8>) -> RpcResult<()>;
 }

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -1,0 +1,20 @@
+use jsonrpc_derive::rpc;
+use zksync_basic_types::{Address, U256};
+
+use super::RpcResult;
+
+#[rpc]
+pub trait AnvilNamespaceT {
+    /// Modifies an account's nonce by overwriting it.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The `Address` whose nonce is to be changed
+    /// * `nonce` - The new nonce
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
+    #[rpc(name = "anvil_setNonce")]
+    fn set_nonce(&self, address: Address, balance: U256) -> RpcResult<bool>;
+}

--- a/src/namespaces/evm.rs
+++ b/src/namespaces/evm.rs
@@ -1,5 +1,5 @@
 use jsonrpc_derive::rpc;
-use zksync_basic_types::U64;
+use zksync_basic_types::{Address, U256, U64};
 
 use crate::namespaces::RpcResult;
 
@@ -14,6 +14,19 @@ pub trait EvmNamespaceT {
     /// The applied time delta to `current_timestamp` value for the InMemoryNodeInner.
     #[rpc(name = "evm_increaseTime")]
     fn increase_time(&self, time_delta_seconds: u64) -> RpcResult<u64>;
+
+    /// Modifies an account's nonce by overwriting it.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The `Address` whose nonce is to be changed
+    /// * `nonce` - The new nonce
+    ///
+    /// # Returns
+    ///
+    /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
+    #[rpc(name = "evm_setAccountNonce")]
+    fn set_nonce(&self, address: Address, balance: U256) -> RpcResult<bool>;
 
     /// Force a single block to be mined.
     ///

--- a/src/namespaces/mod.rs
+++ b/src/namespaces/mod.rs
@@ -1,3 +1,4 @@
+mod anvil;
 mod config;
 mod debug;
 mod eth;
@@ -8,6 +9,7 @@ mod net;
 mod web3;
 mod zks;
 
+pub use anvil::AnvilNamespaceT;
 pub use config::ConfigurationApiNamespaceT;
 pub use debug::DebugNamespaceT;
 pub use eth::EthNamespaceT;

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -1,4 +1,4 @@
-use zksync_basic_types::{Address, U256};
+use zksync_basic_types::{Address, U256, U64};
 use zksync_web3_decl::error::Web3Error;
 
 use crate::{
@@ -15,6 +15,15 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNames
         self.set_nonce(address, balance)
             .map_err(|err| {
                 tracing::error!("failed setting nonce: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
+    fn hardhat_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<bool> {
+        self.mine_blocks(num_blocks, interval)
+            .map_err(|err| {
+                tracing::error!("failed mining blocks: {:?}", err);
                 into_jsrpc_error(Web3Error::InternalError(err))
             })
             .into_boxed_future()

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -73,4 +73,13 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNames
             })
             .into_boxed_future()
     }
+
+    fn set_storage_at(&self, address: Address, slot: U256, value: U256) -> RpcResult<bool> {
+        self.set_storage_at(address, slot, value)
+            .map_err(|err| {
+                tracing::error!("failed setting storage: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
 }

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -3,7 +3,7 @@ use zksync_web3_decl::error::Web3Error;
 
 use crate::{
     fork::ForkSource,
-    namespaces::{AnvilNamespaceT, RpcResult},
+    namespaces::{AnvilNamespaceT, ResetRequest, RpcResult},
     node::InMemoryNode,
     utils::{into_jsrpc_error, IntoBoxedFuture},
 };
@@ -24,6 +24,15 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNames
         self.mine_blocks(num_blocks, interval)
             .map_err(|err| {
                 tracing::error!("failed mining blocks: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
+    fn reset_network(&self, reset_spec: Option<ResetRequest>) -> RpcResult<bool> {
+        self.reset_network(reset_spec)
+            .map_err(|err| {
+                tracing::error!("failed reset: {:?}", err);
                 into_jsrpc_error(Web3Error::InternalError(err))
             })
             .into_boxed_future()

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -5,7 +5,7 @@ use crate::{
     fork::ForkSource,
     namespaces::{AnvilNamespaceT, ResetRequest, RpcResult},
     node::InMemoryNode,
-    utils::{into_jsrpc_error, IntoBoxedFuture},
+    utils::{into_jsrpc_error, into_jsrpc_error_message, IntoBoxedFuture},
 };
 
 impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNamespaceT
@@ -61,6 +61,15 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNames
             .map_err(|err| {
                 tracing::error!("failed stopping to impersonate account: {:?}", err);
                 into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
+    fn set_code(&self, address: Address, code: Vec<u8>) -> RpcResult<()> {
+        self.set_code(address, code)
+            .map_err(|err| {
+                tracing::error!("failed setting code: {:?}", err);
+                into_jsrpc_error_message(err.to_string())
             })
             .into_boxed_future()
     }

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -11,6 +11,15 @@ use crate::{
 impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNamespaceT
     for InMemoryNode<S>
 {
+    fn set_balance(&self, address: Address, balance: U256) -> RpcResult<bool> {
+        self.set_balance(address, balance)
+            .map_err(|err| {
+                tracing::error!("failed setting balance : {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
     fn set_nonce(&self, address: Address, balance: U256) -> RpcResult<bool> {
         self.set_nonce(address, balance)
             .map_err(|err| {

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -29,7 +29,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNames
             .into_boxed_future()
     }
 
-    fn hardhat_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<bool> {
+    fn anvil_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<bool> {
         self.mine_blocks(num_blocks, interval)
             .map_err(|err| {
                 tracing::error!("failed mining blocks: {:?}", err);

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -1,0 +1,22 @@
+use zksync_basic_types::{Address, U256};
+use zksync_web3_decl::error::Web3Error;
+
+use crate::{
+    fork::ForkSource,
+    namespaces::{AnvilNamespaceT, RpcResult},
+    node::InMemoryNode,
+    utils::{into_jsrpc_error, IntoBoxedFuture},
+};
+
+impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNamespaceT
+    for InMemoryNode<S>
+{
+    fn set_nonce(&self, address: Address, balance: U256) -> RpcResult<bool> {
+        self.set_nonce(address, balance)
+            .map_err(|err| {
+                tracing::error!("failed setting nonce: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+}

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -65,7 +65,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNames
             .into_boxed_future()
     }
 
-    fn set_code(&self, address: Address, code: Vec<u8>) -> RpcResult<()> {
+    fn set_code(&self, address: Address, code: String) -> RpcResult<()> {
         self.set_code(address, code)
             .map_err(|err| {
                 tracing::error!("failed setting code: {:?}", err);

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -19,4 +19,22 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNames
             })
             .into_boxed_future()
     }
+
+    fn impersonate_account(&self, address: Address) -> RpcResult<bool> {
+        self.impersonate_account(address)
+            .map_err(|err| {
+                tracing::error!("failed impersonating account: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
+    fn stop_impersonating_account(&self, address: Address) -> RpcResult<bool> {
+        InMemoryNode::<S>::stop_impersonating_account(self, address)
+            .map_err(|err| {
+                tracing::error!("failed stopping to impersonate account: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
 }

--- a/src/node/evm.rs
+++ b/src/node/evm.rs
@@ -1,4 +1,4 @@
-use zksync_basic_types::U64;
+use zksync_basic_types::{Address, U256, U64};
 use zksync_web3_decl::error::Web3Error;
 
 use crate::{
@@ -15,6 +15,15 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> EvmNamespa
         self.increase_time(time_delta_seconds)
             .map_err(|err| {
                 tracing::error!("failed increasing time: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
+    fn set_nonce(&self, address: Address, balance: U256) -> RpcResult<bool> {
+        self.set_nonce(address, balance)
+            .map_err(|err| {
+                tracing::error!("failed setting nonce: {:?}", err);
                 into_jsrpc_error(Web3Error::InternalError(err))
             })
             .into_boxed_future()

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,5 +1,6 @@
 //! In-memory node, that supports forking other networks.
 
+mod anvil;
 mod config_api;
 mod debug;
 mod eth;


### PR DESCRIPTION
# What :computer: 
Added `evm_setAccountNonce`, `anvil_setNonce`, `anvil_impersonateAccount`, `anvil_stopImpersonatingAccount`, `anvil_mine`, `anvil_reset`, `anvil_setBalance`, `anvil_setCode` and `anvil_setStorageAt` as aliases to the corresponding `hardhat_*` methods.

# Why :hand:
Implements https://github.com/matter-labs/era-test-node/issues/160 .

# Evidence :camera:
Extended e2e tests, which pass.
