### PR TITLE
feat: Add persistent cache to OpenChain hash resolving requests

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -20,6 +20,8 @@ const CACHE_TYPE_BLOCKS_MIN: &str = "blocks_min";
 const CACHE_TYPE_BLOCK_RAW_TRANSACTIONS: &str = "block_raw_transactions";
 /// Caches transactions by their hashes
 const CACHE_TYPE_TRANSACTIONS: &str = "transactions";
+/// Caching resolver functions by their selectors
+const CACHE_TYPE_RESOLVER_SELECTORS: &str = "resolver_selectors";
 /// Caches arbitrary values by their keys
 const CACHE_TYPE_KEY_VALUE: &str = "key_value";
 
@@ -35,6 +37,7 @@ pub(crate) struct Cache {
     blocks_min: FxHashMap<H256, Block<TransactionVariant>>,
     block_raw_transactions: FxHashMap<u64, Vec<RawTransaction>>,
     transactions: FxHashMap<H256, Transaction>,
+    resolver_selectors: FxHashMap<String, String>,
     bridge_addresses: Option<BridgeAddresses>,
     confirmed_tokens: FxHashMap<(u32, u8), Vec<zksync_web3_decl::types::Token>>,
 }
@@ -54,6 +57,7 @@ impl Cache {
                     CACHE_TYPE_BLOCKS_MIN,
                     CACHE_TYPE_BLOCK_RAW_TRANSACTIONS,
                     CACHE_TYPE_TRANSACTIONS,
+                    CACHE_TYPE_RESOLVER_SELECTORS,
                     CACHE_TYPE_KEY_VALUE,
                 ] {
                     fs::remove_dir_all(Path::new(dir).join(cache_type)).unwrap_or_else(|err| {
@@ -75,6 +79,7 @@ impl Cache {
                 CACHE_TYPE_BLOCKS_MIN,
                 CACHE_TYPE_BLOCK_RAW_TRANSACTIONS,
                 CACHE_TYPE_TRANSACTIONS,
+                CACHE_TYPE_RESOLVER_SELECTORS,
                 CACHE_TYPE_KEY_VALUE,
             ] {
                 fs::create_dir_all(Path::new(dir).join(cache_type)).unwrap_or_else(|err| {
@@ -198,6 +203,15 @@ impl Cache {
         self.transactions.get(hash)
     }
 
+    /// Returns the cached resolved function/event selector for the provided selector.
+    pub(crate) fn get_resolver_selector(&self, selector: &String) -> Option<&String> {
+        if matches!(self.config, CacheConfig::None) {
+            return None;
+        }
+
+        self.resolver_selectors.get(selector)
+    }
+
     /// Cache a transaction for the provided hash.
     pub(crate) fn insert_transaction(&mut self, hash: H256, transaction: Transaction) {
         if matches!(self.config, CacheConfig::None) {
@@ -210,6 +224,20 @@ impl Cache {
             &transaction,
         );
         self.transactions.insert(hash, transaction);
+    }
+
+    /// Cache a resolver function for the provided selector.
+    pub(crate) fn insert_resolver_selector(&mut self, selector: String, selector_value: String) {
+        if matches!(self.config, CacheConfig::None) {
+            return;
+        }
+
+        self.write_to_disk(
+            CACHE_TYPE_RESOLVER_SELECTORS,
+            selector.clone(),
+            &selector_value,
+        );
+        self.resolver_selectors.insert(selector, selector_value);
     }
 
     /// Returns the cached bridge addresses for the provided hash.
@@ -242,6 +270,7 @@ impl Cache {
             CACHE_TYPE_BLOCKS_MIN,
             CACHE_TYPE_BLOCK_RAW_TRANSACTIONS,
             CACHE_TYPE_TRANSACTIONS,
+            CACHE_TYPE_RESOLVER_SELECTORS,
             CACHE_TYPE_KEY_VALUE,
         ] {
             let cache_dir = Path::new(dir).join(cache_type);
@@ -301,6 +330,13 @@ impl Cache {
                                 format!("failed parsing json for cache file '{:?}': {:?}", key, err)
                             })?;
                         self.transactions.insert(key, transaction);
+                    }
+                    CACHE_TYPE_RESOLVER_SELECTORS => {
+                        let selector: String =
+                            serde_json::from_reader(reader).map_err(|err| {
+                                format!("failed parsing json for cache file '{:?}': {:?}", key, err)
+                            })?;
+                        self.resolver_selectors.insert(key, selector);
                     }
                     CACHE_TYPE_KEY_VALUE => match key.as_str() {
                         CACHE_KEY_BRIDGE_ADDRESSES => {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -332,10 +332,9 @@ impl Cache {
                         self.transactions.insert(key, transaction);
                     }
                     CACHE_TYPE_RESOLVER_SELECTORS => {
-                        let selector: String =
-                            serde_json::from_reader(reader).map_err(|err| {
-                                format!("failed parsing json for cache file '{:?}': {:?}", key, err)
-                            })?;
+                        let selector: String = serde_json::from_reader(reader).map_err(|err| {
+                            format!("failed parsing json for cache file '{:?}': {:?}", key, err)
+                        })?;
                         self.resolver_selectors.insert(key, selector);
                     }
                     CACHE_TYPE_KEY_VALUE => match key.as_str() {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -14,10 +14,7 @@ use std::{
 use tokio::sync::RwLock;
 use tracing::warn;
 
-use crate::{
-    cache::Cache,
-    config::cache::CacheConfig,
-};
+use crate::{cache::Cache, config::cache::CacheConfig};
 
 static SELECTOR_DATABASE_URL: &str = "https://api.openchain.xyz/signature-database/v1/lookup";
 
@@ -234,7 +231,9 @@ pub async fn decode_function_selector(selector: &str) -> eyre::Result<Option<Str
     let client = SignEthClient::new();
     {
         // Check cache
-        if let Some(resolved_selector) = client.as_ref().unwrap()
+        if let Some(resolved_selector) = client
+            .as_ref()
+            .unwrap() // Safe to do as client is created within this function
             .cache
             .read()
             .await
@@ -246,16 +245,23 @@ pub async fn decode_function_selector(selector: &str) -> eyre::Result<Option<Str
     }
 
     tracing::debug!("Making external request to resolve function selector for {selector}");
-    let result = client.as_ref().unwrap()
+    let result = client
+        .as_ref()
+        .unwrap() // Safe to do as client is created within this function
         .decode_function_selector(selector)
         .await;
 
     if let Ok(result) = &result {
-        client.as_ref().unwrap()
+        client
+            .as_ref()
+            .unwrap() // Safe to do as client is created within this function
             .cache
             .write()
             .await
-            .insert_resolver_selector(selector.to_string(), result.clone().unwrap_or_else(|| "".to_string()));
+            .insert_resolver_selector(
+                selector.to_string(),
+                result.clone().unwrap_or_else(|| "".to_string()),
+            );
     }
     result
 }
@@ -264,7 +270,9 @@ pub async fn decode_event_selector(selector: &str) -> eyre::Result<Option<String
     let client = SignEthClient::new();
     {
         // Check cache
-        if let Some(resolved_selector) = client.as_ref().unwrap()
+        if let Some(resolved_selector) = client
+            .as_ref()
+            .unwrap() // Safe to do as client is created within this function
             .cache
             .read()
             .await
@@ -276,16 +284,23 @@ pub async fn decode_event_selector(selector: &str) -> eyre::Result<Option<String
     }
 
     tracing::debug!("Making external request to resolve event selector for {selector}");
-    let result = SignEthClient::new()?
+    let result = client
+        .as_ref()
+        .unwrap()
         .decode_selector(selector, SelectorType::Event)
         .await;
 
     if let Ok(result) = &result {
-        client.as_ref().unwrap()
+        client
+            .as_ref()
+            .unwrap() // Safe to do as client is created within this function
             .cache
             .write()
             .await
-            .insert_resolver_selector(selector.to_string(), result.clone().unwrap_or_else(|| "".to_string()));
+            .insert_resolver_selector(
+                selector.to_string(),
+                result.clone().unwrap_or_else(|| "".to_string()),
+            );
     }
     result
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -14,6 +14,11 @@ use std::{
 use tokio::sync::RwLock;
 use tracing::warn;
 
+use crate::{
+    cache::Cache,
+    config::cache::CacheConfig,
+};
+
 static SELECTOR_DATABASE_URL: &str = "https://api.openchain.xyz/signature-database/v1/lookup";
 
 /// The standard request timeout for API requests
@@ -32,6 +37,8 @@ pub struct SignEthClient {
     timedout_requests: Arc<AtomicUsize>,
     /// Max allowed request that can time out
     max_timedout_requests: usize,
+    /// Cache for network data.
+    pub(crate) cache: Arc<RwLock<Cache>>,
 }
 
 #[derive(Deserialize)]
@@ -50,7 +57,6 @@ lazy_static! {
             .map(|entry| (entry.abi, entry.name))
             .collect()
     };
-    static ref CACHE: RwLock<HashMap<String, Option<String>>> = RwLock::new(HashMap::new());
 }
 
 impl SignEthClient {
@@ -68,6 +74,7 @@ impl SignEthClient {
             spurious_connection: Arc::new(Default::default()),
             timedout_requests: Arc::new(Default::default()),
             max_timedout_requests: MAX_TIMEDOUT_REQ,
+            cache: Arc::new(RwLock::new(Cache::new(CacheConfig::default()))),
         })
     }
 
@@ -224,38 +231,61 @@ pub enum SelectorType {
 }
 /// Fetches a function signature given the selector using api.openchain.xyz
 pub async fn decode_function_selector(selector: &str) -> eyre::Result<Option<String>> {
+    let client = SignEthClient::new();
     {
-        let cache = CACHE.read().await;
-        if let Some(result) = cache.get(selector) {
-            return Ok(result.clone());
+        // Check cache
+        if let Some(resolved_selector) = client.as_ref().unwrap()
+            .cache
+            .read()
+            .await
+            .get_resolver_selector(&(selector.to_string()))
+        {
+            tracing::debug!("Using cached function selector for {selector}");
+            return Ok(Some(resolved_selector.clone()));
         }
     }
-    let result = SignEthClient::new()?
+
+    tracing::debug!("Making external request to resolve function selector for {selector}");
+    let result = client.as_ref().unwrap()
         .decode_function_selector(selector)
         .await;
+
     if let Ok(result) = &result {
-        let mut cache = CACHE.write().await;
-        cache.insert(selector.to_string(), result.clone());
+        client.as_ref().unwrap()
+            .cache
+            .write()
+            .await
+            .insert_resolver_selector(selector.to_string(), result.clone().unwrap_or_else(|| "".to_string()));
     }
     result
 }
 
 pub async fn decode_event_selector(selector: &str) -> eyre::Result<Option<String>> {
+    let client = SignEthClient::new();
     {
-        let cache = CACHE.read().await;
-        if let Some(result) = cache.get(selector) {
-            return Ok(result.clone());
+        // Check cache
+        if let Some(resolved_selector) = client.as_ref().unwrap()
+            .cache
+            .read()
+            .await
+            .get_resolver_selector(&(selector.to_string()))
+        {
+            tracing::debug!("Using cached event selector for {selector}");
+            return Ok(Some(resolved_selector.clone()));
         }
     }
-    if let Some(r) = KNOWN_SIGNATURES.get(selector) {
-        return Ok(Some(r.clone()));
-    }
+
+    tracing::debug!("Making external request to resolve event selector for {selector}");
     let result = SignEthClient::new()?
         .decode_selector(selector, SelectorType::Event)
         .await;
+
     if let Ok(result) = &result {
-        let mut cache = CACHE.write().await;
-        cache.insert(selector.to_string(), result.clone());
+        client.as_ref().unwrap()
+            .cache
+            .write()
+            .await
+            .insert_resolver_selector(selector.to_string(), result.clone().unwrap_or_else(|| "".to_string()));
     }
     result
 }


### PR DESCRIPTION
# What :computer: 
* Add persistent cache for OpenChain requests

# Why :hand:
* To speed up local debugging, as restarting `era_test_node` would clear the previous cache

# Evidence :camera:
BEFORE (tests ran against `era_test_node -d` in 48 seconds):
![image](https://github.com/user-attachments/assets/dd61016a-b08a-49f2-9119-fefb14ecd542)

AFTER (tests ran against `era_test_node -d` in 7 seconds):
![image](https://github.com/user-attachments/assets/614c60e6-6a9a-4612-902c-7fa1adf1aaee)
