### PR TITLE
fix: obtain compressed bytecodes from vm.push_transction

### DIFF
--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1380,9 +1380,11 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             }
             .into_tracer_pointer(),
         ];
-        let (compressed_bytecodes, tx_result) =
-            vm.inspect_transaction_with_bytecode_compression(&mut tracers.into(), tx.clone(), true);
-        let compressed_bytecodes = compressed_bytecodes.context("failed compressing bytecodes")?;
+        let compressed_bytecodes = vm
+            .push_transaction(tx.clone())
+            .compressed_bytecodes
+            .into_owned();
+        let tx_result = vm.inspect(&mut tracers.into(), InspectExecutionMode::OneTx);
 
         let call_traces = call_tracer_result.get().unwrap();
 


### PR DESCRIPTION
# What :computer: 
Reverts to using `vm.push_transaction` that was changed in https://github.com/matter-labs/era-test-node/pull/349/files#diff-1d93f40c8381a01bae127f34171f5bbd3cef45d00038102a2fbcdd9ad4d7fdfdR1356

# Why :hand:
* Some intermittent failures were observed with retrieving compressed bytecodes with the last upstream merge. https://github.com/matter-labs/zksync-era/pull/3126 was merged to simplify this process.

# Evidence :camera:
Tests pass

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
