### PR TITLE
refactor: move time management into its own component

### DIFF
--- a/e2e-tests/test/evm-apis.test.ts
+++ b/e2e-tests/test/evm-apis.test.ts
@@ -44,7 +44,7 @@ describe("evm_increaseTime", function () {
     const wallet = new Wallet(RichAccounts[0].PrivateKey, provider);
     const userWallet = Wallet.createRandom().connect(provider);
     let expectedTimestamp: number = await provider.send("config_getCurrentTimestamp", []);
-    expectedTimestamp += timeIncreaseInSeconds * 1000;
+    expectedTimestamp += timeIncreaseInSeconds;
 
     // Act
     await provider.send("evm_increaseTime", [timeIncreaseInSeconds]);

--- a/src/node/config_api.rs
+++ b/src/node/config_api.rs
@@ -37,15 +37,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> Configurat
     }
 
     fn config_get_current_timestamp(&self) -> Result<u64> {
-        self.get_inner()
-            .read()
-            .map_err(|err| {
-                tracing::error!("failed acquiring lock: {:?}", err);
-                into_jsrpc_error(Web3Error::InternalError(anyhow::Error::msg(
-                    "Failed to acquire read lock for inner node state.",
-                )))
-            })
-            .map(|reader| reader.current_timestamp)
+        Ok(self.time.last_timestamp())
     }
 
     fn config_set_show_calls(&self, value: String) -> Result<String> {

--- a/src/node/eth.rs
+++ b/src/node/eth.rs
@@ -2954,7 +2954,7 @@ mod tests {
         inner.current_batch = 1;
         inner.current_miniblock = 1;
         inner.current_miniblock_hash = H256::repeat_byte(0x1);
-        inner.current_timestamp = 1;
+        inner.time.set_last_timestamp(1);
         inner
             .filters
             .add_block_filter()
@@ -2971,7 +2971,7 @@ mod tests {
 
         let storage = inner.fork_storage.inner.read().unwrap();
         let expected_snapshot = Snapshot {
-            current_timestamp: inner.current_timestamp,
+            current_timestamp: inner.time.last_timestamp(),
             current_batch: inner.current_batch,
             current_miniblock: inner.current_miniblock,
             current_miniblock_hash: inner.current_miniblock_hash,
@@ -3060,7 +3060,7 @@ mod tests {
         inner.current_batch = 1;
         inner.current_miniblock = 1;
         inner.current_miniblock_hash = H256::repeat_byte(0x1);
-        inner.current_timestamp = 1;
+        inner.time.set_last_timestamp(1);
         inner
             .filters
             .add_block_filter()
@@ -3078,7 +3078,7 @@ mod tests {
         let expected_snapshot = {
             let storage = inner.fork_storage.inner.read().unwrap();
             Snapshot {
-                current_timestamp: inner.current_timestamp,
+                current_timestamp: inner.time.last_timestamp(),
                 current_batch: inner.current_batch,
                 current_miniblock: inner.current_miniblock,
                 current_miniblock_hash: inner.current_miniblock_hash,
@@ -3113,7 +3113,7 @@ mod tests {
         inner.current_batch = 2;
         inner.current_miniblock = 2;
         inner.current_miniblock_hash = H256::repeat_byte(0x2);
-        inner.current_timestamp = 2;
+        inner.time.set_last_timestamp(2);
         inner
             .filters
             .add_pending_transaction_filter()
@@ -3134,7 +3134,10 @@ mod tests {
             .expect("failed restoring snapshot");
 
         let storage = inner.fork_storage.inner.read().unwrap();
-        assert_eq!(expected_snapshot.current_timestamp, inner.current_timestamp);
+        assert_eq!(
+            expected_snapshot.current_timestamp,
+            inner.time.last_timestamp()
+        );
         assert_eq!(expected_snapshot.current_batch, inner.current_batch);
         assert_eq!(expected_snapshot.current_miniblock, inner.current_miniblock);
         assert_eq!(

--- a/src/node/eth.rs
+++ b/src/node/eth.rs
@@ -2954,7 +2954,7 @@ mod tests {
         inner.current_batch = 1;
         inner.current_miniblock = 1;
         inner.current_miniblock_hash = H256::repeat_byte(0x1);
-        inner.time.set_last_timestamp(1);
+        inner.time.set_last_timestamp_unchecked(1);
         inner
             .filters
             .add_block_filter()
@@ -3060,7 +3060,7 @@ mod tests {
         inner.current_batch = 1;
         inner.current_miniblock = 1;
         inner.current_miniblock_hash = H256::repeat_byte(0x1);
-        inner.time.set_last_timestamp(1);
+        inner.time.set_last_timestamp_unchecked(1);
         inner
             .filters
             .add_block_filter()
@@ -3113,7 +3113,7 @@ mod tests {
         inner.current_batch = 2;
         inner.current_miniblock = 2;
         inner.current_miniblock_hash = H256::repeat_byte(0x2);
-        inner.time.set_last_timestamp(2);
+        inner.time.set_last_timestamp_unchecked(2);
         inner
             .filters
             .add_pending_transaction_filter()

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -795,7 +795,8 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
             .write()
             .map_err(|err| format!("failed acquiring write lock on storage: {:?}", err))?;
 
-        self.time.set_last_timestamp(snapshot.current_timestamp);
+        self.time
+            .set_last_timestamp_unchecked(snapshot.current_timestamp);
         self.current_batch = snapshot.current_batch;
         self.current_miniblock = snapshot.current_miniblock;
         self.current_miniblock_hash = snapshot.current_miniblock_hash;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -12,6 +12,7 @@ mod in_memory;
 mod in_memory_ext;
 mod net;
 mod storage_logs;
+mod time;
 mod web3;
 mod zks;
 

--- a/src/node/time.rs
+++ b/src/node/time.rs
@@ -1,11 +1,11 @@
 use std::sync::{Arc, RwLock};
 
-/// Manages timestamps across the system.
+/// Manages timestamps (in seconds) across the system.
 ///
 /// Clones always agree on the underlying timestamp and updating one affects all other instances.
 #[derive(Clone, Debug)]
 pub struct TimestampManager {
-    /// The latest timestamp that has already been used.
+    /// The latest timestamp (in seconds) that has already been used.
     last_timestamp: Arc<RwLock<u64>>,
 }
 
@@ -16,7 +16,7 @@ impl TimestampManager {
         }
     }
 
-    /// Returns the last timestamp that has already been used.
+    /// Returns the last timestamp (in seconds) that has already been used.
     pub fn last_timestamp(&self) -> u64 {
         *self
             .last_timestamp
@@ -24,7 +24,7 @@ impl TimestampManager {
             .expect("TimestampManager lock is poisoned")
     }
 
-    /// Returns the next unique timestamp to be used.
+    /// Returns the next unique timestamp (in seconds) to be used.
     pub fn next_timestamp(&self) -> u64 {
         let mut guard = self
             .last_timestamp
@@ -36,7 +36,7 @@ impl TimestampManager {
         next_timestamp
     }
 
-    /// Sets last used timestamp to the provided value.
+    /// Sets last used timestamp (in seconds) to the provided value.
     pub fn set_last_timestamp(&self, timestamp: u64) {
         let mut guard = self
             .last_timestamp

--- a/src/node/time.rs
+++ b/src/node/time.rs
@@ -1,0 +1,58 @@
+use std::sync::{Arc, RwLock};
+
+/// Manages timestamps across the system.
+///
+/// Clones always agree on the underlying timestamp and updating one affects all other instances.
+#[derive(Clone, Debug)]
+pub struct TimestampManager {
+    /// The latest timestamp that has already been used.
+    last_timestamp: Arc<RwLock<u64>>,
+}
+
+impl TimestampManager {
+    pub fn new(last_timestamp: u64) -> TimestampManager {
+        TimestampManager {
+            last_timestamp: Arc::new(RwLock::new(last_timestamp)),
+        }
+    }
+
+    /// Returns the last timestamp that has already been used.
+    pub fn last_timestamp(&self) -> u64 {
+        *self
+            .last_timestamp
+            .read()
+            .expect("TimestampManager lock is poisoned")
+    }
+
+    /// Returns the next unique timestamp to be used.
+    pub fn next_timestamp(&self) -> u64 {
+        let mut guard = self
+            .last_timestamp
+            .write()
+            .expect("TimestampManager lock is poisoned");
+        let next_timestamp = *guard + 1;
+        *guard = next_timestamp;
+
+        next_timestamp
+    }
+
+    /// Sets last used timestamp to the provided value.
+    pub fn set_last_timestamp(&self, timestamp: u64) {
+        let mut guard = self
+            .last_timestamp
+            .write()
+            .expect("TimestampManager lock is poisoned");
+        *guard = timestamp;
+    }
+
+    /// Fast-forwards time by the given amount of seconds.
+    pub fn increase_time(&self, seconds: u64) -> u64 {
+        let mut guard = self
+            .last_timestamp
+            .write()
+            .expect("TimestampManager lock is poisoned");
+        let next = guard.saturating_add(seconds);
+        *guard = next;
+        next
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -124,7 +124,7 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
         // leave node state ready for next interaction
         node.current_batch = block_ctx.batch;
         node.current_miniblock = block_ctx.miniblock;
-        node.time.set_last_timestamp(block_ctx.timestamp);
+        node.time.set_last_timestamp_unchecked(block_ctx.timestamp);
     }
 
     Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -89,7 +89,7 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
             let (batch_env, mut block_ctx) = node.create_l1_batch_env(storage.clone());
             // override the next block's timestamp to match up with interval for subsequent blocks
             if i != 0 {
-                block_ctx.timestamp = node.current_timestamp.saturating_add(interval_sec);
+                block_ctx.timestamp = node.time.increase_time(interval_sec);
             }
 
             // init vm
@@ -124,7 +124,7 @@ pub fn mine_empty_blocks<S: std::fmt::Debug + ForkSource>(
         // leave node state ready for next interaction
         node.current_batch = block_ctx.batch;
         node.current_miniblock = block_ctx.miniblock;
-        node.current_timestamp = block_ctx.timestamp;
+        node.time.set_last_timestamp(block_ctx.timestamp);
     }
 
     Ok(())


### PR DESCRIPTION
# What :computer: 

Makes time management less rigid by moving the logic into its own component.

Closes #386 

# Why :hand:

Some flows depend on getting unique timestamps (e.g. new block, new batch, etc) and they really shouldn't hold a mutable reference to the node's internal state all the time.