### PR TITLE
fix: fixes release pipeline due bump in rust version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 env:
   REPO_NAME: ${{ github.repository_owner }}/era-test-node
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: ""
 
 jobs:
   extract-version:
@@ -59,9 +60,11 @@ jobs:
       #       Builds
       # ==============================
 
-      - name: Install cross v0.2.4 from source
+      - name: Install cross v0.2.5 from source
+        env:
+          RUSTFLAGS: ""
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.4
+          cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 
       - name: Build era-test-node for ${{ matrix.arch }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,11 +60,11 @@ jobs:
       #       Builds
       # ==============================
 
-      - name: Install cross v0.2.5 from source
+      - name: Install cross v0.2.4 from source
         env:
           RUSTFLAGS: ""
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
+          cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.4
 
       - name: Build era-test-node for ${{ matrix.arch }}
         run: |

--- a/Cross.toml
+++ b/Cross.toml
@@ -5,5 +5,8 @@ pre-build = [
     "export DEBIAN_FRONTEND=noninteractive",
     "export TZ=Etc/UTC",
     "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt update -q && apt upgrade -yq && apt install --assume-yes --no-install-recommends libclang-10-dev clang-10 cmake build-essential pkg-config libssl-dev:$CROSS_DEB_ARCH libsasl2-dev llvm-dev gnutls-bin"
+    "apt update -q && apt upgrade -yq && apt install --assume-yes --no-install-recommends libclang-10-dev clang-10 cmake build-essential pkg-config libssl-dev:$CROSS_DEB_ARCH libsasl2-dev llvm-dev gnutls-bin",
+    "apt install -y gcc-10 g++-10",
+    "update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10",
+    "update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10"
 ]


### PR DESCRIPTION
# What :computer: 
* Suppresses warnings that are treated as errors in cross installation and usage 
* Bump gcc dependencies for x86 cross container for `aws-lc-sys` crate

# Why :hand:
* Release pipeline was broken as a result of cross installation failing to be installed. See:  https://github.com/matter-labs/era-test-node/actions/runs/11057024685/job/30719919478
* Building will fail with `error: failed to run custom build command for aws-lc-sys v0.21.2` using old gcc dep in cross-containers building for x86 target

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended
- Test release on forked repo: https://github.com/dutterbutter/era-test-node/actions/runs/11071741595
<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
