### PR TITLE
fix: arg required name for emulate_evm

### DIFF
--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -75,7 +75,7 @@ pub struct Cli {
     pub dev_system_contracts: Option<DevSystemContracts>,
 
     /// Enables EVM emulation. Currently, this requires local system contracts because there is no canonical EVM interpreter released yet.
-    #[arg(long, requires = "dev-system-contracts")]
+    #[arg(long, requires = "dev_system_contracts")]
     pub emulate_evm: bool,
 
     /// Log filter level - default: info


### PR DESCRIPTION
# What :computer: 
* Fix typo in arg name `dev-system-contracts` to `dev_system_contracts`


# Why :hand:
* `emulate_evm` arg has a required defined for `dev-system-contracts` which leads to the following error when run via `era_test_node run`:

```
Command era_test_node: Argument or group 'dev-system-contracts' specified in 'requires*' for 'emulate_evm' does not exist
```

# Evidence :camera:
![image](https://github.com/user-attachments/assets/178b2e3d-e325-448e-a3d9-a73c1ab9f3a2)
