### PR TITLE
fix: changed hardhat_setCode code type

### DIFF
--- a/e2e-tests/test/hardhat-apis.test.ts
+++ b/e2e-tests/test/hardhat-apis.test.ts
@@ -97,7 +97,7 @@ describe("hardhat_setCode", function () {
 
     const address = "0x1000000000000000000000000000000000001111";
     const artifact = await deployer.loadArtifact("Return5");
-    const contractCode = [...ethers.utils.arrayify(artifact.deployedBytecode)];
+    const contractCode = artifact.deployedBytecode;
 
     // Act
     await provider.send("hardhat_setCode", [address, contractCode]);
@@ -126,8 +126,8 @@ describe("hardhat_setCode", function () {
 
       const address = "0x1000000000000000000000000000000000001111";
       const artifact = await deployer.loadArtifact("Return5");
-      const contractCode = [...ethers.utils.arrayify(artifact.deployedBytecode)];
-      const shortCode = contractCode.slice(0, contractCode.length - 1);
+      const contractCode = artifact.deployedBytecode;
+      const shortCode = contractCode.slice(0, contractCode.length - 2);
 
       // Act
       await provider.send("hardhat_setCode", [address, shortCode]);
@@ -144,7 +144,7 @@ describe("hardhat_setCode", function () {
     const greeter = await deployContract(deployer, "Greeter", ["Hi"]);
     expect(await greeter.greet()).to.eq("Hi");
     const artifact = await deployer.loadArtifact("Return5");
-    const newContractCode = [...ethers.utils.arrayify(artifact.deployedBytecode)];
+    const newContractCode = artifact.deployedBytecode;
 
     // Act
     await provider.send("hardhat_setCode", [greeter.address, newContractCode]);

--- a/src/namespaces/hardhat.rs
+++ b/src/namespaces/hardhat.rs
@@ -116,7 +116,7 @@ pub trait HardhatNamespaceT {
     ///
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "hardhat_setCode")]
-    fn set_code(&self, address: Address, code: Vec<u8>) -> RpcResult<()>;
+    fn set_code(&self, address: Address, code: String) -> RpcResult<()>;
 
     /// Directly modifies the storage of a contract at a specified slot.
     ///

--- a/src/node/hardhat.rs
+++ b/src/node/hardhat.rs
@@ -65,7 +65,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> HardhatNam
             .into_boxed_future()
     }
 
-    fn set_code(&self, address: Address, code: Vec<u8>) -> RpcResult<()> {
+    fn set_code(&self, address: Address, code: String) -> RpcResult<()> {
         self.set_code(address, code)
             .map_err(|err| {
                 tracing::error!("failed setting code: {:?}", err);

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -356,7 +356,9 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
             .and_then(|mut writer| {
                 let code_key = get_code_key(&address);
                 tracing::info!("set code for address {address:#x}");
-                let code_slice = code.strip_prefix("0x").unwrap_or(&code);
+                let code_slice = code
+                    .strip_prefix("0x")
+                    .ok_or_else(|| anyhow!("code must be 0x-prefixed"))?;
                 let code_bytes = hex::decode(code_slice)?;
                 let hashcode = bytecode_to_factory_dep(code_bytes)?;
                 let hash = u256_to_h256(hashcode.0);
@@ -598,7 +600,7 @@ mod tests {
             .0;
         assert_eq!(Vec::<u8>::default(), code_before);
 
-        node.set_code(address, hex::encode(new_code.clone()))
+        node.set_code(address, format!("0x{}", hex::encode(new_code.clone())))
             .expect("failed setting code");
 
         let code_after = node

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -349,14 +349,16 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
             })
     }
 
-    pub fn set_code(&self, address: Address, code: Vec<u8>) -> Result<()> {
+    pub fn set_code(&self, address: Address, code: String) -> Result<()> {
         self.get_inner()
             .write()
             .map_err(|err| anyhow!("failed acquiring lock: {:?}", err))
             .and_then(|mut writer| {
                 let code_key = get_code_key(&address);
                 tracing::info!("set code for address {address:#x}");
-                let hashcode = bytecode_to_factory_dep(code)?;
+                let code_slice = code.strip_prefix("0x").unwrap_or(&code);
+                let code_bytes = hex::decode(code_slice)?;
+                let hashcode = bytecode_to_factory_dep(code_bytes)?;
                 let hash = u256_to_h256(hashcode.0);
                 let code = hashcode
                     .1
@@ -596,7 +598,7 @@ mod tests {
             .0;
         assert_eq!(Vec::<u8>::default(), code_before);
 
-        node.set_code(address, new_code.clone())
+        node.set_code(address, hex::encode(new_code.clone()))
             .expect("failed setting code");
 
         let code_after = node


### PR DESCRIPTION
# What :computer: 
Changed `hardhat_setCode` code parameter type to string encoding of a hex number.

# Why :hand:
Fixes https://github.com/matter-labs/era-test-node/issues/325 .

# Evidence :camera:
```
$ mocha test/helpers/setCode.ts 


  setCode
    ✔ should allow setting the code of a given address (115ms)
    accepted parameter types for code
      ✔ should not accept strings that are not 0x-prefixed
      ✔ should not accept non-hex strings


  3 passing (525ms)
```

# Notes :memo:
Note that the hardhat testsuite had been modified to pass the test: its original sample code doesn't pass test node checks.
