### PR TITLE
feat: Add debug-mode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ Example:
 era_test_node --show-storage-logs=all --show-vm-details=all --show-gas-details=all run
 ```
 
+This is now even easier with a single flag (`--debug-mode` or `-d`):
+
+```bash
+era_test_node -d
+```
+
 ## 💰 Using Rich Wallets
 
 For testing and development purposes, the `era-test-node` comes pre-configured with a set of 'rich' wallets. These wallets are loaded with test funds, allowing you to simulate transactions and interactions without the need for real assets.

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -32,6 +32,10 @@ pub struct Cli {
     /// The file path to the config file. If not supplied, defaults will be used.
     pub config: Option<String>,
 
+    #[arg(short, long)]
+    /// Enable default settings for debugging contracts
+    pub debug_mode: bool,
+
     #[arg(long)]
     /// Port to listen on - default: 8011
     pub port: Option<u16>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@ use cache::CacheConfig;
 use cli::{CacheType, Cli, DevSystemContracts};
 use gas::GasConfig;
 use log::LogConfig;
-use node::InMemoryNodeConfig;
+use node::{InMemoryNodeConfig, ShowCalls, ShowGasDetails};
 use serde::Deserialize;
 
 use crate::system_contracts;
@@ -54,6 +54,12 @@ impl TestNodeConfig {
             self.node.port = *port;
         }
 
+        if opt.debug_mode {
+            self.node.show_calls = ShowCalls::All;
+            self.node.show_outputs = true;
+            self.node.show_gas_details = ShowGasDetails::All;
+            self.node.resolve_hashes = true;
+        }
         if let Some(show_calls) = &opt.show_calls {
             self.node.show_calls = *show_calls;
         }


### PR DESCRIPTION
# What :computer: 
* Add `-d` and `--debug-mode` flags

# Why :hand:
* To make it much easier/faster to run `era_test_node` in a configuration that's optimal for debugging smart contracts

# Evidence :camera:
Running `era_test_node --help`:
![image](https://github.com/user-attachments/assets/dcd4d17a-a663-43f8-8702-4c967bc3126a)

Running `era_test_node -d`:
![image](https://github.com/user-attachments/assets/1d66bf69-19c4-4473-a5d4-38c07866155a)
...
![image](https://github.com/user-attachments/assets/39cc5543-0c81-4934-a9bf-72c20c557cf8)