### PR TITLE
feat: adds config-out cli option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,8 +107,9 @@ async fn main() -> anyhow::Result<()> {
     Cli::deprecated_config_option();
 
     let opt = Cli::parse();
+    let command = opt.command.clone();
 
-    let mut config = opt.to_test_node_config().map_err(|e| anyhow!(e))?;
+    let mut config = opt.into_test_node_config().map_err(|e| anyhow!(e))?;
 
     let log_level_filter = LevelFilter::from(config.log_level);
     let log_file = File::create(&config.log_file_path)?;
@@ -118,7 +119,7 @@ async fn main() -> anyhow::Result<()> {
         Observability::init(vec!["era_test_node".into()], log_level_filter, log_file)?;
 
     // Use `Command::Run` as default.
-    let command = opt.command.as_ref().unwrap_or(&Command::Run);
+    let command = command.as_ref().unwrap_or(&Command::Run);
     let fork_details = match command {
         Command::Run => {
             if config.offline {


### PR DESCRIPTION
# What :computer:  
* Added a new CLI option `--config-out` to specify an output file for JSON configuration.  
* Introduced a `config_out` field in the `TestNodeConfig` struct to handle output file specification.  
* Updated configuration handling with new methods: `as_json` for JSON conversion and `set_config_out` for setting the output file.  
* Updated the `print` method in `TestNodeConfig` to write configuration to the specified JSON file if `config_out` is set.  

# Why :hand:  
* Aligns with Anvil CLI options
* To provide users with the ability to export configuration settings as a JSON file for easier debugging and external processing.  

# Evidence :camera:  
Usage examples:  

1. Exporting configuration during a `fork` command:  
   ```bash
   ./target/release/era_test_node --config-out text.json fork --network mainnet
   ```  

2. Exporting configuration during a `run` command:  
   ```bash
   ./target/release/era_test_node --config-out text.json run
   ```  

Output:  

* A JSON file (`text.json`) is created with the current configuration details after execution.