### PR TITLE
feat: add `anvil_` pool manipulation methods

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -14,6 +14,12 @@ The `status` options are:
 
 | Namespace | API | <div style="width:130px">Status</div> | Description |
 | --- | --- | --- | --- |
+| `ANVIL` | `anvil_dropTransaction` | `SUPPORTED` | Removes a transaction from the pool |
+| `ANVIL` | `anvil_dropAllTransactions` | `SUPPORTED` | Remove all transactions from the pool |
+| `ANVIL` | `anvil_removePoolTransactions` | `SUPPORTED` | Remove all transactions from the pool by sender address |
+| `ANVIL` | `anvil_getAutomine` | `SUPPORTED` | Get node's auto mining status |
+| `ANVIL` | `anvil_setAutomine` | `SUPPORTED` | Enable or disables auto mining of new blocks |
+| `ANVIL` | `anvil_setIntervalMining` | `SUPPORTED` | Set the mining behavior to interval with the given interval |
 | `ANVIL` | `anvil_setBlockTimestampInterval` | `SUPPORTED` | Sets the block timestamp interval |
 | `ANVIL` | `anvil_removeBlockTimestampInterval` | `SUPPORTED` | Removes the block timestamp interval |
 | `ANVIL` | `anvil_setMinGasPrice` | `NOT IMPLEMENTED` | Set the minimum gas price for the node. Unsupported for ZKsync as it is only relevant for pre-EIP1559 chains |

--- a/e2e-tests-rust/src/lib.rs
+++ b/e2e-tests-rust/src/lib.rs
@@ -1,3 +1,4 @@
+use alloy::primitives::{Address, TxHash};
 use alloy::providers::{Provider, ProviderCall};
 use alloy::rpc::client::NoParams;
 use alloy::transports::Transport;
@@ -20,6 +21,24 @@ where
     fn set_interval_mining(&self, seconds: u64) -> ProviderCall<T, (u64,), ()> {
         self.client()
             .request("anvil_setIntervalMining", (seconds,))
+            .into()
+    }
+
+    fn drop_transaction(&self, hash: TxHash) -> ProviderCall<T, (TxHash,), Option<TxHash>> {
+        self.client()
+            .request("anvil_dropTransaction", (hash,))
+            .into()
+    }
+
+    fn drop_all_transactions(&self) -> ProviderCall<T, NoParams, ()> {
+        self.client()
+            .request_noparams("anvil_dropAllTransactions")
+            .into()
+    }
+
+    fn remove_pool_transactions(&self, address: Address) -> ProviderCall<T, (Address,), ()> {
+        self.client()
+            .request("anvil_removePoolTransactions", (address,))
             .into()
     }
 }

--- a/spec-tests/Cargo.lock
+++ b/spec-tests/Cargo.lock
@@ -4530,7 +4530,7 @@ dependencies = [
 [[package]]
 name = "zksync_basic_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git?rev=ad5d42e0c7b50068ff0fd501c2b2ee549410adf8#ad5d42e0c7b50068ff0fd501c2b2ee549410adf8"
+source = "git+https://github.com/matter-labs/zksync-era.git?rev=6c034f6e180cc92e99766f14c8840c90efa56cec#6c034f6e180cc92e99766f14c8840c90efa56cec"
 dependencies = [
  "anyhow",
  "chrono",

--- a/spec-tests/Cargo.toml
+++ b/spec-tests/Cargo.toml
@@ -24,7 +24,7 @@ itertools = "0.13"
 tracing = "0.1"
 chrono = "0.4"
 
-zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "ad5d42e0c7b50068ff0fd501c2b2ee549410adf8" }
+zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "6c034f6e180cc92e99766f14c8840c90efa56cec" }
 
 [dev-dependencies]
 test-log = "0.2.16"

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -1,11 +1,34 @@
 use jsonrpc_derive::rpc;
