### PR TITLE
feat: asynchronous and configurable block sealing

### DIFF
--- a/e2e-tests/test/debug-apis.test.ts
+++ b/e2e-tests/test/debug-apis.test.ts
@@ -5,6 +5,7 @@ import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import { RichAccounts } from "../helpers/constants";
 import { deployContract, expectThrowsAsync, getTestProvider } from "../helpers/utils";
 import { BigNumber } from "ethers";
+import {TransactionResponse} from "@ethersproject/abstract-provider";
 
 const provider = getTestProvider();
 
@@ -88,15 +89,16 @@ describe("debug_traceTransaction", function () {
 
     const greeter = await deployContract(deployer, "Greeter", ["Hi"]);
 
-    const txReceipt = await greeter.setGreeting("Luke Skywalker");
-    const trace = await provider.send("debug_traceTransaction", [txReceipt.hash]);
+    const txResponse: TransactionResponse = await greeter.setGreeting("Luke Skywalker");
+    const txReceipt = await txResponse.wait();
+    const trace = await provider.send("debug_traceTransaction", [txReceipt.transactionHash]);
 
     // call should be successful
     expect(trace.error).to.equal(null);
     expect(trace.calls.length).to.equal(1);
 
     // gas limit should match
-    expect(BigNumber.from(trace.gas).toNumber()).to.equal(txReceipt.gasLimit.toNumber());
+    expect(BigNumber.from(trace.gas).toNumber()).to.equal(txResponse.gasLimit.toNumber());
   });
 
   it("Should respect only_top_calls option", async function () {
@@ -105,9 +107,10 @@ describe("debug_traceTransaction", function () {
 
     const greeter = await deployContract(deployer, "Greeter", ["Hi"]);
 
-    const txReceipt = await greeter.setGreeting("Luke Skywalker");
+    const txResponse: TransactionResponse = await greeter.setGreeting("Luke Skywalker");
+    const txReceipt = await txResponse.wait();
     const trace = await provider.send("debug_traceTransaction", [
-      txReceipt.hash,
+      txReceipt.transactionHash,
       { tracer: "callTracer", tracerConfig: { onlyTopCall: true } },
     ]);
 
@@ -124,7 +127,8 @@ describe("debug_traceBlockByHash", function () {
 
     const greeter = await deployContract(deployer, "Greeter", ["Hi"]);
 
-    const txReceipt = await greeter.setGreeting("Luke Skywalker");
+    const txResponse: TransactionResponse = await greeter.setGreeting("Luke Skywalker");
+    await txResponse.wait();
     const latestBlock = await provider.getBlock("latest");
     const block = await provider.getBlock(latestBlock.number - 1);
 
@@ -135,7 +139,7 @@ describe("debug_traceBlockByHash", function () {
 
     // should contain trace for our tx
     const trace = traces[0].result;
-    expect(trace.input).to.equal(txReceipt.data);
+    expect(trace.input).to.equal(txResponse.data);
   });
 });
 
@@ -146,7 +150,8 @@ describe("debug_traceBlockByNumber", function () {
 
     const greeter = await deployContract(deployer, "Greeter", ["Hi"]);
 
-    const txReceipt = await greeter.setGreeting("Luke Skywalker");
+    const txResponse: TransactionResponse = await greeter.setGreeting("Luke Skywalker");
+    await txResponse.wait();
 
     // latest block will be empty, check we get no traces for it
     const empty_traces = await provider.send("debug_traceBlockByNumber", ["latest"]);
@@ -161,6 +166,6 @@ describe("debug_traceBlockByNumber", function () {
 
     // should contain trace for our tx
     const trace = traces[0].result;
-    expect(trace.input).to.equal(txReceipt.data);
+    expect(trace.input).to.equal(txResponse.data);
   });
 });

--- a/e2e-tests/test/evm-apis.test.ts
+++ b/e2e-tests/test/evm-apis.test.ts
@@ -49,10 +49,11 @@ describe("evm_increaseTime", function () {
     // Act
     await provider.send("evm_increaseTime", [timeIncreaseInSeconds]);
 
-    await wallet.sendTransaction({
+    const txResponse = await wallet.sendTransaction({
       to: userWallet.address,
       value: ethers.utils.parseEther("0.1"),
     });
+    await txResponse.wait();
     expectedTimestamp += 2; // New transaction will add two blocks
 
     // Assert
@@ -73,10 +74,11 @@ describe("evm_setNextBlockTimestamp", function () {
     // Act
     await provider.send("evm_setNextBlockTimestamp", [expectedTimestamp.toString(16)]);
 
-    await wallet.sendTransaction({
+    const txResponse = await wallet.sendTransaction({
       to: userWallet.address,
       value: ethers.utils.parseEther("0.1"),
     });
+    await txResponse.wait();
     expectedTimestamp += 1; // After executing a transaction, the node puts it into a block and increases its current timestamp
 
     // Assert
@@ -97,10 +99,11 @@ describe("evm_setTime", function () {
     // Act
     await provider.send("evm_setTime", [expectedTimestamp]);
 
-    await wallet.sendTransaction({
+    const txResponse = await wallet.sendTransaction({
       to: userWallet.address,
       value: ethers.utils.parseEther("0.1"),
     });
+    await txResponse.wait();
     expectedTimestamp += 2; // New transaction will add two blocks
 
     // Assert

--- a/e2e-tests/test/main.test.ts
+++ b/e2e-tests/test/main.test.ts
@@ -32,10 +32,11 @@ describe("Greeter Smart Contract", function () {
 
       // setup user wallet with 3 ETH
       const userWallet = Wallet.createRandom().connect(provider);
-      await wallet.sendTransaction({
+      const txResponse = await wallet.sendTransaction({
         to: userWallet.address,
         value: ethers.utils.parseEther("3"),
       });
+      await txResponse.wait();
 
       // deploy Greeter contract
       const artifact = await deployer.loadArtifact("Greeter");

--- a/e2e-tests/test/zks-apis.test.ts
+++ b/e2e-tests/test/zks-apis.test.ts
@@ -6,6 +6,7 @@ import { BigNumber, ethers } from "ethers";
 import * as hre from "hardhat";
 import { TransactionRequest } from "zksync-web3/build/src/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
+import {TransactionResponse} from "@ethersproject/abstract-provider";
 
 const provider = getTestProvider();
 
@@ -66,8 +67,9 @@ describe("zks_getTransactionDetails", function () {
 
     const greeter = await deployContract(deployer, "Greeter", ["Hi"]);
 
-    const txReceipt = await greeter.setGreeting("Luke Skywalker");
-    const details = await provider.send("zks_getTransactionDetails", [txReceipt.hash]);
+    const txResponse: TransactionResponse = await greeter.setGreeting("Luke Skywalker");
+    const txReceipt = await txResponse.wait();
+    const details = await provider.send("zks_getTransactionDetails", [txReceipt.transactionHash]);
 
     expect(details["status"]).to.equal("included");
     expect(details["initiatorAddress"].toLowerCase()).to.equal(wallet.address.toLowerCase());
@@ -96,7 +98,7 @@ describe("zks_getBlockDetails", function () {
     const deployer = new Deployer(hre, wallet);
 
     const greeter = await deployContract(deployer, "Greeter", ["Hi"]);
-    await greeter.setGreeting("Luke Skywalker");
+    await (await greeter.setGreeting("Luke Skywalker")).wait();
 
     const latestBlock = await provider.getBlock("latest");
     const details = await provider.send("zks_getBlockDetails", [latestBlock.number]);
@@ -145,13 +147,14 @@ describe("zks_getRawBlockTransactions", function () {
     const deployer = new Deployer(hre, wallet);
 
     const greeter = await deployContract(deployer, "Greeter", ["Hi"]);
-    const receipt = await greeter.setGreeting("Luke Skywalker");
+    const txResponse: TransactionResponse = await greeter.setGreeting("Luke Skywalker");
+    await txResponse.wait();
 
     const latestBlock = await provider.getBlock("latest");
     const txns = await provider.send("zks_getRawBlockTransactions", [latestBlock.number - 1]);
 
     expect(txns.length).to.equal(1);
-    expect(txns[0]["execute"]["calldata"]).to.equal(receipt.data);
+    expect(txns[0]["execute"]["calldata"]).to.equal(txResponse.data);
   });
 });
 

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -1,4 +1,5 @@
 use clap::{arg, command, Parser, Subcommand};
+use std::time::Duration;
 use zksync_types::H256;
 
 use crate::config::{
@@ -127,6 +128,11 @@ pub struct Cli {
     #[arg(long, help_heading = "Cache Options")]
     /// Cache directory location for disk cache (default: .cache).
     pub cache_dir: Option<String>,
+
+    #[arg(long, value_parser = duration_from_secs_f64, help_heading = "Block Sealing")]
+    /// Block time in seconds for interval sealing.
+    /// If unset, node seals a new block as soon as there is at least one transaction.
+    pub block_time: Option<Duration>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -248,4 +254,12 @@ impl Cli {
             Ok(config)
         }
     }
+}
+
+fn duration_from_secs_f64(s: &str) -> Result<Duration, String> {
+    let s = s.parse::<f64>().map_err(|e| e.to_string())?;
+    if s == 0.0 {
+        return Err("Duration must be greater than 0".to_string());
+    }
+    Duration::try_from_secs_f64(s).map_err(|e| e.to_string())
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -58,6 +58,8 @@ pub struct TestNodeConfig {
     pub log_file_path: String,
     /// Cache configuration for the test node
     pub cache_config: CacheConfig,
+    /// Maximum number of transactions per block
+    pub max_transactions: usize,
 }
 
 impl Default for TestNodeConfig {
@@ -89,6 +91,9 @@ impl Default for TestNodeConfig {
 
             // Cache configuration default
             cache_config: Default::default(),
+
+            // Block sealing configuration default
+            max_transactions: 1000,
         }
     }
 }

--- a/src/node/block_producer.rs
+++ b/src/node/block_producer.rs
@@ -1,0 +1,54 @@
+use crate::fork::ForkSource;
+use crate::node::pool::{TxBatch, TxPool};
+use crate::node::sealer::BlockSealer;
+use crate::node::InMemoryNode;
+use crate::system_contracts::SystemContracts;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use zksync_multivm::interface::TxExecutionMode;
+
+pub struct BlockProducer<S: Clone> {
+    node: InMemoryNode<S>,
+    pool: TxPool,
+    block_sealer: BlockSealer,
+    system_contracts: SystemContracts,
+}
+
+impl<S: Clone> BlockProducer<S> {
+    pub fn new(
+        node: InMemoryNode<S>,
+        pool: TxPool,
+        block_sealer: BlockSealer,
+        system_contracts: SystemContracts,
+    ) -> Self {
+        Self {
+            node,
+            pool,
+            block_sealer,
+            system_contracts,
+        }
+    }
+}
+
+impl<S: ForkSource + Clone + fmt::Debug> Future for BlockProducer<S> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let pin = self.get_mut();
+        loop {
+            if let Poll::Ready(tx_batch) = pin.block_sealer.poll(&pin.pool, cx) {
+                let TxBatch { impersonating, txs } = tx_batch;
+
+                let base_system_contracts = pin
+                    .system_contracts
+                    .contracts(TxExecutionMode::VerifyExecute, impersonating)
+                    .clone();
+                pin.node
+                    .seal_block(txs, base_system_contracts)
+                    .expect("block sealing failed");
+            }
+        }
+    }
+}

--- a/src/node/impersonate.rs
+++ b/src/node/impersonate.rs
@@ -58,4 +58,16 @@ impl ImpersonationManager {
             .write()
             .expect("ImpersonationManager lock is poisoned") = accounts;
     }
+
+    /// Inspects the entire account set on a user-provided function without dropping the lock.
+    pub fn inspect<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&HashSet<Address>) -> R,
+    {
+        let guard = self
+            .state
+            .read()
+            .expect("ImpersonationManager lock is poisoned");
+        f(&guard)
+    }
 }

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -371,7 +371,7 @@ mod tests {
     use crate::fork::ForkStorage;
     use crate::namespaces::EthNamespaceT;
     use crate::node::time::TimestampManager;
-    use crate::node::{InMemoryNodeInner, Snapshot};
+    use crate::node::{InMemoryNodeInner, Snapshot, TxPool};
     use crate::{http_fork_source::HttpForkSource, node::InMemoryNode};
     use std::str::FromStr;
     use std::sync::{Arc, RwLock};
@@ -499,6 +499,7 @@ mod tests {
         };
         let time = old_inner.time.clone();
         let impersonation = old_inner.impersonation.clone();
+        let pool = TxPool::new(impersonation.clone());
 
         let node = InMemoryNode::<HttpForkSource> {
             inner: Arc::new(RwLock::new(old_inner)),
@@ -506,6 +507,7 @@ mod tests {
             system_contracts_options: old_system_contracts_options,
             time,
             impersonation,
+            pool,
         };
 
         let address = Address::from_str("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049").unwrap();

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,6 +1,7 @@
 //! In-memory node, that supports forking other networks.
 
 mod anvil;
+mod block_producer;
 mod call_error_tracer;
 mod config_api;
 mod debug;
@@ -12,9 +13,15 @@ mod impersonate;
 mod in_memory;
 mod in_memory_ext;
 mod net;
+mod pool;
+mod sealer;
 mod storage_logs;
 mod time;
 mod web3;
 mod zks;
 
+pub use self::{
+    block_producer::BlockProducer, impersonate::ImpersonationManager, pool::TxPool,
+    sealer::BlockSealer, time::TimestampManager,
+};
 pub use in_memory::*;

--- a/src/node/pool.rs
+++ b/src/node/pool.rs
@@ -1,0 +1,62 @@
+use crate::node::impersonate::ImpersonationManager;
+use std::sync::{Arc, RwLock};
+use zksync_types::l2::L2Tx;
+
+#[derive(Clone)]
+pub struct TxPool {
+    inner: Arc<RwLock<Vec<L2Tx>>>,
+    impersonation: ImpersonationManager,
+}
+
+impl TxPool {
+    pub fn new(impersonation: ImpersonationManager) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(Vec::new())),
+            impersonation,
+        }
+    }
+
+    pub fn add_tx(&self, tx: L2Tx) {
+        let mut guard = self.inner.write().expect("TxPool lock is poisoned");
+        guard.push(tx);
+    }
+
+    /// Take up to `n` continuous transactions from the pool that are all uniform in impersonation
+    /// type (either all are impersonating or all non-impersonating).
+    // TODO: We should distinguish ready transactions from non-ready ones. Only ready txs should be takeable.
+    pub fn take_uniform(&self, n: usize) -> Option<TxBatch> {
+        if n == 0 {
+            return None;
+        }
+        let mut guard = self.inner.write().expect("TxPool lock is poisoned");
+        let mut iter = guard.iter();
+        let Some(head_tx) = iter.next() else {
+            // Pool is empty
+            return None;
+        };
+        let (impersonating, tx_count) = self.impersonation.inspect(|impersonated_accounts| {
+            // First tx's impersonation status decides what all other txs' impersonation status is
+            // expected to be.
+            let impersonating =
+                impersonated_accounts.contains(&head_tx.common_data.initiator_address);
+            let tail_txs = iter
+                // Guaranteed to be non-zero
+                .take(n - 1)
+                .take_while(|tx| {
+                    impersonating
+                        == impersonated_accounts.contains(&tx.common_data.initiator_address)
+                });
+            // The amount of transactions that can be taken from the pool; `+1` accounts for `head_tx`.
+            (impersonating, tail_txs.count() + 1)
+        });
+
+        let txs = guard.drain(0..tx_count).collect();
+        Some(TxBatch { impersonating, txs })
+    }
+}
+
+/// A batch of transactions sharing the same impersonation status.
+pub struct TxBatch {
+    pub impersonating: bool,
+    pub txs: Vec<L2Tx>,
+}

--- a/src/node/sealer.rs
+++ b/src/node/sealer.rs
@@ -1,0 +1,80 @@
+use crate::node::pool::{TxBatch, TxPool};
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tokio::time::{Interval, MissedTickBehavior};
+
+/// Mode of operations for the `BlockSealer`
+#[derive(Debug)]
+pub enum BlockSealer {
+    /// Seals a block as soon as there is at least one transaction.
+    Immediate(ImmediateBlockSealer),
+    /// Seals a new block every `interval` tick
+    FixedTime(FixedTimeBlockSealer),
+}
+
+impl BlockSealer {
+    pub fn immediate(max_transactions: usize) -> Self {
+        Self::Immediate(ImmediateBlockSealer { max_transactions })
+    }
+
+    pub fn fixed_time(max_transactions: usize, block_time: Duration) -> Self {
+        Self::FixedTime(FixedTimeBlockSealer::new(max_transactions, block_time))
+    }
+
+    pub fn poll(&mut self, pool: &TxPool, cx: &mut Context<'_>) -> Poll<TxBatch> {
+        match self {
+            BlockSealer::Immediate(immediate) => immediate.poll(pool),
+            BlockSealer::FixedTime(fixed) => fixed.poll(pool, cx),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ImmediateBlockSealer {
+    /// Maximum number of transactions to include in a block.
+    max_transactions: usize,
+}
+
+impl ImmediateBlockSealer {
+    pub fn poll(&mut self, pool: &TxPool) -> Poll<TxBatch> {
+        let Some(tx_batch) = pool.take_uniform(self.max_transactions) else {
+            return Poll::Pending;
+        };
+
+        Poll::Ready(tx_batch)
+    }
+}
+
+#[derive(Debug)]
+pub struct FixedTimeBlockSealer {
+    /// Maximum number of transactions to include in a block.
+    max_transactions: usize,
+    /// The interval when a block should be sealed.
+    interval: Interval,
+}
+
+impl FixedTimeBlockSealer {
+    pub fn new(max_transactions: usize, block_time: Duration) -> Self {
+        let start = tokio::time::Instant::now() + block_time;
+        let mut interval = tokio::time::interval_at(start, block_time);
+        // Avoid shortening interval if a tick was missed
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        Self {
+            max_transactions,
+            interval,
+        }
+    }
+
+    pub fn poll(&mut self, pool: &TxPool, cx: &mut Context<'_>) -> Poll<TxBatch> {
+        if self.interval.poll_tick(cx).is_ready() {
+            // Return a batch even if the pool is empty, i.e. we produce empty blocks by design in
+            // fixed time mode.
+            let tx_batch = pool.take_uniform(self.max_transactions).unwrap_or(TxBatch {
+                impersonating: false,
+                txs: vec![],
+            });
+            return Poll::Ready(tx_batch);
+        }
+        Poll::Pending
+    }
+}

--- a/src/node/time.rs
+++ b/src/node/time.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, RwLock};
 /// Manages timestamps (in seconds) across the system.
 ///
 /// Clones always agree on the underlying timestamp and updating one affects all other instances.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct TimestampManager {
     /// The latest timestamp (in seconds) that has already been used.
     last_timestamp: Arc<RwLock<u64>>,

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -742,15 +742,11 @@ mod tests {
             }),
         );
 
-        let node = InMemoryNode::<HttpForkSource>::new(
-            Some(
-                ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
-                    .await
-                    .unwrap(),
-            ),
-            None,
-            &Default::default(),
-        );
+        let node = InMemoryNode::<HttpForkSource>::default_fork(Some(
+            ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
+                .await
+                .unwrap(),
+        ));
 
         let result = node
             .get_transaction_details(input_tx_hash)
@@ -832,15 +828,11 @@ mod tests {
               }),
         );
 
-        let node = InMemoryNode::<HttpForkSource>::new(
-            Some(
-                ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
-                    .await
-                    .unwrap(),
-            ),
-            None,
-            &Default::default(),
-        );
+        let node = InMemoryNode::<HttpForkSource>::default_fork(Some(
+            ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
+                .await
+                .unwrap(),
+        ));
 
         let result = node
             .get_block_details(miniblock)
@@ -914,15 +906,11 @@ mod tests {
             }),
         );
 
-        let node = InMemoryNode::<HttpForkSource>::new(
-            Some(
-                ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
-                    .await
-                    .unwrap(),
-            ),
-            None,
-            &Default::default(),
-        );
+        let node = InMemoryNode::<HttpForkSource>::default_fork(Some(
+            ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
+                .await
+                .unwrap(),
+        ));
 
         let actual_bridge_addresses = node
             .get_bridge_contracts()
@@ -981,15 +969,11 @@ mod tests {
             }),
         );
 
-        let node = InMemoryNode::<HttpForkSource>::new(
-            Some(
-                ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
-                    .await
-                    .unwrap(),
-            ),
-            None,
-            &Default::default(),
-        );
+        let node = InMemoryNode::<HttpForkSource>::default_fork(Some(
+            ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
+                .await
+                .unwrap(),
+        ));
 
         let actual = node
             .get_bytecode_by_hash(input_hash)
@@ -1106,15 +1090,11 @@ mod tests {
               }),
         );
 
-        let node = InMemoryNode::<HttpForkSource>::new(
-            Some(
-                ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
-                    .await
-                    .unwrap(),
-            ),
-            None,
-            &Default::default(),
-        );
+        let node = InMemoryNode::<HttpForkSource>::default_fork(Some(
+            ForkDetails::from_network(&mock_server.url(), None, &CacheConfig::None)
+                .await
+                .unwrap(),
+        ));
 
         let txns = node
             .get_raw_block_transactions(miniblock)
@@ -1289,15 +1269,11 @@ mod tests {
             }),
         );
 
-        let node = InMemoryNode::<HttpForkSource>::new(
-            Some(
-                ForkDetails::from_network(&mock_server.url(), Some(1), &CacheConfig::None)
-                    .await
-                    .unwrap(),
-            ),
-            None,
-            &Default::default(),
-        );
+        let node = InMemoryNode::<HttpForkSource>::default_fork(Some(
+            ForkDetails::from_network(&mock_server.url(), Some(1), &CacheConfig::None)
+                .await
+                .unwrap(),
+        ));
 
         {
             let inner = node.get_inner();


### PR DESCRIPTION
# What :computer: 
This PR introduces several new components:
* `TxPool` - a very very basic version for now, essentially a mempool where we treat all txs to be ready at all times
* `BlockSealer` - component that takes txs from TxPool and decides whether it is time to seal the block (supports two modes of operation - immediate and intervaled)
* `BlockProducer` - polls BlockSealer for new block that got sealed and actually applies them in the node

CLI supports `--block-time` now (matching anvil's behaviour) and `max_transactions` config param (also matching anvil).

One caveat here is that the new behaviour means that transactions are not included in a block immediately after submission which might be something people relied on. That being said this was never a guarantee and was pretty much an implementation detail.

Still need to add e2e tests for the new functionality (intervaled sealing), but opening a draft now to collect early feedback.

Closes #362 

# Why :hand:
See #362 for motivation
