### PR TITLE
feat: Add support for zks_getBaseTokenL1Address. Add gas used per call in the stack

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -107,7 +107,7 @@ The `status` options are:
 | `HARDHAT` | `hardhat_getAutomine` | `NOT IMPLEMENTED` | Returns `true` if automatic mining is enabled, and `false` otherwise |
 | `HARDHAT` | `hardhat_metadata` | `NOT IMPLEMENTED` | Returns the metadata of the current network |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_mine`](#hardhat_mine) | Mine any number of blocks at once, in constant time |
-| [`HARDHAT`](#hardhat-namespace) | [`hardhat_reset`] | `PARTIALLY` | Resets the state of the network; cannot revert to past block numbers, unless they're in a fork |
+| [`HARDHAT`](#hardhat-namespace) | [`hardhat_reset`](#hardhat_reset) | `PARTIALLY` | Resets the state of the network; cannot revert to past block numbers, unless they're in a fork |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setBalance`](#hardhat_setbalance) | `SUPPORTED` | Modifies the balance of an account |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_setCode`](#hardhat_setcode) | `SUPPORTED` | Sets the bytecode of a given account |
 | `HARDHAT` | `hardhat_setCoinbase` | `NOT IMPLEMENTED` | Sets the coinbase address |
@@ -129,6 +129,7 @@ The `status` options are:
 | [`ZKS`](#zks-namespace) | [`zks_getBlockDetails`](#zks_getblockdetails) | `SUPPORTED` | Returns additional zkSync-specific information about the L2 block |
 | `ZKS` | `zks_getBytecodeByHash` | `NOT IMPLEMENTED` | Returns bytecode of a transaction given by its hash |
 | [`ZKS`](#zks-namespace) | [`zks_getConfirmedTokens`](#zks_getconfirmedtokens) | `SUPPORTED` | Returns [address, symbol, name, and decimal] information of all tokens within a range of ids given by parameters `from` and `limit` |
+| [`ZKS`](#zks-namespace) | [`zks_getBaseTokenL1Address`](#zks_getBaseTokenL1Address) | `SUPPORTED` | Returns the L1 base token address <br/>_(hard-coded to `0x0000000000000000000000000000000000000001`)_ |
 | `ZKS` | `zks_getL1BatchBlockRange` | `NOT IMPLEMENTED` | Returns the range of blocks contained within a batch given by batch number |
 | `ZKS` | `zks_getL1BatchDetails` | `NOT IMPLEMENTED` | Returns data pertaining to a given batch |
 | `ZKS` | `zks_getL2ToL1LogProof` | `NOT IMPLEMENTED` | Given a transaction hash, and an index of the L2 to L1 log produced within the transaction, it returns the proof for the corresponding L2 to L1 log |
@@ -1569,6 +1570,32 @@ curl --request POST \
 }'
 
 ```
+
+### `hardhat_reset`
+
+[source](src/node/hardhat.rs)
+
+Resets the state of the network; cannot revert to past block numbers, unless they're in a fork
+
+#### Arguments
+
++ `reset_spec` - The requested state, defaults to resetting the current network.
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "hardhat_mine",
+    "params": []
+}'
+
+```
+
 ### `hardhat_impersonateAccount`
 
 [source](src/node/hardhat.rs)
@@ -2034,6 +2061,30 @@ curl --request POST \
     "id": "1",
     "method": "zks_getConfirmedTokens",
     "params": [0, 100]
+}'
+```
+
+### `zks_getBaseTokenL1Address`
+
+[source](src/zks.rs)
+
+Retrieves the L1 base token address.
+
+#### Arguments
+
++ _NONE_
+
+#### Example
+
+```bash
+curl --request POST \
+  --url http://localhost:8011/ \
+  --header 'content-type: application/json' \
+  --data '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "zks_getBaseTokenL1Address",
+    "params": []
 }'
 ```
 

--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -175,3 +175,10 @@ describe("zks_getAllAccountBalances", function () {
     expect(ethBalance.eq(expectedBalance)).to.be.true;
   });
 });
+
+describe("zks_getBaseTokenL1Address", function () {
+  it("Should return 0x1 address", async function () {
+    const token_address = await provider.send("zks_getBaseTokenL1Address", []);
+    expect(token_address).to.equal("0x0000000000000000000000000000000000000001");
+  });
+});

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -185,7 +185,7 @@ pub fn print_call(
         };
 
         let pretty_print = format!(
-            "{}{:?} {} {} {} {} {} {}",
+            "{}{:?} {} {} {} {} {} {} ({})",
             " ".repeat(padding),
             call.r#type,
             address_to_human_readable(call.to)
@@ -201,7 +201,8 @@ pub fn print_call(
                 .as_ref()
                 .map(|s| format!("Error: {}", s))
                 .unwrap_or_default(),
-            call.gas
+            call.gas,
+            call.gas_used
         );
 
         if call.revert_reason.as_ref().is_some() || call.error.as_ref().is_some() {

--- a/src/namespaces/zks.rs
+++ b/src/namespaces/zks.rs
@@ -108,4 +108,7 @@ pub trait ZksNamespaceT {
         keys: Vec<H256>,
         l1_batch_number: L1BatchNumber,
     ) -> BoxFuture<Result<Proof>>;
+
+    #[rpc(name = "zks_getBaseTokenL1Address")]
+    fn get_base_token_l1_address(&self) -> BoxFuture<Result<Address>>;
 }

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -11,7 +11,7 @@ use zksync_types::{
     },
     fee::Fee,
     utils::storage_key_for_standard_token_balance,
-    ExecuteTransactionCommon, ProtocolVersionId, Transaction, L2_BASE_TOKEN_ADDRESS,
+    ExecuteTransactionCommon, ProtocolVersionId, Transaction, H160, L2_BASE_TOKEN_ADDRESS,
 };
 use zksync_utils::h256_to_u256;
 use zksync_web3_decl::error::Web3Error;
@@ -562,6 +562,15 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> ZksNamespa
 
     fn get_protocol_version(&self, _version_id: Option<u16>) -> RpcResult<Option<ProtocolVersion>> {
         not_implemented("zks_getProtocolVersion")
+    }
+
+    /// Retrieves the L1 base token address.
+    ///
+    /// # Returns
+    ///
+    /// Hard-coded address of 0x1 to replicate mainnet/testnet
+    fn get_base_token_l1_address(&self) -> RpcResult<zksync_basic_types::Address> {
+        Ok(H160::from_low_u64_be(1)).into_boxed_future()
     }
 }
 
@@ -1294,5 +1303,18 @@ mod tests {
             .await
             .expect("get balances");
         assert_eq!(balances.get(&cbeth_address).unwrap(), &U256::from(1337));
+    }
+
+    #[tokio::test]
+    async fn test_get_base_token_l1_address() {
+        let node = InMemoryNode::<HttpForkSource>::default();
+        let token_address = node
+            .get_base_token_l1_address()
+            .await
+            .expect("get base token l1 address");
+        assert_eq!(
+            "0x0000000000000000000000000000000000000001",
+            format!("{:?}", token_address)
+        );
     }
 }

--- a/test_endpoints.http
+++ b/test_endpoints.http
@@ -834,3 +834,25 @@ content-type: application/json
     "method": "web3_clientVersion",
     "params": []
 }
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "hardhat_reset",
+    "params": []
+}
+
+###
+POST http://localhost:8011
+content-type: application/json
+
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "zks_getBaseTokenL1Address",
+    "params": []
+}


### PR DESCRIPTION
# What :computer: 
* Add support for `zks_getBaseTokenL1Address`
* Add gas used per call in the stack
* Added/fixed `SUPPORTED_APIS.md` for `hardhat_reset`

# Why :hand:
* The updated Portal will not work with In-Memory Node without this endpoint
* Having the diff gas used within the stack is useful instead of having to do mental math
* Formatting of the table looked weird and we should include `curl` snippets for these commands for users to easily reference

# Evidence :camera:
Using the `zks_getbaseTokenL1Address` endpoint
![image](https://github.com/user-attachments/assets/f4bab2b8-d89e-4564-94de-6213f5c689e9)

The new gas usage diff within the call stack of `era_test_node -d`
![image](https://github.com/user-attachments/assets/4606635b-c14a-412f-8ecc-56ab233ef2ce)
