### PR TITLE
refactor: separate block sealing logic from executing txs

### DIFF
--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -44,7 +44,7 @@ pub trait AnvilNamespaceT {
     ///
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "anvil_mine")]
-    fn anvil_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<bool>;
+    fn anvil_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<()>;
 
     /// Reset the state of the network back to a fresh forked state, or disable forking.
     ///

--- a/src/namespaces/hardhat.rs
+++ b/src/namespaces/hardhat.rs
@@ -63,7 +63,7 @@ pub trait HardhatNamespaceT {
     ///
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "hardhat_mine")]
-    fn hardhat_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<bool>;
+    fn hardhat_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<()>;
 
     /// Retrieves the current automine status of the network.
     ///

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -29,7 +29,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNames
             .into_boxed_future()
     }
 
-    fn anvil_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<bool> {
+    fn anvil_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<()> {
         self.mine_blocks(num_blocks, interval)
             .map_err(|err| {
                 tracing::error!("failed mining blocks: {:?}", err);

--- a/src/node/eth.rs
+++ b/src/node/eth.rs
@@ -101,12 +101,13 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
             return Err(err.into());
         };
 
-        self.run_l2_tx(l2_tx, system_contracts).map_err(|err| {
-            Web3Error::SubmitTransactionError(
-                format!("Execution error: {err}"),
-                hash.as_bytes().to_vec(),
-            )
-        })?;
+        self.seal_block(vec![l2_tx], system_contracts)
+            .map_err(|err| {
+                Web3Error::SubmitTransactionError(
+                    format!("Execution error: {err}"),
+                    hash.as_bytes().to_vec(),
+                )
+            })?;
         Ok(hash)
     }
 
@@ -188,12 +189,13 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
             }
         }
 
-        self.run_l2_tx(l2_tx, system_contracts).map_err(|err| {
-            Web3Error::SubmitTransactionError(
-                format!("Execution error: {err}"),
-                hash.as_bytes().to_vec(),
-            )
-        })?;
+        self.seal_block(vec![l2_tx], system_contracts)
+            .map_err(|err| {
+                Web3Error::SubmitTransactionError(
+                    format!("Execution error: {err}"),
+                    hash.as_bytes().to_vec(),
+                )
+            })?;
         Ok(hash)
     }
 }
@@ -1596,7 +1598,7 @@ mod tests {
             .expect("no block");
 
         assert_eq!(0, block.number.as_u64());
-        assert_eq!(compute_hash(0, H256::zero()), block.hash);
+        assert_eq!(compute_hash(0, []), block.hash);
     }
 
     #[tokio::test]
@@ -1604,7 +1606,7 @@ mod tests {
         let node = InMemoryNode::<HttpForkSource>::default();
 
         let block = node
-            .get_block_by_hash(compute_hash(0, H256::zero()), false)
+            .get_block_by_hash(compute_hash(0, []), false)
             .await
             .expect("failed fetching block by hash")
             .expect("no block");

--- a/src/node/hardhat.rs
+++ b/src/node/hardhat.rs
@@ -29,7 +29,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> HardhatNam
             .into_boxed_future()
     }
 
