### PR TITLE
fix: fixes gas params usage and add alias 

### DIFF
--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -96,7 +96,7 @@ pub struct Cli {
     /// Custom L1 gas price (in wei).
     pub l1_gas_price: Option<u64>,
 
-    #[arg(long, help_heading = "Gas Configuration")]
+    #[arg(long, alias = "gas-price", help_heading = "Gas Configuration")]
     /// Custom L2 gas price (in wei).
     pub l2_gas_price: Option<u64>,
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -720,12 +720,24 @@ impl TestNodeConfig {
     ) -> Result<Option<ForkDetails>, anyhow::Error> {
         match fork_details_result {
             Ok(fd) => {
-                self.update_l1_gas_price(Some(fd.l1_gas_price))
-                    .update_l2_gas_price(Some(fd.l2_fair_gas_price))
-                    .update_l1_pubdata_price(Some(fd.fair_pubdata_price))
-                    .update_price_scale(Some(fd.estimate_gas_price_scale_factor))
-                    .update_gas_limit_scale(Some(fd.estimate_gas_scale_factor))
-                    .update_chain_id(Some(fd.chain_id.as_u64() as u32));
+                let l1_gas_price = self.l1_gas_price.or(Some(fd.l1_gas_price));
+                let l2_gas_price = self.l2_gas_price.or(Some(fd.l2_fair_gas_price));
+                let l1_pubdata_price = self.l1_pubdata_price.or(Some(fd.fair_pubdata_price));
+                let price_scale = self
+                    .price_scale_factor
+                    .or(Some(fd.estimate_gas_price_scale_factor));
+                let gas_limit_scale = self
+                    .limit_scale_factor
+                    .or(Some(fd.estimate_gas_scale_factor));
+                let chain_id = self.chain_id.or(Some(fd.chain_id.as_u64() as u32));
+
+                self.update_l1_gas_price(l1_gas_price)
+                    .update_l2_gas_price(l2_gas_price)
+                    .update_l1_pubdata_price(l1_pubdata_price)
+                    .update_price_scale(price_scale)
+                    .update_gas_limit_scale(gas_limit_scale)
+                    .update_chain_id(chain_id);
+
                 Ok(Some(fd))
             }
             Err(error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,11 +139,26 @@ async fn main() -> anyhow::Result<()> {
                 match fee {
                     FeeParams::V2(fee_v2) => {
                         config = config
-                            .with_l1_gas_price(Some(fee_v2.l1_gas_price()))
-                            .with_l2_gas_price(Some(fee_v2.config().minimal_l2_gas_price))
-                            .with_price_scale(Some(DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR))
-                            .with_gas_limit_scale(Some(DEFAULT_ESTIMATE_GAS_SCALE_FACTOR))
-                            .with_l1_pubdata_price(Some(fee_v2.l1_pubdata_price()));
+                            .clone()
+                            .with_l1_gas_price(config.l1_gas_price.or(Some(fee_v2.l1_gas_price())))
+                            .with_l2_gas_price(
+                                config
+                                    .l2_gas_price
+                                    .or(Some(fee_v2.config().minimal_l2_gas_price)),
+                            )
+                            .with_price_scale(
+                                config
+                                    .price_scale_factor
+                                    .or(Some(DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR)),
+                            )
+                            .with_gas_limit_scale(
+                                config
+                                    .limit_scale_factor
+                                    .or(Some(DEFAULT_ESTIMATE_GAS_SCALE_FACTOR)),
+                            )
+                            .with_l1_pubdata_price(
+                                config.l1_pubdata_price.or(Some(fee_v2.l1_pubdata_price())),
+                            );
                     }
                     FeeParams::V1(_) => {
                         return Err(anyhow!("Unsupported FeeParams::V1 in this context"));


### PR DESCRIPTION
# What :computer: 
* Fixes use of configuring gas params using `run` and `fork` instances
* Adds alias for l2-gas-price for `gas-price` 

# Why :hand:
* Allows for overriding gas params for `run` and `fork` instances
* Aligns with anvil 
 
# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

### Usage

**Example with random values:**
`./target/release/era_test_node --l1-gas-price 1000000 --l2-gas-price 50 --l1-pubdata-price 1000 --limit-scale-factor 1.5 fork --fork-url mainnet`

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
