### PR TITLE
feat: add `anvil_setNextBlockBaseFeePerGas`

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -14,6 +14,7 @@ The `status` options are:
 
 | Namespace | API | <div style="width:130px">Status</div> | Description |
 | --- | --- | --- | --- |
+| `ANVIL` | `anvil_setNextBlockBaseFeePerGas` | `SUPPORTED` | Sets the base fee of the next block |
 | `ANVIL` | `anvil_dropTransaction` | `SUPPORTED` | Removes a transaction from the pool |
 | `ANVIL` | `anvil_dropAllTransactions` | `SUPPORTED` | Remove all transactions from the pool |
 | `ANVIL` | `anvil_removePoolTransactions` | `SUPPORTED` | Remove all transactions from the pool by sender address |

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -11,6 +11,44 @@ import * as fs from "node:fs";
 
 const provider = getTestProvider();
 
+describe("anvil_setNextBlockBaseFeePerGas", function () {
+  it("Should change gas price", async function () {
+    const oldBaseFee = (await provider.getGasPrice()).toNumber()
+    const expectedNewBaseFee = oldBaseFee + 42;
+
+    // Act
+    await provider.send("anvil_setNextBlockBaseFeePerGas", [ethers.utils.hexlify(expectedNewBaseFee)]);
+
+    // Assert
+    const newBaseFee = (await provider.getGasPrice()).toNumber()
+    expect(newBaseFee).to.equal(expectedNewBaseFee);
+
+    // Revert
+    await provider.send("anvil_setNextBlockBaseFeePerGas", [ethers.utils.hexlify(oldBaseFee)]);
+  });
+
+  it("Should produce a block with new gas price", async function () {
+    const wallet = new Wallet(RichAccounts[0].PrivateKey, provider);
+    const userWallet = Wallet.createRandom().connect(provider);
+    const oldBaseFee = (await provider.getGasPrice()).toNumber()
+    const expectedNewBaseFee = oldBaseFee + 42;
+
+    // Act
+    await provider.send("anvil_setNextBlockBaseFeePerGas", [ethers.utils.hexlify(expectedNewBaseFee)]);
+
+    const txResponse = await wallet.sendTransaction({
+      to: userWallet.address,
+      value: ethers.utils.parseEther("0.1"),
+    });
+    const txReceipt = await txResponse.wait();
+    const newBlock = (await provider.getBlock(txReceipt.blockNumber));
+    expect(newBlock.baseFeePerGas?.toNumber()).to.equal(expectedNewBaseFee);
+
+    // Revert
+    await provider.send("anvil_setNextBlockBaseFeePerGas", [ethers.utils.hexlify(oldBaseFee)]);
+  });
+});
+
 describe("anvil_setBlockTimestampInterval & anvil_removeBlockTimestampInterval", function () {
   it("Should control timestamp interval between blocks", async function () {
     // Arrange

--- a/e2e-tests/test/anvil-apis.test.ts
+++ b/e2e-tests/test/anvil-apis.test.ts
@@ -13,14 +13,14 @@ const provider = getTestProvider();
 
 describe("anvil_setNextBlockBaseFeePerGas", function () {
   it("Should change gas price", async function () {
-    const oldBaseFee = (await provider.getGasPrice()).toNumber()
+    const oldBaseFee = (await provider.getGasPrice()).toNumber();
     const expectedNewBaseFee = oldBaseFee + 42;
 
     // Act
     await provider.send("anvil_setNextBlockBaseFeePerGas", [ethers.utils.hexlify(expectedNewBaseFee)]);
 
     // Assert
-    const newBaseFee = (await provider.getGasPrice()).toNumber()
+    const newBaseFee = (await provider.getGasPrice()).toNumber();
     expect(newBaseFee).to.equal(expectedNewBaseFee);
 
     // Revert
@@ -30,7 +30,7 @@ describe("anvil_setNextBlockBaseFeePerGas", function () {
   it("Should produce a block with new gas price", async function () {
     const wallet = new Wallet(RichAccounts[0].PrivateKey, provider);
     const userWallet = Wallet.createRandom().connect(provider);
-    const oldBaseFee = (await provider.getGasPrice()).toNumber()
+    const oldBaseFee = (await provider.getGasPrice()).toNumber();
     const expectedNewBaseFee = oldBaseFee + 42;
 
     // Act
@@ -41,7 +41,7 @@ describe("anvil_setNextBlockBaseFeePerGas", function () {
       value: ethers.utils.parseEther("0.1"),
     });
     const txReceipt = await txResponse.wait();
-    const newBlock = (await provider.getBlock(txReceipt.blockNumber));
+    const newBlock = await provider.getBlock(txReceipt.blockNumber);
     expect(newBlock.baseFeePerGas?.toNumber()).to.equal(expectedNewBaseFee);
 
     // Revert

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -6,6 +6,14 @@ use crate::utils::Numeric;
 
 #[rpc]
 pub trait AnvilNamespaceT {
+    /// Sets the base fee of the next block.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_fee` - Value to be set as base fee for the next block
+    #[rpc(name = "anvil_setNextBlockBaseFeePerGas")]
+    fn set_next_block_base_fee_per_gas(&self, base_fee: U256) -> RpcResult<()>;
+
     /// Removes a transaction from the pool.
     ///
     /// # Arguments

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -12,6 +12,15 @@ use crate::{
 impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNamespaceT
     for InMemoryNode<S>
 {
+    fn set_next_block_base_fee_per_gas(&self, base_fee: U256) -> RpcResult<()> {
+        self.set_next_block_base_fee_per_gas(base_fee)
+            .map_err(|err| {
+                tracing::error!("failed setting next block's base fee: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
     fn drop_transaction(&self, hash: H256) -> RpcResult<Option<H256>> {
         self.drop_transaction(hash)
             .map_err(|err| {

--- a/src/node/fee_model.rs
+++ b/src/node/fee_model.rs
@@ -1,23 +1,41 @@
-use zksync_types::fee_model::{BatchFeeInput, FeeModelConfigV2, FeeParams, FeeParamsV2};
+use zksync_multivm::utils::derive_base_fee_and_gas_per_pubdata;
+use zksync_multivm::VmVersion;
+use zksync_types::fee_model::{
+    BaseTokenConversionRatio, BatchFeeInput, FeeModelConfigV2, FeeParams, FeeParamsV2,
+};
 
 use crate::config::constants::{
     DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR, DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
     DEFAULT_FAIR_PUBDATA_PRICE, DEFAULT_L1_GAS_PRICE, DEFAULT_L2_GAS_PRICE,
 };
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct TestNodeFeeInputProvider {
-    pub l1_gas_price: u64,
-    pub l1_pubdata_price: u64,
-    pub l2_gas_price: u64,
-    pub compute_overhead_part: f64,
-    pub pubdata_overhead_part: f64,
-    pub batch_overhead_l1_gas: u64,
-    pub max_gas_per_batch: u64,
-    pub max_pubdata_per_batch: u64,
     /// L1 Gas Price Scale Factor for gas estimation.
     pub estimate_gas_price_scale_factor: f64,
     /// The factor by which to scale the gasLimit.
     pub estimate_gas_scale_factor: f32,
+
+    fee_params: FeeParamsV2,
+}
+
+// TODO: Derive PartialEq for `FeeParamsV2` in upstream
+impl PartialEq for TestNodeFeeInputProvider {
+    fn eq(&self, other: &Self) -> bool {
+        fn eq_config(a: FeeModelConfigV2, b: FeeModelConfigV2) -> bool {
+            a.minimal_l2_gas_price == b.minimal_l2_gas_price
+                && a.compute_overhead_part == b.compute_overhead_part
+                && a.pubdata_overhead_part == b.pubdata_overhead_part
+                && a.batch_overhead_l1_gas == b.batch_overhead_l1_gas
+                && a.max_gas_per_batch == b.max_gas_per_batch
+                && a.max_pubdata_per_batch == b.max_pubdata_per_batch
+        }
+
+        self.estimate_gas_price_scale_factor == other.estimate_gas_price_scale_factor
+            && self.estimate_gas_scale_factor == other.estimate_gas_scale_factor
+            && self.fee_params.l1_gas_price() == other.fee_params.l1_gas_price()
+            && self.fee_params.l1_pubdata_price() == other.fee_params.l1_pubdata_price()
+            && eq_config(self.fee_params.config(), other.fee_params.config())
+    }
 }
 
 impl TestNodeFeeInputProvider {
@@ -29,16 +47,9 @@ impl TestNodeFeeInputProvider {
         match fee_params {
             FeeParams::V1(_) => todo!(),
             FeeParams::V2(fee_params) => Self {
-                l1_gas_price: fee_params.l1_gas_price(),
-                l1_pubdata_price: fee_params.l1_pubdata_price(),
-                l2_gas_price: fee_params.config().minimal_l2_gas_price,
-                compute_overhead_part: fee_params.config().compute_overhead_part,
-                pubdata_overhead_part: fee_params.config().pubdata_overhead_part,
-                batch_overhead_l1_gas: fee_params.config().batch_overhead_l1_gas,
-                max_gas_per_batch: fee_params.config().max_gas_per_batch,
-                max_pubdata_per_batch: fee_params.config().max_pubdata_per_batch,
                 estimate_gas_price_scale_factor,
                 estimate_gas_scale_factor,
+                fee_params,
             },
         }
     }
@@ -55,24 +66,12 @@ impl TestNodeFeeInputProvider {
     }
 
     pub fn get_fee_model_config(&self) -> FeeModelConfigV2 {
-        FeeModelConfigV2 {
-            minimal_l2_gas_price: self.l2_gas_price,
-            compute_overhead_part: self.compute_overhead_part,
-            pubdata_overhead_part: self.pubdata_overhead_part,
-            batch_overhead_l1_gas: self.batch_overhead_l1_gas,
-            max_gas_per_batch: self.max_gas_per_batch,
-            max_pubdata_per_batch: self.max_pubdata_per_batch,
-        }
+        self.fee_params.config()
     }
 
     fn get_params(&self) -> FeeParams {
         // TODO: consider using old fee model for the olds blocks, when forking
-        FeeParams::V2(FeeParamsV2::new(
-            self.get_fee_model_config(),
-            self.l1_gas_price,
-            self.l1_pubdata_price,
-            Default::default(),
-        ))
+        FeeParams::V2(self.fee_params)
     }
 
     pub(crate) fn get_batch_fee_input(&self) -> BatchFeeInput {
@@ -83,21 +82,38 @@ impl TestNodeFeeInputProvider {
         let scale_factor = self.estimate_gas_price_scale_factor;
         self.get_params().scale(scale_factor, scale_factor)
     }
+
+    pub fn gas_price(&self) -> u64 {
+        let (base_fee, _) = derive_base_fee_and_gas_per_pubdata(
+            self.get_batch_fee_input_scaled(),
+            VmVersion::latest(),
+        );
+        base_fee
+    }
+
+    pub fn fair_pubdata_price(&self) -> u64 {
+        self.get_batch_fee_input_scaled().fair_pubdata_price()
+    }
 }
 
 impl Default for TestNodeFeeInputProvider {
     fn default() -> Self {
         Self {
-            l1_gas_price: DEFAULT_L1_GAS_PRICE,
-            l1_pubdata_price: DEFAULT_FAIR_PUBDATA_PRICE,
-            l2_gas_price: DEFAULT_L2_GAS_PRICE,
-            compute_overhead_part: 0.0,
-            pubdata_overhead_part: 1.0,
-            batch_overhead_l1_gas: 800000,
-            max_gas_per_batch: 200000000,
-            max_pubdata_per_batch: 500000,
             estimate_gas_price_scale_factor: DEFAULT_ESTIMATE_GAS_PRICE_SCALE_FACTOR,
             estimate_gas_scale_factor: DEFAULT_ESTIMATE_GAS_SCALE_FACTOR,
+            fee_params: FeeParamsV2::new(
+                FeeModelConfigV2 {
+                    minimal_l2_gas_price: DEFAULT_L2_GAS_PRICE,
+                    compute_overhead_part: 0.0,
+                    pubdata_overhead_part: 1.0,
+                    batch_overhead_l1_gas: 800000,
+                    max_gas_per_batch: 200000000,
+                    max_pubdata_per_batch: 500000,
+                },
+                DEFAULT_L1_GAS_PRICE,
+                DEFAULT_FAIR_PUBDATA_PRICE,
+                BaseTokenConversionRatio::default(),
+            ),
         }
     }
 }

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1430,7 +1430,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             .read()
             .expect("failed acquiring reader")
             .fee_input_provider
-            .l2_gas_price;
+            .gas_price();
         if tx.common_data.fee.max_fee_per_gas < l2_gas_price.into() {
             tracing::info!(
                 "Submitted Tx is Unexecutable {:?} because of MaxFeePerGasTooLow {}",
@@ -1706,7 +1706,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             } else {
                 U64::from(1)
             },
-            effective_gas_price: Some(inner.fee_input_provider.l2_gas_price.into()),
+            effective_gas_price: Some(inner.fee_input_provider.gas_price().into()),
             transaction_type: Some((transaction_type as u32).into()),
             logs_bloom: Default::default(),
         };

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -414,6 +414,15 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
         self.pool.drop_transactions_by_sender(address);
         Ok(())
     }
+
+    pub fn set_next_block_base_fee_per_gas(&self, base_fee: U256) -> Result<()> {
+        self.inner
+            .write()
+            .expect("")
+            .fee_input_provider
+            .set_base_fee(base_fee.as_u64());
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -387,8 +387,8 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> ZksNamespa
                         execute_tx_hash: None,
                         executed_at: None,
                         l1_gas_price: 0,
-                        l2_fair_gas_price: reader.fee_input_provider.l2_gas_price,
-                        fair_pubdata_price: Some(reader.fee_input_provider.l1_pubdata_price),
+                        l2_fair_gas_price: reader.fee_input_provider.gas_price(),
+                        fair_pubdata_price: Some(reader.fee_input_provider.fair_pubdata_price()),
                         base_system_contracts_hashes: reader
                             .system_contracts
                             .baseline_contracts


### PR DESCRIPTION
# What :computer: 
Closes #449 

Fee management is a big mess right now and IMHO we should invest some time into aligning it with core. This PR introduces support for `anvil_setNextBlockBaseFeePerGas` with minimal invasion for now.

# Why :hand:
Feature parity with anvil
