### PR TITLE
fix: remove erroneous clap::requires

### DIFF
--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -134,7 +134,6 @@ pub struct ForkArgs {
         long,
         value_name = "BLOCK",
         long_help = "Fetch state from a specific block number over a remote endpoint.",
-        requires = "fork",
         alias = "fork-at"
     )]
     pub fork_block_number: Option<u64>,


### PR DESCRIPTION
# What :computer: 
* Removes erroneous `requires("fork")`

# Why :hand:
* The group `fork` does not exist and panics in debug builds due to clap's `debug_asserts`. Additionally the args are now contained within the `fork` subcommand so requires is redundant.
* Similar to https://github.com/matter-labs/era-test-node/pull/379

# Evidence :camera:
Tested locally