### PR TITLE
fix: Update gas estimation logic for forks

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -284,6 +284,8 @@ pub mod gas {
     // TODO: for now, that's fine, as computation overhead is set to zero, but we may consider using calculated fee input everywhere.
     /// The default L2 Gas Price to be used if not supplied via the CLI argument.
     pub const DEFAULT_L2_GAS_PRICE: u64 = 25_000_000;
+    // Default fair pubdata price based on an average from Sepolia Testnet blocks
+    pub const DEFAULT_FAIR_PUBDATA_PRICE: u64 = 450_000_000_000;
     /// L1 Gas Price Scale Factor for gas estimation.
     pub const DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR: f64 = 1.5;
     /// The factor by which to scale the gasLimit.

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -39,7 +39,7 @@ use zksync_web3_decl::{namespaces::EthNamespaceClient, types::Index};
 
 use crate::{config::cache::CacheConfig, node::TEST_NODE_NETWORK_ID};
 use crate::{
-    config::gas::{DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR, DEFAULT_ESTIMATE_GAS_SCALE_FACTOR},
+    config::gas::{DEFAULT_FAIR_PUBDATA_PRICE, DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR, DEFAULT_ESTIMATE_GAS_SCALE_FACTOR},
     system_contracts,
 };
 use crate::{deps::InMemoryStorage, http_fork_source::HttpForkSource};
@@ -400,6 +400,8 @@ pub struct ForkDetails {
     pub overwrite_chain_id: Option<L2ChainId>,
     pub l1_gas_price: u64,
     pub l2_fair_gas_price: u64,
+    // Cost of publishing one byte (in wei).
+    pub fair_pubdata_price: u64,
     /// L1 Gas Price Scale Factor for gas estimation.
     pub estimate_gas_price_scale_factor: f64,
     /// The factor by which to scale the gasLimit.
@@ -522,6 +524,7 @@ impl ForkDetails {
             overwrite_chain_id: chain_id,
             l1_gas_price: block_details.base.l1_gas_price,
             l2_fair_gas_price: block_details.base.l2_fair_gas_price,
+            fair_pubdata_price: block_details.base.fair_pubdata_price.unwrap_or(DEFAULT_FAIR_PUBDATA_PRICE),
             estimate_gas_price_scale_factor,
             estimate_gas_scale_factor,
             fee_params,
@@ -719,8 +722,8 @@ mod tests {
 
     use crate::config::cache::CacheConfig;
     use crate::config::gas::{
-        DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR, DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
-        DEFAULT_L2_GAS_PRICE,
+        DEFAULT_FAIR_PUBDATA_PRICE, DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
+        DEFAULT_ESTIMATE_GAS_SCALE_FACTOR, DEFAULT_L2_GAS_PRICE,
     };
     use crate::{deps::InMemoryStorage, system_contracts, testing};
 
@@ -752,6 +755,7 @@ mod tests {
             overwrite_chain_id: None,
             l1_gas_price: 100,
             l2_fair_gas_price: DEFAULT_L2_GAS_PRICE,
+            fair_pubdata_price: DEFAULT_FAIR_PUBDATA_PRICE,
             estimate_gas_price_scale_factor: DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
             estimate_gas_scale_factor: DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
             fee_params: None,
@@ -786,6 +790,7 @@ mod tests {
             overwrite_chain_id: None,
             l1_gas_price: 0,
             l2_fair_gas_price: 0,
+            fair_pubdata_price: 0,
             estimate_gas_price_scale_factor: 0.0,
             estimate_gas_scale_factor: 0.0,
             fee_params: None,

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -39,7 +39,10 @@ use zksync_web3_decl::{namespaces::EthNamespaceClient, types::Index};
 
 use crate::{config::cache::CacheConfig, node::TEST_NODE_NETWORK_ID};
 use crate::{
-    config::gas::{DEFAULT_FAIR_PUBDATA_PRICE, DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR, DEFAULT_ESTIMATE_GAS_SCALE_FACTOR},
+    config::gas::{
+        DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR, DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
+        DEFAULT_FAIR_PUBDATA_PRICE,
+    },
     system_contracts,
 };
 use crate::{deps::InMemoryStorage, http_fork_source::HttpForkSource};
@@ -524,7 +527,10 @@ impl ForkDetails {
             overwrite_chain_id: chain_id,
             l1_gas_price: block_details.base.l1_gas_price,
             l2_fair_gas_price: block_details.base.l2_fair_gas_price,
-            fair_pubdata_price: block_details.base.fair_pubdata_price.unwrap_or(DEFAULT_FAIR_PUBDATA_PRICE),
+            fair_pubdata_price: block_details
+                .base
+                .fair_pubdata_price
+                .unwrap_or(DEFAULT_FAIR_PUBDATA_PRICE),
             estimate_gas_price_scale_factor,
             estimate_gas_scale_factor,
             fee_params,
@@ -722,8 +728,8 @@ mod tests {
 
     use crate::config::cache::CacheConfig;
     use crate::config::gas::{
-        DEFAULT_FAIR_PUBDATA_PRICE, DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
-        DEFAULT_ESTIMATE_GAS_SCALE_FACTOR, DEFAULT_L2_GAS_PRICE,
+        DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR, DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
+        DEFAULT_FAIR_PUBDATA_PRICE, DEFAULT_L2_GAS_PRICE,
     };
     use crate::{deps::InMemoryStorage, system_contracts, testing};
 

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -287,7 +287,7 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
         &self,
         storage: StoragePtr<ST>,
     ) -> (L1BatchEnv, BlockContext) {
-        tracing::debug!("creating l1 batch env...");
+        tracing::debug!("Creating l1 batch env...");
 
         let (last_l1_block_num, last_l1_block_ts) = load_last_l1_batch(storage.clone())
             .map(|(num, ts)| (num as u32, ts))
@@ -318,17 +318,21 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
             .expect("fork_storage lock is already held by the current thread")
             .fork
         {
-            tracing::debug!(
-                "fork details are present. Updating fee input provider's
-                `l1_gas_price`, `l2_fair_gas_price`, `fair_pubdata_price`
-                for batch {}, that is being created..",
-                block_ctx.batch
-            );
-
+            // fee_input = BatchFeeInput::PubdataIndependent(PubdataIndependentBatchFeeModelInput {
+            //     l1_gas_price: fork.l1_gas_price,
+            //     fair_l2_gas_price: fork.l2_fair_gas_price,
+            //     fair_pubdata_price: fork.fair_pubdata_price,
+            // });
             let (l1_gas_price, fair_l2_gas_price, fair_pubdata_price) = {
                 fork.get_block_gas_details(block_ctx.miniblock as u32)
-                    .unwrap()
+                .unwrap()
             };
+            tracing::info!(
+                "Using fee_input with l1_gas_price: {}, fair_l2_gas_price: {}, fair_pubdata_price: {}",
+                l1_gas_price,
+                fair_l2_gas_price,
+                fair_pubdata_price
+            );
 
             fee_input = BatchFeeInput::PubdataIndependent(PubdataIndependentBatchFeeModelInput {
                 fair_l2_gas_price,
@@ -1264,7 +1268,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
 
     // Validates L2 transaction
     fn validate_tx(&self, tx: &L2Tx) -> Result<(), String> {
-        let max_gas = U256::from(u32::MAX);
+        let max_gas = U256::from(u64::MAX);
         if tx.common_data.fee.gas_limit > max_gas
             || tx.common_data.fee.gas_per_pubdata_limit > max_gas
         {
@@ -1771,6 +1775,7 @@ pub fn load_last_l1_batch<S: ReadStorage>(storage: StoragePtr<S>) -> Option<(u64
 #[cfg(test)]
 mod tests {
     use ethabi::{Token, Uint};
+    use gas::DEFAULT_FAIR_PUBDATA_PRICE;
     use zksync_basic_types::Nonce;
     use zksync_types::{utils::deployed_address_create, K256PrivateKey};
 
@@ -1793,7 +1798,7 @@ mod tests {
     async fn test_run_l2_tx_validates_tx_gas_limit_too_high() {
         let node = InMemoryNode::<HttpForkSource>::default();
         let tx = testing::TransactionBuilder::new()
-            .set_gas_limit(U256::from(u32::MAX) + 1)
+            .set_gas_limit(U256::from(u64::MAX) + 1)
             .build();
         node.set_rich_account(tx.common_data.initiator_address);
 
@@ -1889,6 +1894,7 @@ mod tests {
                 overwrite_chain_id: None,
                 l1_gas_price: 1000,
                 l2_fair_gas_price: DEFAULT_L2_GAS_PRICE,
+                fair_pubdata_price: DEFAULT_FAIR_PUBDATA_PRICE,
                 fee_params: None,
                 estimate_gas_price_scale_factor: DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
                 estimate_gas_scale_factor: DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -318,26 +318,10 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
             .expect("fork_storage lock is already held by the current thread")
             .fork
         {
-            // fee_input = BatchFeeInput::PubdataIndependent(PubdataIndependentBatchFeeModelInput {
-            //     l1_gas_price: fork.l1_gas_price,
-            //     fair_l2_gas_price: fork.l2_fair_gas_price,
-            //     fair_pubdata_price: fork.fair_pubdata_price,
-            // });
-            let (l1_gas_price, fair_l2_gas_price, fair_pubdata_price) = {
-                fork.get_block_gas_details(block_ctx.miniblock as u32)
-                .unwrap()
-            };
-            tracing::info!(
-                "Using fee_input with l1_gas_price: {}, fair_l2_gas_price: {}, fair_pubdata_price: {}",
-                l1_gas_price,
-                fair_l2_gas_price,
-                fair_pubdata_price
-            );
-
             fee_input = BatchFeeInput::PubdataIndependent(PubdataIndependentBatchFeeModelInput {
-                fair_l2_gas_price,
-                fair_pubdata_price,
-                l1_gas_price,
+                l1_gas_price: fork.l1_gas_price,
+                fair_l2_gas_price: fork.l2_fair_gas_price,
+                fair_pubdata_price: fork.fair_pubdata_price,
             });
         } else {
             let fee_input_provider = self.fee_input_provider.clone();


### PR DESCRIPTION
# What :computer: 
* Gas estimation logic for forks now uses the block detail values when the node starts
* `max_gas` during transaction validation is increased from `u32::MAX` to `u64::MAX`

# Why :hand:
* Previously, every transaction would attempt to grab the block details of the current miniblock. However, `era_test_node` can mine blocks _much_ faster than Sepolia Testnet, so sometimes it would require block details for a block that doesn't exist yet.
* During the `1.5.0` upgrade, [the gas limit of ZKsync was upgraded from `u32` to `u64`](https://github.com/matter-labs/zksync-era/commit/56dc049993d673635e55b545962bf4f6d4f32739). This check was missed in the updates for `era-test-node`

# Evidence :camera:
Forking sepolia and running a transaction still works
![image](https://github.com/user-attachments/assets/9ecbef34-1b48-4d6e-b0a4-7b1a67751498)

# Notes :memo:
* This fixes #326 
