### PR TITLE
feat(spec-tests): add execution-apis submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "contracts"]
 	path = contracts
 	url = https://github.com/matter-labs/era-contracts.git
+[submodule "execution-apis"]
+	path = execution-apis
+	url = https://github.com/ethereum/execution-apis.git


### PR DESCRIPTION
# What :computer: 

This PR creates a git submodule that points to https://github.com/ethereum/execution-apis (official ETH JSONRPC spec). Building it produces `openrpc.json` file that we rely on for spec tests.

Closes #375 

# Why :hand:

On the road of making spec tests enforceable in CI