### PR TITLE
feat: previous L1 block hash

### DIFF
--- a/src/fork.rs
+++ b/src/fork.rs
@@ -507,10 +507,14 @@ impl ForkDetails {
             }
         };
         let l1_block_hash = opt_l1_batch.and_then(|l1_batch| l1_batch.base.root_hash);
-
+        let l1_block_hash_str = if let Some(hash) = l1_block_hash {
+            format!(" (0x{})", hex::encode(hash))
+        } else {
+            String::new()
+        };
         tracing::info!(
-            "Creating fork from {:?} L1 block: {:?} ({:?}) L2 block: {:?} with timestamp {:?}, L1 gas price {:?}, L2 fair gas price {:?} and protocol version: {:?}" ,
-            url, l1_batch_number, l1_block_hash, miniblock, block_details.base.timestamp, block_details.base.l1_gas_price, block_details.base.l2_fair_gas_price, block_details.protocol_version
+            "Creating fork from {:?} L1 block: {:?}{} L2 block: {:?} with timestamp {:?}, L1 gas price {:?}, L2 fair gas price {:?} and protocol version: {:?}" ,
+            url, l1_batch_number, l1_block_hash_str, miniblock, block_details.base.timestamp, block_details.base.l1_gas_price, block_details.base.l2_fair_gas_price, block_details.protocol_version
         );
 
         if !block_details

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -1199,6 +1199,38 @@ mod tests {
         mock_server.expect(
             serde_json::json!({
                 "jsonrpc": "2.0",
+                "id": 2,
+                "method": "zks_getL1BatchDetails",
+                "params": [0]
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "result": {
+                    "number": 1,
+                    "timestamp": 1711649164,
+                    "l1TxCount": 1,
+                    "l2TxCount": 2363,
+                    "rootHash": "0x7b31ef880f09238f13b71a0f6bfea340b9c76d01bba0712af6aa0a4f224be167",
+                    "status": "verified",
+                    "commitTxHash": "0x5b2598bf1260d498c1c6a05326f7416ef2a602b8a1ac0f75b583cd6e08ae83cb",
+                    "committedAt": "2024-03-28T18:24:49.713730Z",
+                    "proveTxHash": "0xc02563331d0a83d634bc4190750e920fc26b57096ec72dd100af2ab037b43912",
+                    "provenAt": "2024-03-29T03:09:19.634524Z",
+                    "executeTxHash": "0xbe1ba1fdd17c2421cf2dabe2908fafa26ff4fa2190a7724d16295dd9df72b144",
+                    "executedAt": "2024-03-29T18:18:04.204270Z",
+                    "l1GasPrice": 47875552051u64,
+                    "l2FairGasPrice": 25000000,
+                    "baseSystemContractsHashes": {
+                        "bootloader": "0x010007ede999d096c84553fb514d3d6ca76fbf39789dda76bfeda9f3ae06236e",
+                        "default_aa": "0x0100055b041eb28aff6e3a6e0f37c31fd053fc9ef142683b05e5f0aee6934066"
+                    }
+                },
+               "id": 2
+            }),
+        );
+        mock_server.expect(
+            serde_json::json!({
+                "jsonrpc": "2.0",
                 "id": 0,
                 "method": "zks_getConfirmedTokens",
                 "params": [0, 100]
@@ -1220,7 +1252,7 @@ mod tests {
         mock_server.expect(
             serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": 2,
+                "id": 3,
                 "method": "zks_getFeeParams",
             }),
             serde_json::json!({
@@ -1239,7 +1271,7 @@ mod tests {
                   "l1_pubdata_price": 100780475095u64
                 }
               },
-              "id": 2
+              "id": 3
             }),
         );
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -150,6 +150,38 @@ impl MockServer {
             Expectation::matching(request::body(json_decoded(eq(serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 3,
+                "method": "zks_getL1BatchDetails",
+                "params": [1]
+            })))))
+            .respond_with(json_encoded(serde_json::json!({
+                "jsonrpc": "2.0",
+                "result": {
+                    "number": 1,
+                    "timestamp": 1711649164,
+                    "l1TxCount": 1,
+                    "l2TxCount": 2363,
+                    "rootHash": "0x7b31ef880f09238f13b71a0f6bfea340b9c76d01bba0712af6aa0a4f224be167",
+                    "status": "verified",
+                    "commitTxHash": "0x5b2598bf1260d498c1c6a05326f7416ef2a602b8a1ac0f75b583cd6e08ae83cb",
+                    "committedAt": "2024-03-28T18:24:49.713730Z",
+                    "proveTxHash": "0xc02563331d0a83d634bc4190750e920fc26b57096ec72dd100af2ab037b43912",
+                    "provenAt": "2024-03-29T03:09:19.634524Z",
+                    "executeTxHash": "0xbe1ba1fdd17c2421cf2dabe2908fafa26ff4fa2190a7724d16295dd9df72b144",
+                    "executedAt": "2024-03-29T18:18:04.204270Z",
+                    "l1GasPrice": 47875552051u64,
+                    "l2FairGasPrice": 25000000,
+                    "baseSystemContractsHashes": {
+                        "bootloader": "0x010007ede999d096c84553fb514d3d6ca76fbf39789dda76bfeda9f3ae06236e",
+                        "default_aa": "0x0100055b041eb28aff6e3a6e0f37c31fd053fc9ef142683b05e5f0aee6934066"
+                    }
+                },
+               "id": 3
+            }))),
+        );
+        server.expect(
+            Expectation::matching(request::body(json_decoded(eq(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 4,
                 "method": "zks_getFeeParams",
             })))))
             .respond_with(json_encoded(serde_json::json!(
@@ -169,7 +201,7 @@ impl MockServer {
                   "l1_pubdata_price": 100780475095u64
                 }
               },
-              "id": 3
+              "id": 4
             }))),
         );
 


### PR DESCRIPTION
# What :computer: 
Taking L1 block hash when forking, using it for the first test node transaction.

# Why :hand:
More realistic environment for transaction replay.

# Evidence :camera:
```
$ ./target/release/era_test_node --show-calls=user replay_tx sepolia-testnet 0x31c50670d48138491087678f8c7b688a47fd7a695e72dd19adcc6187887c3ff5
08:40:17  INFO Creating fork from "https://sepolia.era.zksync.dev:443" L1 block: L1BatchNumber(10732) (0xf3cf8ec637b05d7a618c16ada38dc4a054186b0e01608b69b6cc488f4013f060) L2 block: 3309677 with timestamp 1720483530, L1 gas price 8057661564, L2 fair gas price 25000000 and protocol version: Some(Version24)
```
