### PR TITLE
fix: changed evm_setNextBlockTimestamp argument type

### DIFF
--- a/src/namespaces/evm.rs
+++ b/src/namespaces/evm.rs
@@ -32,7 +32,7 @@ pub trait EvmNamespaceT {
     /// # Returns
     /// The new timestamp value for the InMemoryNodeInner.
     #[rpc(name = "evm_setNextBlockTimestamp")]
-    fn set_next_block_timestamp(&self, timestamp: u64) -> RpcResult<u64>;
+    fn set_next_block_timestamp(&self, timestamp: U64) -> RpcResult<U64>;
 
     /// Set the current timestamp for the node.
     /// Warning: This will allow you to move backwards in time, which may cause new blocks to appear to be

--- a/src/node/evm.rs
+++ b/src/node/evm.rs
@@ -29,7 +29,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> EvmNamespa
             .into_boxed_future()
     }
 
-    fn set_next_block_timestamp(&self, timestamp: u64) -> RpcResult<u64> {
+    fn set_next_block_timestamp(&self, timestamp: U64) -> RpcResult<U64> {
         self.set_next_block_timestamp(timestamp)
             .map_err(|err| {
                 tracing::error!("failed setting time for next timestamp: {:?}", err);

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -50,19 +50,20 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
     ///
     /// # Returns
     /// The new timestamp value for the InMemoryNodeInner.
-    pub fn set_next_block_timestamp(&self, timestamp: u64) -> Result<u64> {
+    pub fn set_next_block_timestamp(&self, timestamp: U64) -> Result<U64> {
         self.get_inner()
             .write()
             .map_err(|err| anyhow!("failed acquiring lock: {:?}", err))
             .and_then(|mut writer| {
-                if timestamp < writer.current_timestamp {
+                let ts = timestamp.as_u64();
+                if ts < writer.current_timestamp {
                     Err(anyhow!(
                         "timestamp ({}) must be greater than current timestamp ({})",
-                        timestamp,
+                        ts,
                         writer.current_timestamp
                     ))
                 } else {
-                    writer.current_timestamp = timestamp;
+                    writer.current_timestamp = ts;
                     Ok(timestamp)
                 }
             })
@@ -742,7 +743,7 @@ mod tests {
         let expected_response = new_timestamp;
 
         let actual_response = node
-            .set_next_block_timestamp(new_timestamp)
+            .set_next_block_timestamp(new_timestamp.into())
             .expect("failed setting timestamp");
         let timestamp_after = node
             .get_inner()
@@ -750,7 +751,11 @@ mod tests {
             .map(|inner| inner.current_timestamp)
             .expect("failed reading timestamp");
 
-        assert_eq!(expected_response, actual_response, "erroneous response");
+        assert_eq!(
+            expected_response,
+            actual_response.as_u64(),
+            "erroneous response"
+        );
         assert_eq!(
             new_timestamp, timestamp_after,
             "timestamp was not set correctly",
@@ -768,10 +773,10 @@ mod tests {
             .expect("failed reading timestamp");
 
         let new_timestamp = timestamp_before + 500;
-        node.set_next_block_timestamp(new_timestamp)
+        node.set_next_block_timestamp(new_timestamp.into())
             .expect("failed setting timestamp");
 
-        let result = node.set_next_block_timestamp(timestamp_before);
+        let result = node.set_next_block_timestamp(timestamp_before.into());
 
         assert!(result.is_err(), "expected an error for timestamp in past");
     }
@@ -790,7 +795,7 @@ mod tests {
         let expected_response = new_timestamp;
 
         let actual_response = node
-            .set_next_block_timestamp(new_timestamp)
+            .set_next_block_timestamp(new_timestamp.into())
             .expect("failed setting timestamp");
         let timestamp_after = node
             .get_inner()
@@ -798,7 +803,11 @@ mod tests {
             .map(|inner| inner.current_timestamp)
             .expect("failed reading timestamp");
 
-        assert_eq!(expected_response, actual_response, "erroneous response");
+        assert_eq!(
+            expected_response,
+            actual_response.as_u64(),
+            "erroneous response"
+        );
         assert_eq!(
             timestamp_before, timestamp_after,
             "timestamp must not change",


### PR DESCRIPTION
# What :computer: 
Changed `evm_setNextBlockTimestamp` argument and return type to U64.

# Why :hand:
Running a hardhat e2e test of `evm_setNextBlockTimestamp` against Era Test Node fails, apparently due to type mismatch. The return type is also changed because it holds the same value.

# Evidence :camera:
Before:
```
$ mocha test/helpers/time/setNextBlockTimestamp.ts 


  time#setNextBlockTimestamp
    simple project
      1) should not mine a new block
      2) should set the next block to the given timestamp [epoch seconds]
      3) should set the next block to the given timestamp [Date]
      ✔ should throw if given a timestamp that is equal to the current block timestamp
      ✔ should throw if given a timestamp that is less than the current block timestamp
    blocks with same timestamp
      4) should not throw if given a timestamp that is equal to the current block timestamp
      5) should throw if given a timestamp that is less than the current block timestamp


  2 passing (754ms)
  5 failing

  1) time#setNextBlockTimestamp
       simple project
         should not mine a new block:
     ProviderError: Invalid params: invalid type: string "0x3e9", expected u64.
...
```

After:
```
$ mocha test/helpers/time/setNextBlockTimestamp.ts 


  time#setNextBlockTimestamp
    simple project
      ✔ should not mine a new block (117ms)
      1) should set the next block to the given timestamp [epoch seconds]
      2) should set the next block to the given timestamp [Date]
      3) should throw if given a timestamp that is equal to the current block timestamp
      ✔ should throw if given a timestamp that is less than the current block timestamp
    blocks with same timestamp
      ✔ should not throw if given a timestamp that is equal to the current block timestamp
      4) should throw if given a timestamp that is less than the current block timestamp


  3 passing (659ms)
  4 failing
```
