### PR TITLE
fix: Use actual replayed tx's  gas and pubdata prices to replay tx.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,6 +2987,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3779,7 +3820,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "multivm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "anyhow",
  "circuit_sequencer_api 0.1.0",
@@ -5972,6 +6013,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7420,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "vlog"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -8141,7 +8204,7 @@ dependencies = [
 [[package]]
 name = "zksync_basic_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8150,7 +8213,7 @@ dependencies = [
  "num_enum 0.7.2",
  "serde",
  "serde_json",
- "sqlx",
+ "serde_with",
  "strum 0.24.1",
  "thiserror",
  "tiny-keccak 2.0.2",
@@ -8160,7 +8223,7 @@ dependencies = [
 [[package]]
 name = "zksync_concurrency"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=92ecb2d5d65e3bc4a883dacd18d0640e86576c8c#92ecb2d5d65e3bc4a883dacd18d0640e86576c8c"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=3e6f101ee4124308c4c974caaa259d524549b0c6#3e6f101ee4124308c4c974caaa259d524549b0c6"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -8178,7 +8241,7 @@ dependencies = [
 [[package]]
 name = "zksync_config"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -8192,7 +8255,7 @@ dependencies = [
 [[package]]
 name = "zksync_consensus_crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=92ecb2d5d65e3bc4a883dacd18d0640e86576c8c#92ecb2d5d65e3bc4a883dacd18d0640e86576c8c"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=3e6f101ee4124308c4c974caaa259d524549b0c6#3e6f101ee4124308c4c974caaa259d524549b0c6"
 dependencies = [
  "anyhow",
  "blst",
@@ -8213,7 +8276,7 @@ dependencies = [
 [[package]]
 name = "zksync_consensus_roles"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=92ecb2d5d65e3bc4a883dacd18d0640e86576c8c#92ecb2d5d65e3bc4a883dacd18d0640e86576c8c"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=3e6f101ee4124308c4c974caaa259d524549b0c6#3e6f101ee4124308c4c974caaa259d524549b0c6"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -8234,7 +8297,7 @@ dependencies = [
 [[package]]
 name = "zksync_consensus_storage"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=92ecb2d5d65e3bc4a883dacd18d0640e86576c8c#92ecb2d5d65e3bc4a883dacd18d0640e86576c8c"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=3e6f101ee4124308c4c974caaa259d524549b0c6#3e6f101ee4124308c4c974caaa259d524549b0c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8252,7 +8315,7 @@ dependencies = [
 [[package]]
 name = "zksync_consensus_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=92ecb2d5d65e3bc4a883dacd18d0640e86576c8c#92ecb2d5d65e3bc4a883dacd18d0640e86576c8c"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=3e6f101ee4124308c4c974caaa259d524549b0c6#3e6f101ee4124308c4c974caaa259d524549b0c6"
 dependencies = [
  "rand 0.8.5",
  "thiserror",
@@ -8262,7 +8325,7 @@ dependencies = [
 [[package]]
 name = "zksync_contracts"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "envy",
  "ethabi 18.0.0",
@@ -8276,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "zksync_crypto"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
@@ -8290,7 +8353,7 @@ dependencies = [
 [[package]]
 name = "zksync_crypto_primitives"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "anyhow",
  "hex",
@@ -8306,7 +8369,7 @@ dependencies = [
 [[package]]
 name = "zksync_dal"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -8338,7 +8401,7 @@ dependencies = [
 [[package]]
 name = "zksync_db_connection"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -8356,7 +8419,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_client"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -8374,7 +8437,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_signer"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "async-trait",
  "rlp",
@@ -8385,7 +8448,7 @@ dependencies = [
 [[package]]
 name = "zksync_health_check"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "async-trait",
  "futures 0.3.30",
@@ -8400,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "zksync_mini_merkle_tree"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -8410,7 +8473,7 @@ dependencies = [
 [[package]]
 name = "zksync_node_fee_model"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8428,7 +8491,7 @@ dependencies = [
 [[package]]
 name = "zksync_protobuf"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=92ecb2d5d65e3bc4a883dacd18d0640e86576c8c#92ecb2d5d65e3bc4a883dacd18d0640e86576c8c"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=3e6f101ee4124308c4c974caaa259d524549b0c6#3e6f101ee4124308c4c974caaa259d524549b0c6"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -8448,7 +8511,7 @@ dependencies = [
 [[package]]
 name = "zksync_protobuf_build"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-consensus.git?rev=92ecb2d5d65e3bc4a883dacd18d0640e86576c8c#92ecb2d5d65e3bc4a883dacd18d0640e86576c8c"
+source = "git+https://github.com/matter-labs/era-consensus.git?rev=3e6f101ee4124308c4c974caaa259d524549b0c6#3e6f101ee4124308c4c974caaa259d524549b0c6"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -8464,8 +8527,10 @@ dependencies = [
 [[package]]
 name = "zksync_shared_metrics"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
+ "rustc_version",
+ "tracing",
  "vise",
  "zksync_dal",
  "zksync_types",
@@ -8474,7 +8539,7 @@ dependencies = [
 [[package]]
 name = "zksync_state"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8495,7 +8560,7 @@ dependencies = [
 [[package]]
 name = "zksync_storage"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "num_cpus",
  "once_cell",
@@ -8508,7 +8573,7 @@ dependencies = [
 [[package]]
 name = "zksync_system_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -8518,7 +8583,7 @@ dependencies = [
 [[package]]
 name = "zksync_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "anyhow",
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8550,7 +8615,7 @@ dependencies = [
 [[package]]
 name = "zksync_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -8558,8 +8623,10 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "num",
+ "once_cell",
  "reqwest",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",
@@ -8571,7 +8638,7 @@ dependencies = [
 [[package]]
 name = "zksync_web3_decl"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=e10bbdd1e863962552f37e768ae6af649353e4ea#e10bbdd1e863962552f37e768ae6af649353e4ea"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=0d51cd6f3e65eef1bda981fe96f3026d8e12156d#0d51cd6f3e65eef1bda981fe96f3026d8e12156d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,15 @@ publish = false                                           # We don't want to pub
 
 [dependencies]
 zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "v1.5.0" }
-zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e10bbdd1e863962552f37e768ae6af649353e4ea" }
-zksync_node_fee_model = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e10bbdd1e863962552f37e768ae6af649353e4ea" }
-multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e10bbdd1e863962552f37e768ae6af649353e4ea" }
-zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e10bbdd1e863962552f37e768ae6af649353e4ea" }
-zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e10bbdd1e863962552f37e768ae6af649353e4ea" }
-zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e10bbdd1e863962552f37e768ae6af649353e4ea" }
-zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e10bbdd1e863962552f37e768ae6af649353e4ea" }
-zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "e10bbdd1e863962552f37e768ae6af649353e4ea", features = [
+zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "0d51cd6f3e65eef1bda981fe96f3026d8e12156d" }
+zksync_node_fee_model = { git = "https://github.com/matter-labs/zksync-era.git", rev = "0d51cd6f3e65eef1bda981fe96f3026d8e12156d" }
+multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "0d51cd6f3e65eef1bda981fe96f3026d8e12156d" }
+zksync_contracts = { git = "https://github.com/matter-labs/zksync-era.git", rev = "0d51cd6f3e65eef1bda981fe96f3026d8e12156d" }
+zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "0d51cd6f3e65eef1bda981fe96f3026d8e12156d" }
+zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "0d51cd6f3e65eef1bda981fe96f3026d8e12156d" }
+zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", rev = "0d51cd6f3e65eef1bda981fe96f3026d8e12156d" }
+zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "0d51cd6f3e65eef1bda981fe96f3026d8e12156d", features = [
     "server",
-    "client",
 ] }
 sha3 = "0.10.6"
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -388,7 +388,7 @@ mod tests {
             execute: Execute {
                 calldata: Default::default(),
                 contract_address: Default::default(),
-                factory_deps: None,
+                factory_deps: vec![],
                 value: Default::default(),
             },
             received_timestamp_ms: 0,
@@ -453,7 +453,7 @@ mod tests {
             execute: Execute {
                 calldata: Default::default(),
                 contract_address: Default::default(),
-                factory_deps: None,
+                factory_deps: vec![],
                 value: Default::default(),
             },
             received_timestamp_ms: 0,
@@ -553,7 +553,7 @@ mod tests {
             execute: Execute {
                 calldata: Default::default(),
                 contract_address: Default::default(),
-                factory_deps: None,
+                factory_deps: vec![],
                 value: Default::default(),
             },
             received_timestamp_ms: 0,

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -646,22 +646,22 @@ impl ForkDetails {
     }
 
     pub fn get_block_gas_details(&self, miniblock: u32) -> Option<(u64, u64, u64)> {
-        let opt_block_details = self
-            .fork_source
-            .get_block_details(L2BlockNumber(miniblock))
-            .unwrap();
-
-        if let Some(block_details) = opt_block_details {
-            Some((
-                block_details.base.l1_gas_price,
-                block_details.base.l2_fair_gas_price,
-                block_details
-                    .base
-                    .fair_pubdata_price
-                    .expect("fair pubdata price is not present in block details"),
-            ))
-        } else {
-            None
+        let res_opt_block_details = self.fork_source.get_block_details(L2BlockNumber(miniblock));
+        match res_opt_block_details {
+            Ok(opt_block_details) => opt_block_details.map(|block_details| {
+                (
+                    block_details.base.l1_gas_price,
+                    block_details.base.l2_fair_gas_price,
+                    block_details
+                        .base
+                        .fair_pubdata_price
+                        .expect("fair pubdata price is not present in block details"),
+                )
+            }),
+            Err(e) => {
+                tracing::warn!("Error getting block details: {:?}", e);
+                None
+            }
         }
     }
 }

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -644,6 +644,26 @@ impl ForkDetails {
             replay_tx, miniblock
         );
     }
+
+    pub fn get_block_gas_details(&self, miniblock: u32) -> Option<(u64, u64, u64)> {
+        let opt_block_details = self
+            .fork_source
+            .get_block_details(L2BlockNumber(miniblock))
+            .unwrap();
+
+        if let Some(block_details) = opt_block_details {
+            Some((
+                block_details.base.l1_gas_price,
+                block_details.base.l2_fair_gas_price,
+                block_details
+                    .base
+                    .fair_pubdata_price
+                    .expect("fair pubdata price is not present in block details"),
+            ))
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -645,6 +645,13 @@ impl ForkDetails {
         );
     }
 
+    /// Returns
+    ///
+    /// - `l1_gas_price`
+    /// - `l2_fair_gas_price`
+    /// - `fair_pubdata_price`
+    ///
+    /// for the given l2 block.
     pub fn get_block_gas_details(&self, miniblock: u32) -> Option<(u64, u64, u64)> {
         let res_opt_block_details = self.fork_source.get_block_details(L2BlockNumber(miniblock));
         match res_opt_block_details {
@@ -652,10 +659,12 @@ impl ForkDetails {
                 (
                     block_details.base.l1_gas_price,
                     block_details.base.l2_fair_gas_price,
-                    block_details
-                        .base
-                        .fair_pubdata_price
-                        .expect("fair pubdata price is not present in block details"),
+                    block_details.base.fair_pubdata_price.unwrap_or_else(|| {
+                        panic!(
+                            "fair pubdata price is not present in {} l2 block details",
+                            miniblock
+                        )
+                    }),
                 )
             }),
             Err(e) => {

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -726,4 +726,30 @@ mod tests {
         fork_storage.set_value(key_with_value_0, H256::zero());
         assert!(!fork_storage.is_write_initial(&key_with_value_0));
     }
+
+    #[test]
+    fn test_get_block_gas_details() {
+        let fork_details = ForkDetails {
+            fork_source: Box::new(testing::ExternalStorage {
+                raw_storage: InMemoryStorage::default(),
+            }),
+            l1_block: L1BatchNumber(0),
+            l2_block: zksync_types::api::Block::<TransactionVariant>::default(),
+            l2_miniblock: 0,
+            l2_miniblock_hash: H256::zero(),
+            block_timestamp: 0,
+            overwrite_chain_id: None,
+            l1_gas_price: 0,
+            l2_fair_gas_price: 0,
+            estimate_gas_price_scale_factor: 0.0,
+            estimate_gas_scale_factor: 0.0,
+            fee_params: None,
+            cache_config: CacheConfig::None,
+        };
+
+        let actual_result = fork_details.get_block_gas_details(1);
+        let expected_result = Some((123, 234, 345));
+
+        assert_eq!(actual_result, expected_result);
+    }
 }

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -288,7 +288,7 @@ impl ForkSource for HttpForkSource {
     ) -> eyre::Result<Option<zksync_types::api::BlockDetails>> {
         let client = self.create_client();
         block_on(async move { client.get_block_details(miniblock).await })
-            .wrap_err("fork http client failed")
+            .wrap_err_with(|| format!("Failed to get block details for {} l2 block", miniblock))
     }
 
     /// Returns fee parameters for the give source.

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -288,7 +288,7 @@ impl ForkSource for HttpForkSource {
     ) -> eyre::Result<Option<zksync_types::api::BlockDetails>> {
         let client = self.create_client();
         block_on(async move { client.get_block_details(miniblock).await })
-            .wrap_err_with(|| format!("Failed to get block details for {} l2 block", miniblock))
+            .wrap_err(format!("Failed to get block details for {} l2 block", miniblock))
     }
 
     /// Returns fee parameters for the give source.

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -679,12 +679,13 @@ mod tests {
                   "executedAt": null,
                   "l1GasPrice": 6156252068u64,
                   "l2FairGasPrice": 50000000u64,
+                  "fairPubdataPrice": 100u64,
                   "baseSystemContractsHashes": {
                     "bootloader": "0x0100089b8a2f2e6a20ba28f02c9e0ed0c13d702932364561a0ea61621f65f0a8",
                     "default_aa": "0x0100067d16a5485875b4249040bf421f53e869337fe118ec747cf40a4c777e5f"
                   },
                   "operatorAddress": "0xa9232040bf0e0aea2578a5b2243f2916dbfc0a69",
-                  "protocolVersion": "Version15"
+                  "protocolVersion": "Version15",
                 },
                 "id": 0
               }),

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -287,8 +287,10 @@ impl ForkSource for HttpForkSource {
         miniblock: zksync_basic_types::L2BlockNumber,
     ) -> eyre::Result<Option<zksync_types::api::BlockDetails>> {
         let client = self.create_client();
-        block_on(async move { client.get_block_details(miniblock).await })
-            .wrap_err(format!("Failed to get block details for {} l2 block", miniblock))
+        block_on(async move { client.get_block_details(miniblock).await }).wrap_err(format!(
+            "Failed to get block details for {} l2 block in fork http client",
+            miniblock
+        ))
     }
 
     /// Returns fee parameters for the give source.

--- a/src/node/eth.rs
+++ b/src/node/eth.rs
@@ -1400,7 +1400,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> EthTestNod
                     "Failed to acquire read lock for chain ID retrieval.".to_string(),
                 ))
                 .boxed()
-            }   
+            }
         };
 
         let mut tx_req = TransactionRequest::from(tx.clone());

--- a/src/node/eth.rs
+++ b/src/node/eth.rs
@@ -2862,8 +2862,13 @@ mod tests {
             actual_snapshot.current_miniblock_hash
         );
         assert_eq!(
-            expected_snapshot.fee_input_provider,
-            actual_snapshot.fee_input_provider
+            expected_snapshot
+                .fee_input_provider
+                .0
+                .read()
+                .unwrap()
+                .clone(),
+            actual_snapshot.fee_input_provider.0.read().unwrap().clone()
         );
         assert_eq!(
             expected_snapshot.tx_results.keys().collect_vec(),
@@ -2997,9 +3002,15 @@ mod tests {
             expected_snapshot.current_miniblock_hash,
             inner.current_miniblock_hash
         );
+
         assert_eq!(
-            expected_snapshot.fee_input_provider,
-            inner.fee_input_provider
+            expected_snapshot
+                .fee_input_provider
+                .0
+                .read()
+                .unwrap()
+                .clone(),
+            inner.fee_input_provider.0.read().unwrap().clone()
         );
         assert_eq!(
             expected_snapshot.tx_results.keys().collect_vec(),

--- a/src/node/fee_model.rs
+++ b/src/node/fee_model.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::sync::{Arc, RwLock};
 use zksync_node_fee_model::BatchFeeModelInputProvider;
 use zksync_types::fee_model::{FeeModelConfigV2, FeeParams, FeeParamsV2};
 use zksync_types::L1_GAS_PER_PUBDATA_BYTE;
@@ -9,8 +10,8 @@ use crate::config::gas::{
 };
 use crate::utils::to_human_size;
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct TestNodeFeeInputProvider {
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct TestNodeFeeInputProviderInner {
     pub l1_gas_price: u64,
     pub l1_pubdata_price: u64,
     pub l2_gas_price: u64,
@@ -25,15 +26,18 @@ pub struct TestNodeFeeInputProvider {
     pub estimate_gas_scale_factor: f32,
 }
 
+#[derive(Debug, Clone)]
+pub struct TestNodeFeeInputProvider(pub Arc<RwLock<TestNodeFeeInputProviderInner>>);
+
 impl TestNodeFeeInputProvider {
     pub fn from_fee_params_and_estimate_scale_factors(
         fee_params: FeeParams,
         estimate_gas_price_scale_factor: f64,
         estimate_gas_scale_factor: f32,
     ) -> Self {
-        match fee_params {
+        let inner = match fee_params {
             FeeParams::V1(_) => todo!(),
-            FeeParams::V2(fee_params) => Self {
+            FeeParams::V2(fee_params) => TestNodeFeeInputProviderInner {
                 l1_gas_price: fee_params.l1_gas_price,
                 l1_pubdata_price: fee_params.l1_pubdata_price,
                 l2_gas_price: fee_params.config.minimal_l2_gas_price,
@@ -45,80 +49,114 @@ impl TestNodeFeeInputProvider {
                 estimate_gas_price_scale_factor,
                 estimate_gas_scale_factor,
             },
-        }
+        };
+        Self(Arc::new(RwLock::new(inner)))
     }
 
     pub fn from_estimate_scale_factors(
         estimate_gas_price_scale_factor: f64,
         estimate_gas_scale_factor: f32,
     ) -> Self {
-        Self {
+        let inner = TestNodeFeeInputProviderInner {
             estimate_gas_price_scale_factor,
             estimate_gas_scale_factor,
             ..Default::default()
-        }
+        };
+
+        Self(Arc::new(RwLock::new(inner)))
     }
 
-    pub fn with_overrides(mut self, gas_config: Option<GasConfig>) -> Self {
+    pub fn with_overrides(&self, gas_config: Option<GasConfig>) -> Self {
         let Some(gas_config) = gas_config else {
-            return self;
+            return self.clone();
         };
+
+        let mut inner = self.0.write().unwrap();
 
         if let Some(l1_gas_price) = gas_config.l1_gas_price {
             tracing::info!(
                 "L1 gas price set to {} (overridden from {})",
                 to_human_size(l1_gas_price.into()),
-                to_human_size(self.l1_gas_price.into())
+                to_human_size(inner.l1_gas_price.into())
             );
-            self.l1_gas_price = l1_gas_price;
+            inner.l1_gas_price = l1_gas_price;
         }
         if let Some(l2_gas_price) = gas_config.l2_gas_price {
             tracing::info!(
                 "L2 gas price set to {} (overridden from {})",
                 to_human_size(l2_gas_price.into()),
-                to_human_size(self.l2_gas_price.into())
+                to_human_size(inner.l2_gas_price.into())
             );
-            self.l2_gas_price = l2_gas_price;
+            inner.l2_gas_price = l2_gas_price;
         }
 
         if let Some(estimation) = gas_config.estimation {
             if let Some(factor) = estimation.price_scale_factor {
-                self.estimate_gas_price_scale_factor = factor;
+                inner.estimate_gas_price_scale_factor = factor;
             }
             if let Some(factor) = estimation.limit_scale_factor {
-                self.estimate_gas_scale_factor = factor;
+                inner.estimate_gas_scale_factor = factor;
             }
         }
 
-        self
+        self.clone()
     }
 
     pub fn get_fee_model_config(&self) -> FeeModelConfigV2 {
+        let inner = self.0.read().unwrap();
+
         FeeModelConfigV2 {
-            minimal_l2_gas_price: self.l2_gas_price,
-            compute_overhead_part: self.compute_overhead_part,
-            pubdata_overhead_part: self.pubdata_overhead_part,
-            batch_overhead_l1_gas: self.batch_overhead_l1_gas,
-            max_gas_per_batch: self.max_gas_per_batch,
-            max_pubdata_per_batch: self.max_pubdata_per_batch,
+            minimal_l2_gas_price: inner.l2_gas_price,
+            compute_overhead_part: inner.compute_overhead_part,
+            pubdata_overhead_part: inner.pubdata_overhead_part,
+            batch_overhead_l1_gas: inner.batch_overhead_l1_gas,
+            max_gas_per_batch: inner.max_gas_per_batch,
+            max_pubdata_per_batch: inner.max_pubdata_per_batch,
         }
+    }
+
+    pub fn get_l2_gas_price(&self) -> u64 {
+        let inner = self.0.read().unwrap();
+        inner.l2_gas_price
+    }
+
+    pub fn get_l1_gas_price(&self) -> u64 {
+        let inner = self.0.read().unwrap();
+        inner.l1_gas_price
+    }
+
+    pub fn get_l1_pubdata_price(&self) -> u64 {
+        let inner = self.0.read().unwrap();
+        inner.l1_pubdata_price
+    }
+
+    pub fn get_estimate_gas_price_scale_factor(&self) -> f64 {
+        let inner = self.0.read().unwrap();
+        inner.estimate_gas_price_scale_factor
+    }
+
+    pub fn get_estimate_gas_scale_factor(&self) -> f32 {
+        let inner = self.0.read().unwrap();
+        inner.estimate_gas_scale_factor
     }
 }
 
 impl BatchFeeModelInputProvider for TestNodeFeeInputProvider {
     fn get_fee_model_params(&self) -> FeeParams {
+        let inner = self.0.read().unwrap();
+
         // TODO: consider using old fee model for the olds blocks, when forking
         FeeParams::V2(FeeParamsV2 {
             config: self.get_fee_model_config(),
-            l1_gas_price: self.l1_gas_price,
-            l1_pubdata_price: self.l1_pubdata_price,
+            l1_gas_price: inner.l1_gas_price,
+            l1_pubdata_price: inner.l1_pubdata_price,
         })
     }
 }
 
 impl Default for TestNodeFeeInputProvider {
     fn default() -> Self {
-        Self {
+        let inner = TestNodeFeeInputProviderInner {
             l1_gas_price: DEFAULT_L1_GAS_PRICE,
             l1_pubdata_price: DEFAULT_L1_GAS_PRICE * L1_GAS_PER_PUBDATA_BYTE as u64,
             l2_gas_price: DEFAULT_L2_GAS_PRICE,
@@ -129,6 +167,8 @@ impl Default for TestNodeFeeInputProvider {
             max_pubdata_per_batch: 100000,
             estimate_gas_price_scale_factor: DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
             estimate_gas_scale_factor: DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
-        }
+        };
+
+        Self(Arc::new(RwLock::new(inner)))
     }
 }

--- a/src/node/fee_model.rs
+++ b/src/node/fee_model.rs
@@ -1,5 +1,4 @@
 use std::fmt::Debug;
-use std::sync::{Arc, RwLock};
 use zksync_node_fee_model::BatchFeeModelInputProvider;
 use zksync_types::fee_model::{FeeModelConfigV2, FeeParams, FeeParamsV2};
 use zksync_types::L1_GAS_PER_PUBDATA_BYTE;
@@ -10,8 +9,8 @@ use crate::config::gas::{
 };
 use crate::utils::to_human_size;
 
-#[derive(Debug, Clone, PartialEq, Default)]
-pub struct TestNodeFeeInputProviderInner {
+#[derive(Debug, Clone, PartialEq)]
+pub struct TestNodeFeeInputProvider {
     pub l1_gas_price: u64,
     pub l1_pubdata_price: u64,
     pub l2_gas_price: u64,
@@ -26,18 +25,15 @@ pub struct TestNodeFeeInputProviderInner {
     pub estimate_gas_scale_factor: f32,
 }
 
-#[derive(Debug, Clone)]
-pub struct TestNodeFeeInputProvider(pub Arc<RwLock<TestNodeFeeInputProviderInner>>);
-
 impl TestNodeFeeInputProvider {
     pub fn from_fee_params_and_estimate_scale_factors(
         fee_params: FeeParams,
         estimate_gas_price_scale_factor: f64,
         estimate_gas_scale_factor: f32,
     ) -> Self {
-        let inner = match fee_params {
+        match fee_params {
             FeeParams::V1(_) => todo!(),
-            FeeParams::V2(fee_params) => TestNodeFeeInputProviderInner {
+            FeeParams::V2(fee_params) => Self {
                 l1_gas_price: fee_params.l1_gas_price,
                 l1_pubdata_price: fee_params.l1_pubdata_price,
                 l2_gas_price: fee_params.config.minimal_l2_gas_price,
@@ -49,114 +45,80 @@ impl TestNodeFeeInputProvider {
                 estimate_gas_price_scale_factor,
                 estimate_gas_scale_factor,
             },
-        };
-        Self(Arc::new(RwLock::new(inner)))
+        }
     }
 
     pub fn from_estimate_scale_factors(
         estimate_gas_price_scale_factor: f64,
         estimate_gas_scale_factor: f32,
     ) -> Self {
-        let inner = TestNodeFeeInputProviderInner {
+        Self {
             estimate_gas_price_scale_factor,
             estimate_gas_scale_factor,
             ..Default::default()
-        };
-
-        Self(Arc::new(RwLock::new(inner)))
+        }
     }
 
-    pub fn with_overrides(&self, gas_config: Option<GasConfig>) -> Self {
+    pub fn with_overrides(mut self, gas_config: Option<GasConfig>) -> Self {
         let Some(gas_config) = gas_config else {
-            return self.clone();
+            return self;
         };
-
-        let mut inner = self.0.write().unwrap();
 
         if let Some(l1_gas_price) = gas_config.l1_gas_price {
             tracing::info!(
                 "L1 gas price set to {} (overridden from {})",
                 to_human_size(l1_gas_price.into()),
-                to_human_size(inner.l1_gas_price.into())
+                to_human_size(self.l1_gas_price.into())
             );
-            inner.l1_gas_price = l1_gas_price;
+            self.l1_gas_price = l1_gas_price;
         }
         if let Some(l2_gas_price) = gas_config.l2_gas_price {
             tracing::info!(
                 "L2 gas price set to {} (overridden from {})",
                 to_human_size(l2_gas_price.into()),
-                to_human_size(inner.l2_gas_price.into())
+                to_human_size(self.l2_gas_price.into())
             );
-            inner.l2_gas_price = l2_gas_price;
+            self.l2_gas_price = l2_gas_price;
         }
 
         if let Some(estimation) = gas_config.estimation {
             if let Some(factor) = estimation.price_scale_factor {
-                inner.estimate_gas_price_scale_factor = factor;
+                self.estimate_gas_price_scale_factor = factor;
             }
             if let Some(factor) = estimation.limit_scale_factor {
-                inner.estimate_gas_scale_factor = factor;
+                self.estimate_gas_scale_factor = factor;
             }
         }
 
-        self.clone()
+        self
     }
 
     pub fn get_fee_model_config(&self) -> FeeModelConfigV2 {
-        let inner = self.0.read().unwrap();
-
         FeeModelConfigV2 {
-            minimal_l2_gas_price: inner.l2_gas_price,
-            compute_overhead_part: inner.compute_overhead_part,
-            pubdata_overhead_part: inner.pubdata_overhead_part,
-            batch_overhead_l1_gas: inner.batch_overhead_l1_gas,
-            max_gas_per_batch: inner.max_gas_per_batch,
-            max_pubdata_per_batch: inner.max_pubdata_per_batch,
+            minimal_l2_gas_price: self.l2_gas_price,
+            compute_overhead_part: self.compute_overhead_part,
+            pubdata_overhead_part: self.pubdata_overhead_part,
+            batch_overhead_l1_gas: self.batch_overhead_l1_gas,
+            max_gas_per_batch: self.max_gas_per_batch,
+            max_pubdata_per_batch: self.max_pubdata_per_batch,
         }
-    }
-
-    pub fn get_l2_gas_price(&self) -> u64 {
-        let inner = self.0.read().unwrap();
-        inner.l2_gas_price
-    }
-
-    pub fn get_l1_gas_price(&self) -> u64 {
-        let inner = self.0.read().unwrap();
-        inner.l1_gas_price
-    }
-
-    pub fn get_l1_pubdata_price(&self) -> u64 {
-        let inner = self.0.read().unwrap();
-        inner.l1_pubdata_price
-    }
-
-    pub fn get_estimate_gas_price_scale_factor(&self) -> f64 {
-        let inner = self.0.read().unwrap();
-        inner.estimate_gas_price_scale_factor
-    }
-
-    pub fn get_estimate_gas_scale_factor(&self) -> f32 {
-        let inner = self.0.read().unwrap();
-        inner.estimate_gas_scale_factor
     }
 }
 
 impl BatchFeeModelInputProvider for TestNodeFeeInputProvider {
     fn get_fee_model_params(&self) -> FeeParams {
-        let inner = self.0.read().unwrap();
-
         // TODO: consider using old fee model for the olds blocks, when forking
         FeeParams::V2(FeeParamsV2 {
             config: self.get_fee_model_config(),
-            l1_gas_price: inner.l1_gas_price,
-            l1_pubdata_price: inner.l1_pubdata_price,
+            l1_gas_price: self.l1_gas_price,
+            l1_pubdata_price: self.l1_pubdata_price,
         })
     }
 }
 
 impl Default for TestNodeFeeInputProvider {
     fn default() -> Self {
-        let inner = TestNodeFeeInputProviderInner {
+        Self {
             l1_gas_price: DEFAULT_L1_GAS_PRICE,
             l1_pubdata_price: DEFAULT_L1_GAS_PRICE * L1_GAS_PER_PUBDATA_BYTE as u64,
             l2_gas_price: DEFAULT_L2_GAS_PRICE,
@@ -167,8 +129,6 @@ impl Default for TestNodeFeeInputProvider {
             max_pubdata_per_batch: 100000,
             estimate_gas_price_scale_factor: DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
             estimate_gas_scale_factor: DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
-        };
-
-        Self(Arc::new(RwLock::new(inner)))
+        }
     }
 }

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -51,10 +51,10 @@ use zksync_basic_types::{
     U256, U64,
 };
 use zksync_contracts::BaseSystemContracts;
-use zksync_node_fee_model::{l1_gas_price, BatchFeeModelInputProvider};
+use zksync_node_fee_model::BatchFeeModelInputProvider;
 use zksync_state::{ReadStorage, StoragePtr, WriteStorage};
 use zksync_types::{
-    api::{Block, BlockDetails, DebugCall, Log, TransactionReceipt, TransactionVariant},
+    api::{Block, DebugCall, Log, TransactionReceipt, TransactionVariant},
     block::{unpack_block_info, L2BlockHasher},
     fee::Fee,
     get_nonce_key,
@@ -324,7 +324,7 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
                 fork.get_block_gas_details(block_ctx.miniblock as u32)
                     .unwrap()
             };
-            
+
             {
                 let mut fee_input_provider = self.fee_input_provider.0.write().unwrap();
 

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1933,7 +1933,7 @@ mod tests {
             U256::from(0),
             zksync_basic_types::L2ChainId::from(260),
             &private_key,
-            None,
+            vec![],
             Default::default(),
         )
         .expect("failed signing tx");

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -57,6 +57,7 @@ use zksync_types::{
     api::{Block, DebugCall, Log, TransactionReceipt, TransactionVariant},
     block::{unpack_block_info, L2BlockHasher},
     fee::Fee,
+    fee_model::{BatchFeeInput, PubdataIndependentBatchFeeModelInput},
     get_nonce_key,
     l2::L2Tx,
     l2::TransactionType,
@@ -306,6 +307,8 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
         )
         .new_batch();
 
+        let fee_input: BatchFeeInput;
+
         if let Some(fork) = &self
             .fork_storage
             .inner
@@ -320,27 +323,25 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
                 block_ctx.batch
             );
 
-            let (l1_gas_price, l2_fair_gas_price, fair_pubdata_price) = {
+            let (l1_gas_price, fair_l2_gas_price, fair_pubdata_price) = {
                 fork.get_block_gas_details(block_ctx.miniblock as u32)
                     .unwrap()
             };
 
-            {
-                let mut fee_input_provider = self.fee_input_provider.0.write().unwrap();
-
-                fee_input_provider.l1_gas_price = l1_gas_price;
-                fee_input_provider.l2_gas_price = l2_fair_gas_price;
-                fee_input_provider.l1_pubdata_price = fair_pubdata_price;
-            }
+            fee_input = BatchFeeInput::PubdataIndependent(PubdataIndependentBatchFeeModelInput {
+                fair_l2_gas_price,
+                fair_pubdata_price,
+                l1_gas_price,
+            });
+        } else {
+            let fee_input_provider = self.fee_input_provider.clone();
+            fee_input = block_on(async move {
+                fee_input_provider
+                    .get_batch_fee_input_scaled(1.0, 1.0)
+                    .await
+                    .unwrap()
+            });
         }
-
-        let fee_input_provider = self.fee_input_provider.clone();
-        let fee_input = block_on(async move {
-            fee_input_provider
-                .get_batch_fee_input_scaled(1.0, 1.0)
-                .await
-                .unwrap()
-        });
 
         let batch_env = L1BatchEnv {
             // TODO: set the previous batch hash properly (take from fork, when forking, and from local storage, when this is not the first block).
@@ -429,8 +430,8 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
             let fee_input = block_on(async move {
                 fee_input_provider
                     .get_batch_fee_input_scaled(
-                        fee_input_provider.get_estimate_gas_price_scale_factor(),
-                        fee_input_provider.get_estimate_gas_price_scale_factor(),
+                        fee_input_provider.estimate_gas_price_scale_factor,
+                        fee_input_provider.estimate_gas_price_scale_factor,
                     )
                     .await
                     .unwrap()
@@ -560,12 +561,12 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
         tracing::trace!("  Final upper_bound: {}", upper_bound);
         tracing::trace!(
             "  ESTIMATE_GAS_SCALE_FACTOR: {}",
-            self.fee_input_provider.get_estimate_gas_scale_factor()
+            self.fee_input_provider.estimate_gas_scale_factor
         );
         tracing::trace!("  MAX_L2_TX_GAS_LIMIT: {}", MAX_L2_TX_GAS_LIMIT);
         let tx_body_gas_limit = upper_bound;
         let suggested_gas_limit = ((upper_bound + additional_gas_for_pubdata) as f32
-            * self.fee_input_provider.get_estimate_gas_scale_factor())
+            * self.fee_input_provider.estimate_gas_scale_factor)
             as u64;
 
         let estimate_gas_result = InMemoryNodeInner::estimate_gas_step(
@@ -938,11 +939,11 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
 
         let fee_input_provider = &inner.fee_input_provider;
         Ok(GasConfig {
-            l1_gas_price: Some(fee_input_provider.get_l1_gas_price()),
-            l2_gas_price: Some(fee_input_provider.get_l2_gas_price()),
+            l1_gas_price: Some(fee_input_provider.l1_gas_price),
+            l2_gas_price: Some(fee_input_provider.l2_gas_price),
             estimation: Some(gas::Estimation {
-                price_scale_factor: Some(fee_input_provider.get_estimate_gas_price_scale_factor()),
-                limit_scale_factor: Some(fee_input_provider.get_estimate_gas_scale_factor()),
+                price_scale_factor: Some(fee_input_provider.estimate_gas_price_scale_factor),
+                limit_scale_factor: Some(fee_input_provider.estimate_gas_scale_factor),
             }),
         })
     }
@@ -1262,7 +1263,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             .read()
             .expect("failed acquiring reader")
             .fee_input_provider
-            .get_l2_gas_price();
+            .l2_gas_price;
         if tx.common_data.fee.max_fee_per_gas < l2_gas_price.into() {
             tracing::info!(
                 "Submitted Tx is Unexecutable {:?} because of MaxFeePerGasTooLow {}",
@@ -1612,7 +1613,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             } else {
                 U64::from(1)
             },
-            effective_gas_price: Some(inner.fee_input_provider.get_l2_gas_price().into()),
+            effective_gas_price: Some(inner.fee_input_provider.l2_gas_price.into()),
             transaction_type: Some((transaction_type as u32).into()),
             logs_bloom: Default::default(),
         };

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -537,7 +537,7 @@ mod tests {
             },
             to_impersonate,
             U256::one(),
-            None,
+            vec![],
             Default::default(),
         );
         tx.set_input(vec![], H256::random());

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -804,6 +804,7 @@ mod tests {
                   "executedAt": null,
                   "l1GasPrice": 6156252068u64,
                   "l2FairGasPrice": 50000000u64,
+                  "fairPubdataPrice": 100u64,
                   "baseSystemContractsHashes": {
                     "bootloader": "0x0100089b8a2f2e6a20ba28f02c9e0ed0c13d702932364561a0ea61621f65f0a8",
                     "default_aa": "0x0100067d16a5485875b4249040bf421f53e869337fe118ec747cf40a4c777e5f"

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -386,7 +386,8 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> ZksNamespa
                         execute_tx_hash: None,
                         executed_at: None,
                         l1_gas_price: 0,
-                        l2_fair_gas_price: reader.fee_input_provider.l2_gas_price,
+                        l2_fair_gas_price: reader.fee_input_provider.get_l2_gas_price(),
+                        fair_pubdata_price: Some(reader.fee_input_provider.get_l1_pubdata_price()),
                         base_system_contracts_hashes: reader
                             .system_contracts
                             .baseline_contracts

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -832,6 +832,7 @@ mod tests {
         assert!(matches!(result.number, L2BlockNumber(16474138)));
         assert_eq!(result.l1_batch_number, L1BatchNumber(270435));
         assert_eq!(result.base.timestamp, 1697405098);
+        assert_eq!(result.base.fair_pubdata_price, Some(100));
     }
 
     #[tokio::test]

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -386,8 +386,8 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> ZksNamespa
                         execute_tx_hash: None,
                         executed_at: None,
                         l1_gas_price: 0,
-                        l2_fair_gas_price: reader.fee_input_provider.get_l2_gas_price(),
-                        fair_pubdata_price: Some(reader.fee_input_provider.get_l1_pubdata_price()),
+                        l2_fair_gas_price: reader.fee_input_provider.l2_gas_price,
+                        fair_pubdata_price: Some(reader.fee_input_provider.l1_pubdata_price),
                         base_system_contracts_hashes: reader
                             .system_contracts
                             .baseline_contracts

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -446,7 +446,7 @@ impl TransactionBuilder {
             U256::from(1),
             L2ChainId::from(260),
             &self.from_account_private_key,
-            None,
+            vec![],
             Default::default(),
         )
         .unwrap();
@@ -547,7 +547,7 @@ pub fn deploy_contract<T: ForkSource + std::fmt::Debug + Clone>(
         U256::from(0),
         zksync_basic_types::L2ChainId::from(260),
         private_key,
-        Some(vec![bytecode]),
+        vec![bytecode],
         Default::default(),
     )
     .expect("failed signing tx");

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -20,8 +20,10 @@ use httptest::{
 use itertools::Itertools;
 use multivm::interface::{ExecutionResult, VmExecutionResultAndLogs};
 use std::str::FromStr;
-use zksync_basic_types::{AccountTreeId, L2BlockNumber, H160, U64};
-use zksync_types::api::{BlockIdVariant, BridgeAddresses, DebugCall, DebugCallType, Log};
+use zksync_basic_types::{AccountTreeId, L1BatchNumber, L2BlockNumber, H160, U64};
+use zksync_types::api::{
+    BlockDetailsBase, BlockIdVariant, BlockStatus, BridgeAddresses, DebugCall, DebugCallType, Log,
+};
 use zksync_types::block::pack_block_info;
 use zksync_types::{fee::Fee, l2::L2Tx, Address, L2ChainId, Nonce, ProtocolVersionId, H256, U256};
 use zksync_types::{K256PrivateKey, StorageKey};
@@ -793,9 +795,31 @@ impl ForkSource for ExternalStorage {
 
     fn get_block_details(
         &self,
-        _miniblock: L2BlockNumber,
+        miniblock: L2BlockNumber,
     ) -> eyre::Result<Option<zksync_types::api::BlockDetails>> {
-        todo!()
+        Ok(Some(zksync_types::api::BlockDetails {
+            number: miniblock,
+            l1_batch_number: L1BatchNumber(123),
+            base: BlockDetailsBase {
+                timestamp: 0,
+                l1_tx_count: 0,
+                l2_tx_count: 0,
+                root_hash: None,
+                status: BlockStatus::Sealed,
+                commit_tx_hash: None,
+                committed_at: None,
+                prove_tx_hash: None,
+                proven_at: None,
+                execute_tx_hash: None,
+                executed_at: None,
+                l1_gas_price: 123,
+                l2_fair_gas_price: 234,
+                fair_pubdata_price: Some(345),
+                base_system_contracts_hashes: Default::default(),
+            },
+            operator_address: H160::zero(),
+            protocol_version: None,
+        }))
     }
 
     fn get_fee_params(&self) -> eyre::Result<zksync_types::fee_model::FeeParams> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -265,7 +265,9 @@ pub fn report_into_jsrpc_error(error: eyre::Report) -> Error {
 pub fn into_jsrpc_error(err: Web3Error) -> Error {
     Error {
         code: match err {
-            Web3Error::InternalError(_) | Web3Error::NotImplemented => ErrorCode::InternalError,
+            Web3Error::InternalError(_) | Web3Error::MethodNotImplemented => {
+                ErrorCode::InternalError
+            }
             Web3Error::NoBlock
             | Web3Error::PrunedBlock(_)
             | Web3Error::PrunedL1Batch(_)


### PR DESCRIPTION
# What :computer: 
+ bump `zksync era` dependencies version
+ new get_block_gas_details in `fork.rs` to extract l1 batch gas info.
+ modify `create_l1_batch_env` to construct `BatchFeeInput` from values taken from l1 batch details, if memory node is running in fork mode.

# Why :hand:
Context: successful txs from fork fails while replaying them with node. 
This is caused by wrong gas/fee values stored in `fee_input_provider` that are used to calculate tx cost.