-    fn hardhat_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<bool> {
+    fn hardhat_mine(&self, num_blocks: Option<U64>, interval: Option<U64>) -> RpcResult<()> {
         self.mine_blocks(num_blocks, interval)
             .map_err(|err| {
                 tracing::error!("failed mining blocks: {:?}", err);

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -11,7 +11,7 @@ use crate::{
     fork::{ForkDetails, ForkSource},
     namespaces::ResetRequest,
     node::InMemoryNode,
-    utils::{self, bytecode_to_factory_dep},
+    utils::bytecode_to_factory_dep,
 };
 
 type Result<T> = anyhow::Result<T>;
@@ -65,14 +65,14 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
     /// # Returns
     /// The string "0x0".
     pub fn mine_block(&self) -> Result<String> {
-        self.get_inner()
-            .write()
+        let bootloader_code = self
+            .get_inner()
+            .read()
             .map_err(|err| anyhow!("failed acquiring lock: {:?}", err))
-            .and_then(|mut writer| {
-                utils::mine_empty_blocks(&mut writer, 1, 1000)?;
-                tracing::info!("👷 Mined block #{}", writer.current_miniblock);
-                Ok("0x0".to_string())
-            })
+            .map(|inner| inner.system_contracts.contracts_for_l2_call().clone())?;
+        let block_number = self.seal_block(vec![], bootloader_code.clone())?;
+        tracing::info!("👷 Mined block #{}", block_number);
+        Ok("0x0".to_string())
     }
 
     /// Snapshot the state of the blockchain at the current block. Takes no parameters. Returns the id of the snapshot
@@ -219,22 +219,33 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
     }
 
     pub fn mine_blocks(&self, num_blocks: Option<U64>, interval: Option<U64>) -> Result<bool> {
-        self.get_inner()
-            .write()
-            .map_err(|err| anyhow!("failed acquiring lock: {:?}", err))
-            .and_then(|mut writer| {
-                let num_blocks = num_blocks.unwrap_or_else(|| U64::from(1));
-                let interval_sec = interval.unwrap_or_else(|| U64::from(1));
-                if num_blocks.is_zero() {
-                    return Err(anyhow!(
-                        "Number of blocks must be greater than 0".to_string(),
-                    ));
-                }
-                utils::mine_empty_blocks(&mut writer, num_blocks.as_u64(), interval_sec.as_u64())?;
-                tracing::info!("👷 Mined {} blocks", num_blocks);
+        let num_blocks = num_blocks.unwrap_or_else(|| U64::from(1)).as_u64();
+        let interval_sec = interval.unwrap_or_else(|| U64::from(1)).as_u64();
 
-                Ok(true)
-            })
+        if num_blocks == 0 {
+            return Err(anyhow!(
+                "Number of blocks must be greater than 0".to_string(),
+            ));
+        }
+
+        let bootloader_code = self
+            .get_inner()
+            .read()
+            .map_err(|err| anyhow!("failed acquiring lock: {:?}", err))
+            .map(|inner| inner.system_contracts.contracts_for_l2_call().clone())?;
+        for i in 0..num_blocks {
+            if i != 0 {
+                // Accounts for the default increment of 1 done in `seal_block`. Note that
+                // there is no guarantee that blocks produced by this method will have *exactly*
+                // `interval` seconds in-between of their respective timestamps. Instead, we treat
+                // it as the minimum amount of time that should have passed in-between of blocks.
+                self.time.increase_time(interval_sec - 1);
+            }
+            self.seal_block(vec![], bootloader_code.clone())?;
+        }
+        tracing::info!("👷 Mined {} blocks", num_blocks);
+
+        Ok(true)
     }
 
     // @dev This function is necessary for Hardhat Ignite compatibility with `evm_emulator`.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -483,7 +483,7 @@ pub fn apply_tx<T: ForkSource + std::fmt::Debug + Clone>(
         .read()
         .map(|reader| reader.current_miniblock.saturating_add(1))
         .expect("failed getting current batch number");
-    let produced_block_hash = compute_hash(next_miniblock, tx_hash);
+    let produced_block_hash = compute_hash(next_miniblock, [&tx_hash]);
 
     let tx = TransactionBuilder::new().set_hash(tx_hash).build();
 
@@ -512,7 +512,7 @@ pub fn deploy_contract<T: ForkSource + std::fmt::Debug + Clone>(
         .read()
         .map(|reader| reader.current_miniblock.saturating_add(1))
         .expect("failed getting current batch number");
-    let produced_block_hash = compute_hash(next_miniblock, tx_hash);
+    let produced_block_hash = compute_hash(next_miniblock, [&tx_hash]);
 
     let salt = [0u8; 32];
     let bytecode_hash = eip712::hash_bytecode(&bytecode).expect("invalid bytecode");


### PR DESCRIPTION
# What :computer: 

Hefty refactoring of block sealing into its own logical layer on top of tx execution. This opens up a way to support several txs per block and dynamic block sealing in general. This PR also gets rid of all the ad-hoc empty block logic and instead replaces them with `seal_block([])`. Making us have a centralized place where all the blocks are created and thus this PR closes #358 

The code is still pretty messy but I want to gradually improve it as I suspect many things here will go into separate subcomponents (e.g. `BlockSealer`, `BatchSealer` etc)

# Why :hand:

Entangled sealing logic made it very hard to make it customizable for #362 
