### PR TITLE
chore(refactor): update so forked networks chainID is used and rename `fork-at` to fork-block-number`

### DIFF
--- a/docs/rustbook/src/usage/fork.md
+++ b/docs/rustbook/src/usage/fork.md
@@ -42,8 +42,8 @@ This command starts the node, forking it from the latest block on the zkSync Sep
 You also have the option to specify a custom http endpoint and a custom forking height, like so:
 
 ```sh
-# Usage: era_test_node fork --fork-at <FORK_AT> <NETWORK>
-era_test_node fork --fork-at 7000000 mainnet http://172.17.0.3:3060
+# Usage: era_test_node fork --fork-block-number <BLOCK> <NETWORK>
+era_test_node fork --fork-block-number 7000000 mainnet http://172.17.0.3:3060
 ```
 
 ## Sending network calls

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -134,7 +134,8 @@ pub struct ForkArgs {
         long,
         value_name = "BLOCK",
         long_help = "Fetch state from a specific block number over a remote endpoint.",
-        requires = "fork"
+        requires = "fork",
+        alias = "fork-at"
     )]
     pub fork_block_number: Option<u64>,
 }

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -128,10 +128,15 @@ pub struct ForkArgs {
     ///  - testnet
     ///  - http://XXX:YY
     pub network: String,
-    #[arg(long)]
     // Fork at a given L2 miniblock height.
     // If not set - will use the current finalized block from the network.
-    pub fork_at: Option<u64>,
+    #[arg(
+        long,
+        value_name = "BLOCK",
+        long_help = "Fetch state from a specific block number over a remote endpoint.",
+        requires = "fork"
+    )]
+    pub fork_block_number: Option<u64>,
 }
 
 #[derive(Debug, Parser)]

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -550,15 +550,15 @@ impl ForkDetails {
     /// Create a fork from a given network at a given height.
     pub async fn from_network(
         fork: &str,
-        fork_at: Option<u64>,
+        fork_block_number: Option<u64>,
         cache_config: CacheConfig,
     ) -> eyre::Result<Self> {
         let (network, client) = Self::fork_network_and_client(fork)?;
         let chain_id_u64 = client.chain_id().await?;
         let chain_id = L2ChainId::from(chain_id_u64.as_u32());
 
-        let l2_miniblock = if let Some(fork_at) = fork_at {
-            fork_at
+        let l2_miniblock = if let Some(fork_block_number) = fork_block_number {
+            fork_block_number
         } else {
             match client.get_block_number().await {
                 Ok(bn) => bn.as_u64(),
@@ -613,7 +613,7 @@ impl ForkDetails {
     /// Return URL and HTTP client for `hardhat_reset`.
     pub fn from_url(
         url: String,
-        fork_at: Option<u64>,
+        fork_block_number: Option<u64>,
         cache_config: CacheConfig,
     ) -> eyre::Result<Self> {
         let parsed_url = SensitiveUrl::from_str(&url)?;
@@ -623,8 +623,8 @@ impl ForkDetails {
         block_on(async move {
             let chain_id_u64 = client.chain_id().await?;
             let chain_id = L2ChainId::from(chain_id_u64.as_u32());
-            let l2_miniblock = if let Some(fork_at) = fork_at {
-                fork_at
+            let l2_miniblock = if let Some(fork_block_number) = fork_block_number {
+                fork_block_number
             } else {
                 client.get_block_number().await?.as_u64()
             };

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -556,6 +556,7 @@ impl ForkDetails {
         let (network, client) = Self::fork_network_and_client(fork)?;
         let chain_id_u64 = client.chain_id().await?;
         let chain_id = L2ChainId::from(chain_id_u64.as_u32());
+
         let l2_miniblock = if let Some(fork_at) = fork_at {
             fork_at
         } else {
@@ -566,6 +567,7 @@ impl ForkDetails {
                 }
             }
         };
+
         Self::from_network_and_miniblock_and_chain(
             network,
             client,
@@ -745,6 +747,7 @@ mod tests {
         DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR, DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
         DEFAULT_FAIR_PUBDATA_PRICE, DEFAULT_L2_GAS_PRICE,
     };
+    use crate::node::TEST_NODE_NETWORK_ID;
     use crate::{deps::InMemoryStorage, system_contracts, testing};
 
     use super::{ForkDetails, ForkStorage};
@@ -767,6 +770,7 @@ mod tests {
 
         let fork_details = ForkDetails {
             fork_source: Box::new(external_storage),
+            chain_id: TEST_NODE_NETWORK_ID.into(),
             l1_block: L1BatchNumber(1),
             l2_block: zksync_types::api::Block::<TransactionVariant>::default(),
             l2_miniblock: 1,
@@ -802,6 +806,7 @@ mod tests {
             fork_source: Box::new(testing::ExternalStorage {
                 raw_storage: InMemoryStorage::default(),
             }),
+            chain_id: TEST_NODE_NETWORK_ID.into(),
             l1_block: L1BatchNumber(0),
             l2_block: zksync_types::api::Block::<TransactionVariant>::default(),
             l2_miniblock: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,9 @@ async fn main() -> anyhow::Result<()> {
     let fork_details = match command {
         Command::Run => None,
         Command::Fork(fork) => {
-            match ForkDetails::from_network(&fork.network, fork.fork_at, config.cache).await {
+            match ForkDetails::from_network(&fork.network, fork.fork_block_number, config.cache)
+                .await
+            {
                 Ok(fd) => Some(fd),
                 Err(error) => {
                     tracing::error!("cannot fork: {:?}", error);

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1936,6 +1936,7 @@ mod tests {
         let node: InMemoryNode<testing::ExternalStorage> = InMemoryNode::new(
             Some(ForkDetails {
                 fork_source: Box::new(mock_db),
+                chain_id: TEST_NODE_NETWORK_ID.into(),
                 l1_block: L1BatchNumber(1),
                 l2_block: Block::default(),
                 l2_miniblock: 2,

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -1158,6 +1158,19 @@ mod tests {
             serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 0,
+                "method": "eth_chainId",
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "result": "0x104",
+            }),
+        );
+
+        mock_server.expect(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
                 "method": "zks_getBlockDetails",
                 "params": [1]
             }),
@@ -1186,13 +1199,13 @@ mod tests {
                     "status": "verified",
                     "timestamp": 1000
                 },
-                "id": 0
+                "id": 1
             }),
         );
         mock_server.expect(
             serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": 1,
+                "id": 2,
                 "method": "eth_getBlockByHash",
                 "params": ["0xdaa77426c30c02a43d9fba4e841a6556c524d47030762eb14dc4af897e605d9b", true]
             }),
@@ -1224,7 +1237,7 @@ mod tests {
                     "transactionsRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
                     "uncles": []
                 },
-                "id": 1
+                "id": 2
             }),
         );
         mock_server.expect(
@@ -1251,7 +1264,7 @@ mod tests {
         mock_server.expect(
             serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": 2,
+                "id": 3,
                 "method": "zks_getFeeParams",
             }),
             serde_json::json!({
@@ -1270,7 +1283,7 @@ mod tests {
                   "l1_pubdata_price": 100780475095u64
                 }
               },
-              "id": 2
+              "id": 3
             }),
         );
 
@@ -1284,6 +1297,7 @@ mod tests {
             Default::default(),
             Default::default(),
         );
+
         {
             let inner = node.get_inner();
             let writer = inner.write().unwrap();

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -61,24 +61,37 @@ impl MockServer {
             Expectation::matching(request::body(json_decoded(eq(serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 0,
-                "method": "eth_blockNumber",
+                "method": "eth_chainId",
             })))))
             .respond_with(json_encoded(serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 0,
+                "result": "0x104",
+            }))),
+        );
+
+        server.expect(
+            Expectation::matching(request::body(json_decoded(eq(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "eth_blockNumber",
+            })))))
+            .respond_with(json_encoded(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
                 "result": format!("{:#x}", block_config.number),
             }))),
         );
         server.expect(
             Expectation::matching(request::body(json_decoded(eq(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": 1,
+                "id": 2,
                 "method": "zks_getBlockDetails",
                 "params": [ block_config.number ],
             })))))
             .respond_with(json_encoded(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": 1,
+                "id": 2,
                 "result": {
                     "number": block_config.number,
                     "l1BatchNumber": 1,
@@ -107,13 +120,13 @@ impl MockServer {
         server.expect(
             Expectation::matching(request::body(json_decoded(eq(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": 2,
+                "id": 3,
                 "method": "eth_getBlockByHash",
                 "params": [format!("{:#x}", block_config.hash), true],
             }))))).times(0..)
             .respond_with(json_encoded(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": 2,
+                "id": 3,
                 "result": {
                     "hash": format!("{:#x}", block_config.hash),
                     "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -151,7 +164,7 @@ impl MockServer {
         server.expect(
             Expectation::matching(request::body(json_decoded(eq(serde_json::json!({
                 "jsonrpc": "2.0",
-                "id": 3,
+                "id": 4,
                 "method": "zks_getFeeParams",
             })))))
             .respond_with(json_encoded(serde_json::json!(
@@ -171,7 +184,7 @@ impl MockServer {
                   "l1_pubdata_price": 100780475095u64
                 }
               },
-              "id": 3
+              "id": 4
             }))),
         );
 


### PR DESCRIPTION
# What :computer: 
* Update so forked networks chainID is used, is overridden if explicitly set `--chain-id`
* Rename `fork-at` to fork-block-number`
* Updates tests accordingly

# Why :hand:
* ChainID when forking a network was still `260` 
* Renames `fork-at` to reflect anvil `fork-block-number` 
* Supports PR for alloy-zksync: https://github.com/popzxc/alloy-zksync/pull/11

# Evidence :camera:

**BEFORE:**

<img width="566" alt="Screenshot 2024-10-31 at 8 05 33 PM" src="https://github.com/user-attachments/assets/e2b09947-48fe-4a39-b268-f6aa0a986664">

**AFTER:**
<img width="593" alt="Screenshot 2024-10-31 at 8 04 15 PM" src="https://github.com/user-attachments/assets/255c5ece-a4e1-4dd1-8e2d-dc25312fea3e">

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
