### PR TITLE
feat: add `anvil_setLoggingEnabled`

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -14,6 +14,7 @@ The `status` options are:
 
 | Namespace | API | <div style="width:130px">Status</div> | Description |
 | --- | --- | --- | --- |
+| `ANVIL` | `anvil_setLoggingEnabled` | `SUPPORTED` | Enables or disables logging |
 | `ANVIL` | `anvil_snapshot` | `SUPPORTED` | Snapshot the state of the blockchain at the current block |
 | `ANVIL` | `anvil_revert` | `SUPPORTED` | Revert the state of the blockchain to a previous snapshot |
 | `ANVIL` | `anvil_setTime` | `SUPPORTED` | Sets the internal clock time to the given timestamp |

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -7,8 +7,33 @@ import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import * as hre from "hardhat";
 import { keccak256 } from "ethers/lib/utils";
 import { BigNumber } from "ethers";
+import * as fs from "node:fs";
 
 const provider = getTestProvider();
+
+describe("anvil_setLoggingEnabled", function () {
+  it("Should disable and enable logging", async function () {
+    // Arrange
+    const wallet = new Wallet(RichAccounts[0].PrivateKey, provider);
+    const userWallet = Wallet.createRandom().connect(provider);
+
+    // Act
+    await provider.send("anvil_setLoggingEnabled", [false]);
+    const logSizeBefore = fs.statSync("../era_test_node.log").size;
+
+    await wallet.sendTransaction({
+      to: userWallet.address,
+      value: ethers.utils.parseEther("0.1"),
+    });
+    const logSizeAfter = fs.statSync("../era_test_node.log").size;
+
+    // Reset
+    await provider.send("anvil_setLoggingEnabled", [true]);
+
+    // Assert
+    expect(logSizeBefore).to.equal(logSizeAfter);
+  });
+});
 
 describe("anvil_snapshot", function () {
   it("Should return incrementing snapshot ids", async function () {

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -6,6 +6,14 @@ use crate::utils::Numeric;
 
 #[rpc]
 pub trait AnvilNamespaceT {
+    /// Enable or disable logging.
+    ///
+    /// # Arguments
+    ///
+    /// * `enable` - if `true` logging will be enabled, disabled otherwise
+    #[rpc(name = "anvil_setLoggingEnabled")]
+    fn set_logging_enabled(&self, enable: bool) -> RpcResult<()>;
+
     /// Snapshot the state of the blockchain at the current block. Takes no parameters. Returns the id of the snapshot
     /// that was created. A snapshot can only be reverted once. After a successful `anvil_revert`, the same snapshot id cannot
     /// be used again. Consider creating a new snapshot after each `anvil_revert` if you need to revert to the same

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -12,6 +12,15 @@ use crate::{
 impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNamespaceT
     for InMemoryNode<S>
 {
+    fn set_logging_enabled(&self, enable: bool) -> RpcResult<()> {
+        self.set_logging_enabled(enable)
+            .map_err(|err| {
+                tracing::error!("failed creating snapshot: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
     fn snapshot(&self) -> RpcResult<U64> {
         self.snapshot()
             .map_err(|err| {

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -1,3 +1,10 @@
+use crate::utils::Numeric;
+use crate::{
+    fork::{ForkDetails, ForkSource},
+    namespaces::ResetRequest,
+    node::InMemoryNode,
+    utils::bytecode_to_factory_dep,
+};
 use anyhow::{anyhow, Context};
 use std::convert::TryInto;
 use zksync_types::{
@@ -7,14 +14,6 @@ use zksync_types::{
 };
 use zksync_types::{AccountTreeId, Address, U256, U64};
 use zksync_utils::u256_to_h256;
-
-use crate::utils::Numeric;
-use crate::{
-    fork::{ForkDetails, ForkSource},
-    namespaces::ResetRequest,
-    node::InMemoryNode,
-    utils::bytecode_to_factory_dep,
-};
 
 type Result<T> = anyhow::Result<T>;
 
@@ -350,6 +349,17 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
                 true
             })
     }
+
+    pub fn set_logging_enabled(&self, enable: bool) -> Result<()> {
+        let Some(observability) = &self.observability else {
+            anyhow::bail!("Node's logging is not set up");
+        };
+        if enable {
+            observability.enable_logging()
+        } else {
+            observability.disable_logging()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -485,7 +495,6 @@ mod tests {
             impersonation: Default::default(),
             rich_accounts: Default::default(),
             previous_states: Default::default(),
-            observability: None,
         };
         let time = old_inner.time.clone();
         let impersonation = old_inner.impersonation.clone();
@@ -496,6 +505,7 @@ mod tests {
             system_contracts_options: old_system_contracts_options,
             time,
             impersonation,
+            observability: None,
         };
 
         let address = Address::from_str("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049").unwrap();

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1,8 +1,8 @@
-use core::fmt;
-use std::{fs::File, sync::Mutex};
-
 use clap::ValueEnum;
+use core::fmt;
 use serde::{Deserialize, Serialize};
+use std::sync::{Arc, RwLock};
+use std::{fs::File, sync::Mutex};
 use tracing_subscriber::{
     filter::LevelFilter, layer::SubscriberExt, reload, util::SubscriberInitExt, EnvFilter, Registry,
 };
@@ -44,10 +44,12 @@ impl From<LogLevel> for LevelFilter {
 }
 
 /// A sharable reference to the observability stack.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct Observability {
     binary_names: Vec<String>,
-    reload_handle: Option<reload::Handle<EnvFilter, Registry>>,
+    reload_handle: reload::Handle<EnvFilter, Registry>,
+    /// Last directives used to reload the underlying `EnvFilter` instance.
+    last_directives: Arc<RwLock<String>>,
 }
 
 impl Observability {
@@ -57,12 +59,12 @@ impl Observability {
         log_level_filter: LevelFilter,
         log_file: File,
     ) -> Result<Self, anyhow::Error> {
-        let joined_filter = binary_names
+        let directives = binary_names
             .iter()
             .map(|x| format!("{}={}", x, log_level_filter.to_string().to_lowercase()))
             .collect::<Vec<String>>()
             .join(",");
-        let filter = Self::parse_filter(&joined_filter)?;
+        let filter = Self::parse_filter(&directives)?;
         let (filter, reload_handle) = reload::Layer::new(filter);
 
         let timer_format =
@@ -95,22 +97,23 @@ impl Observability {
 
         Ok(Self {
             binary_names,
-            reload_handle: Some(reload_handle),
+            reload_handle,
+            last_directives: Arc::new(RwLock::new(directives)),
         })
     }
 
     /// Set the log level for the binary.
-    pub fn set_log_level(&self, level: LogLevel) -> Result<(), anyhow::Error> {
+    pub fn set_log_level(&self, level: LogLevel) -> anyhow::Result<()> {
         let level = LevelFilter::from(level);
-        let new_filter = Self::parse_filter(
-            &self
-                .binary_names
-                .join(format!("={},", level.to_string().to_lowercase()).as_str()),
-        )?;
-
-        if let Some(handle) = &self.reload_handle {
-            handle.modify(|filter| *filter = new_filter)?;
-        }
+        let directives = self
+            .binary_names
+            .join(&format!("={},", level.to_string().to_lowercase()));
+        let new_filter = Self::parse_filter(&directives)?;
+        self.reload_handle.reload(new_filter)?;
+        *self
+            .last_directives
+            .write()
+            .expect("Observability lock is poisoned") = directives;
 
         Ok(())
     }
@@ -120,12 +123,13 @@ impl Observability {
     ///     * "my_crate=debug"
     ///     * "my_crate::module=trace"
     ///     * "my_crate=debug,other_crate=warn"
-    pub fn set_logging(&self, directive: &str) -> Result<(), anyhow::Error> {
-        let new_filter = Self::parse_filter(directive)?;
-
-        if let Some(handle) = &self.reload_handle {
-            handle.modify(|filter| *filter = new_filter)?;
-        }
+    pub fn set_logging(&self, directives: String) -> Result<(), anyhow::Error> {
+        let new_filter = Self::parse_filter(&directives)?;
+        self.reload_handle.reload(new_filter)?;
+        *self
+            .last_directives
+            .write()
+            .expect("Observability lock is poisoned") = directives;
 
         Ok(())
     }
@@ -135,12 +139,32 @@ impl Observability {
     ///     * "my_crate=debug"
     ///     * "my_crate::module=trace"
     ///     * "my_crate=debug,other_crate=warn"
-    fn parse_filter(directive: &str) -> Result<EnvFilter, anyhow::Error> {
+    fn parse_filter(directives: &str) -> Result<EnvFilter, anyhow::Error> {
         let mut filter = EnvFilter::from_default_env();
-        for directive in directive.split(',') {
+        for directive in directives.split(',') {
             filter = filter.add_directive(directive.parse()?);
         }
 
         Ok(filter)
+    }
+
+    /// Enables logging with the latest used directives.
+    pub fn enable_logging(&self) -> Result<(), anyhow::Error> {
+        let last_directives = &*self
+            .last_directives
+            .read()
+            .expect("Observability lock is poisoned");
+        let new_filter = Self::parse_filter(&last_directives)?;
+        self.reload_handle.reload(new_filter)?;
+
+        Ok(())
+    }
+
+    /// Disables all logging.
+    pub fn disable_logging(&self) -> Result<(), anyhow::Error> {
+        let new_filter = EnvFilter::new("off");
+        self.reload_handle.reload(new_filter)?;
+
+        Ok(())
     }
 }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -154,7 +154,7 @@ impl Observability {
             .last_directives
             .read()
             .expect("Observability lock is poisoned");
-        let new_filter = Self::parse_filter(&last_directives)?;
+        let new_filter = Self::parse_filter(last_directives)?;
         self.reload_handle.reload(new_filter)?;
 
         Ok(())


### PR DESCRIPTION
# What :computer: 
Closes #433 

This PR does a minor refactoring of `Observability` + its usage in `InMemoryNode` while adding the ability to disable logging entirely by setting env filter to `off`. As a consequence of that we need to store last used directives so we can recover them when user re-enables the logs. The exact cross-interaction with `config_` methods is unspecified as `anvil` does not support that namespace, so I went with made the most sense to me.

# Why :hand:
Feature parity with anvil
