### PR TITLE
fix: returning errors from fork handling

### DIFF
--- a/src/fork.rs
+++ b/src/fork.rs
@@ -640,7 +640,12 @@ impl ForkDetails {
         let opt_tx_details = self
             .fork_source
             .get_transaction_by_hash(replay_tx)
-            .map_err(|err| eyre!("Cannot get transaction: {:?}", err))?;
+            .map_err(|err| {
+                eyre!(
+                    "Cannot get transaction to replay by hash from fork source: {:?}",
+                    err
+                )
+            })?;
         let tx_details =
             opt_tx_details.ok_or_else(|| eyre!("Cannot find transaction {:?}", replay_tx))?;
         let block_number = tx_details

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -241,7 +241,10 @@ impl<S: ForkSource> ForkStorage<S> {
 
         // If value was 0, there is still a chance, that the slot was written to in the past - and only now set to 0.
         // We unfortunately don't have the API to check it on the fork, but we can at least try to check it on local storage.
-        let mut mutator = self.inner.write().unwrap();
+        let mut mutator = self
+            .inner
+            .write()
+            .map_err(|err| eyre!("failed acquiring write lock on storage: {:?}", err))?;
         Ok(mutator.raw_storage.is_write_initial(key))
     }
 

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -699,7 +699,7 @@ impl ForkDetails {
                         None
                     }
                 } else {
-                    tracing::warn!("No block details");
+                    tracing::warn!("No block details for {}", miniblock);
                     None
                 }
             }

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -244,7 +244,7 @@ impl<S: ForkSource> ForkStorage<S> {
         let mut mutator = self
             .inner
             .write()
-            .map_err(|err| eyre!("failed acquiring write lock on storage: {:?}", err))?;
+            .map_err(|err| eyre!("failed acquiring write lock on fork storage: {:?}", err))?;
         Ok(mutator.raw_storage.is_write_initial(key))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,11 +235,17 @@ async fn main() -> anyhow::Result<()> {
     // If we're replaying the transaction, we need to sync to the previous block
     // and then replay all the transactions that happened in
     let transactions_to_replay = if let Command::ReplayTx(replay_tx) = command {
-        fork_details
+        match fork_details
             .as_ref()
             .unwrap()
             .get_earlier_transactions_in_same_block(replay_tx.tx)
-            .await
+        {
+            Ok(txs) => txs,
+            Err(error) => {
+                tracing::error!("cannot get transactions: {:?}", error);
+                return Err(anyhow!(error));
+            }
+        }
     } else {
         vec![]
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,7 +242,10 @@ async fn main() -> anyhow::Result<()> {
         {
             Ok(txs) => txs,
             Err(error) => {
-                tracing::error!("cannot get transactions: {:?}", error);
+                tracing::error!(
+                    "failed to get earlier transactions in the same block for replay tx: {:?}",
+                    error
+                );
                 return Err(anyhow!(error));
             }
         }


### PR DESCRIPTION
# What :computer: 
Replaced calls to unwrap & panic in is_write_initial_internal, fork_network_and_client, get_earlier_transactions_in_same_block and get_block_gas_details by explicit errors.

# Why :hand:
Improved reporting, not panicking on invalid inputs.

# Evidence :camera:
Tests pass.