### PR TITLE
feat: add `anvil_setRpcUrl`

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -14,6 +14,7 @@ The `status` options are:
 
 | Namespace | API | <div style="width:130px">Status</div> | Description |
 | --- | --- | --- | --- |
+| `ANVIL` | `anvil_setRpcUrl` | `SUPPORTED` | Sets the fork RPC url. Assumes the underlying chain is the same as before |
 | `ANVIL` | `anvil_setNextBlockBaseFeePerGas` | `SUPPORTED` | Sets the base fee of the next block |
 | `ANVIL` | `anvil_dropTransaction` | `SUPPORTED` | Removes a transaction from the pool |
 | `ANVIL` | `anvil_dropAllTransactions` | `SUPPORTED` | Remove all transactions from the pool |

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -729,6 +729,11 @@ impl ForkDetails {
             }
         }
     }
+
+    /// Sets fork's internal URL. Assumes the underlying chain is the same as before.
+    pub fn set_rpc_url(&mut self, url: String) {
+        self.fork_source = Box::new(HttpForkSource::new(url, self.cache_config.clone()));
+    }
 }
 
 #[cfg(test)]

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -6,6 +6,14 @@ use crate::utils::Numeric;
 
 #[rpc]
 pub trait AnvilNamespaceT {
+    /// Sets the fork RPC url. Assumes the underlying chain is the same as before.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - Fork's new URL
+    #[rpc(name = "anvil_setRpcUrl")]
+    fn set_rpc_url(&self, url: String) -> RpcResult<()>;
+
     /// Sets the base fee of the next block.
     ///
     /// # Arguments

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -12,6 +12,15 @@ use crate::{
 impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNamespaceT
     for InMemoryNode<S>
 {
+    fn set_rpc_url(&self, url: String) -> RpcResult<()> {
+        self.set_rpc_url(url)
+            .map_err(|err| {
+                tracing::error!("failed setting RPC url: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
     fn set_next_block_base_fee_per_gas(&self, base_fee: U256) -> RpcResult<()> {
         self.set_next_block_base_fee_per_gas(base_fee)
             .map_err(|err| {


### PR DESCRIPTION
# What :computer: 
Closes #448

We don't have any tests for forks right now and we should discuss what shape they should take as depending on external services is generally not a great idea for tests. For now I tested this manually (changed from https://mainnet.era.zksync.io to https://1rpc.io/zksync2-era), seems to work as expected.

# Why :hand:
Feature parity with anvil