-use zksync_types::{Address, U256, U64};
+use zksync_types::{Address, H256, U256, U64};
 
 use super::{ResetRequest, RpcResult};
 use crate::utils::Numeric;
 
 #[rpc]
 pub trait AnvilNamespaceT {
+    /// Removes a transaction from the pool.
+    ///
+    /// # Arguments
+    ///
+    /// * `hash` - Hash of the transaction to be removed from the pool
+    ///
+    /// # Returns
+    /// `Some(hash)` if transaction was in the pool before being removed, `None` otherwise
+    #[rpc(name = "anvil_dropTransaction")]
+    fn drop_transaction(&self, hash: H256) -> RpcResult<Option<H256>>;
+
+    /// Remove all transactions from the pool.
+    #[rpc(name = "anvil_dropAllTransactions")]
+    fn drop_all_transactions(&self) -> RpcResult<()>;
+
+    /// Remove all transactions from the pool by sender address.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - Sender which transactions should be removed from the pool
+    #[rpc(name = "anvil_removePoolTransactions")]
+    fn remove_pool_transactions(&self, address: Address) -> RpcResult<()>;
+
     /// Gets node's auto mining status.
     ///
     /// # Returns

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -1,4 +1,4 @@
-use zksync_types::{Address, U256, U64};
+use zksync_types::{Address, H256, U256, U64};
 use zksync_web3_decl::error::Web3Error;
 
 use crate::utils::Numeric;
@@ -12,6 +12,33 @@ use crate::{
 impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNamespaceT
     for InMemoryNode<S>
 {
+    fn drop_transaction(&self, hash: H256) -> RpcResult<Option<H256>> {
+        self.drop_transaction(hash)
+            .map_err(|err| {
+                tracing::error!("failed dropping transaction: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
+    fn drop_all_transactions(&self) -> RpcResult<()> {
+        self.drop_all_transactions()
+            .map_err(|err| {
+                tracing::error!("failed dropping all transactions: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
+    fn remove_pool_transactions(&self, address: Address) -> RpcResult<()> {
+        self.remove_pool_transactions(address)
+            .map_err(|err| {
+                tracing::error!("failed removing pool transactions: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
     fn get_auto_mine(&self) -> RpcResult<bool> {
         self.get_immediate_sealing()
             .map_err(|err| {

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -406,7 +406,8 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
     }
 
     pub fn drop_all_transactions(&self) -> Result<()> {
-        Ok(self.pool.clear())
+        self.pool.clear();
+        Ok(())
     }
 
     pub fn remove_pool_transactions(&self, address: Address) -> Result<()> {

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -14,7 +14,7 @@ use zksync_types::{
     utils::{nonces_to_full_nonce, storage_key_for_eth_balance},
     StorageKey,
 };
-use zksync_types::{AccountTreeId, Address, U256, U64};
+use zksync_types::{AccountTreeId, Address, H256, U256, U64};
 use zksync_utils::u256_to_h256;
 
 type Result<T> = anyhow::Result<T>;
@@ -398,6 +398,19 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
             )
         };
         self.sealer.set_mode(sealing_mode);
+        Ok(())
+    }
+
+    pub fn drop_transaction(&self, hash: H256) -> Result<Option<H256>> {
+        Ok(self.pool.drop_transaction(hash).map(|tx| tx.hash()))
+    }
+
+    pub fn drop_all_transactions(&self) -> Result<()> {
+        Ok(self.pool.clear())
+    }
+
+    pub fn remove_pool_transactions(&self, address: Address) -> Result<()> {
+        self.pool.drop_transactions_by_sender(address);
         Ok(())
     }
 }


### PR DESCRIPTION
# What :computer: 
Closes #417 

The logic is fairly straightforward for now, the complexity will arrive once we start building dependency graphs between transactions in the mempool. Then deleting one manually can cause a cascading effect resulting in more deleted transactions.

# Why :hand:
Feature parity with anvil
