### PR TITLE
chore: bump version for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,7 +2412,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "era_test_node"
-version = "0.1.0-alpha.31"
+version = "0.1.0-alpha.32"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era_test_node"
-version = "0.1.0-alpha.31"
+version = "0.1.0-alpha.32"
 edition = "2018"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"


### PR DESCRIPTION
# What :computer: 
* Bump version to `0.1.0-alpha.32`

# Why :hand:
* For release
