### PR TITLE
feat: add `anvil_setMinGasPrice` as an unimplemented method

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -14,7 +14,7 @@ The `status` options are:
 
 | Namespace | API | <div style="width:130px">Status</div> | Description |
 | --- | --- | --- | --- |
-| `ANVIL` | `anvil_setMinGasPrice` | `NOT IMPLEMENTED` | Set the minimum gas price for the node. Unsupported by design |
+| `ANVIL` | `anvil_setMinGasPrice` | `NOT IMPLEMENTED` | Set the minimum gas price for the node. Unsupported for ZKsync as it is only relevant for pre-EIP1559 chains |
 | `ANVIL` | `anvil_snapshot` | `SUPPORTED` | Snapshot the state of the blockchain at the current block |
 | `ANVIL` | `anvil_revert` | `SUPPORTED` | Revert the state of the blockchain to a previous snapshot |
 | `ANVIL` | `anvil_setTime` | `SUPPORTED` | Sets the internal clock time to the given timestamp |

--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -14,6 +14,7 @@ The `status` options are:
 
 | Namespace | API | <div style="width:130px">Status</div> | Description |
 | --- | --- | --- | --- |
+| `ANVIL` | `anvil_setMinGasPrice` | `NOT IMPLEMENTED` | Set the minimum gas price for the node. Unsupported by design |
 | `ANVIL` | `anvil_snapshot` | `SUPPORTED` | Snapshot the state of the blockchain at the current block |
 | `ANVIL` | `anvil_revert` | `SUPPORTED` | Revert the state of the blockchain to a previous snapshot |
 | `ANVIL` | `anvil_setTime` | `SUPPORTED` | Sets the internal clock time to the given timestamp |
@@ -110,7 +111,7 @@ The `status` options are:
 | `HARDHAT` | `hardhat_addCompilationResult` | `NOT IMPLEMENTED` | Add information about compiled contracts |
 | `HARDHAT` | `hardhat_dropTransaction` | `NOT IMPLEMENTED` | Remove a transaction from the mempool |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_impersonateAccount`](#hardhat_impersonateaccount) | `SUPPORTED` | Impersonate an account |
-| [`HARDHAT`](#hardhat-namespace) | [`hardhat_getAutomine`](#hardhat_getautomine) | `PARTIAL` | Currently always returns `true` as era-test-node by default mines new blocks with each new transaction.  |
+| [`HARDHAT`](#hardhat-namespace) | [`hardhat_getAutomine`](#hardhat_getautomine) | `PARTIAL` | Currently always returns `true` as era-test-node by default mines new blocks with each new transaction. |
 | `HARDHAT` | `hardhat_metadata` | `NOT IMPLEMENTED` | Returns the metadata of the current network |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_mine`](#hardhat_mine) | Mine any number of blocks at once, in constant time |
 | [`HARDHAT`](#hardhat-namespace) | [`hardhat_reset`](#hardhat_reset) | `PARTIALLY` | Resets the state of the network; cannot revert to past block numbers, unless they're in a fork |

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -6,7 +6,8 @@ use crate::utils::Numeric;
 
 #[rpc]
 pub trait AnvilNamespaceT {
-    /// Set the minimum gas price for the node. Unsupported by design.
+    /// Set the minimum gas price for the node. Unsupported for ZKsync as it is only relevant for
+    /// pre-EIP1559 chains.
     ///
     /// # Arguments
     ///

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -6,6 +6,14 @@ use crate::utils::Numeric;
 
 #[rpc]
 pub trait AnvilNamespaceT {
+    /// Set the minimum gas price for the node. Unsupported by design.
+    ///
+    /// # Arguments
+    ///
+    /// * `gas` - The minimum gas price to be set
+    #[rpc(name = "anvil_setMinGasPrice")]
+    fn set_min_gas_price(&self, gas: U256) -> RpcResult<()>;
+
     /// Snapshot the state of the blockchain at the current block. Takes no parameters. Returns the id of the snapshot
     /// that was created. A snapshot can only be reverted once. After a successful `anvil_revert`, the same snapshot id cannot
     /// be used again. Consider creating a new snapshot after each `anvil_revert` if you need to revert to the same

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -12,6 +12,11 @@ use crate::{
 impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNamespaceT
     for InMemoryNode<S>
 {
+    fn set_min_gas_price(&self, _gas: U256) -> RpcResult<()> {
+        tracing::info!("anvil_setMinGasPrice is unsupported as ZKsync is a post-EIP1559 chain");
+        Err(into_jsrpc_error(Web3Error::MethodNotImplemented)).into_boxed_future()
+    }
+
     fn snapshot(&self) -> RpcResult<U64> {
         self.snapshot()
             .map_err(|err| {


### PR DESCRIPTION
# What :computer: 
Closes #434

This PR explicitly marks this method as unimplemented by design (see issue for the discussion on why).

# Why :hand:
Transparency about its status
