### PR TITLE
fix: make manual mining produce non-empty blocks

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -14,6 +14,7 @@ The `status` options are:
 
 | Namespace | API | <div style="width:130px">Status</div> | Description |
 | --- | --- | --- | --- |
+| `ANVIL` | `anvil_mine_detailed` | `SUPPORTED` | Mines a single block in the same way as `evm_mine` but returns extra fields |
 | `ANVIL` | `anvil_setRpcUrl` | `SUPPORTED` | Sets the fork RPC url. Assumes the underlying chain is the same as before |
 | `ANVIL` | `anvil_setNextBlockBaseFeePerGas` | `SUPPORTED` | Sets the base fee of the next block |
 | `ANVIL` | `anvil_dropTransaction` | `SUPPORTED` | Removes a transaction from the pool |

--- a/e2e-tests-rust/Cargo.lock
+++ b/e2e-tests-rust/Cargo.lock
@@ -626,8 +626,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-zksync"
-version = "0.6.0"
-source = "git+https://github.com/itegulov/alloy-zksync.git?rev=e0e54a5ac9e24c1c32c7a8783bbf3e34dde2e218#e0e54a5ac9e24c1c32c7a8783bbf3e34dde2e218"
+version = "0.6.1"
+source = "git+https://github.com/itegulov/alloy-zksync.git?rev=c43bba1a6c5e744afb975b261cba6e964d6a58c6#c43bba1a6c5e744afb975b261cba6e964d6a58c6"
 dependencies = [
  "alloy",
  "async-trait",

--- a/e2e-tests-rust/Cargo.toml
+++ b/e2e-tests-rust/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography"]
 publish = false
 
 [dependencies]
-alloy-zksync = { git = "https://github.com/itegulov/alloy-zksync.git", rev = "e0e54a5ac9e24c1c32c7a8783bbf3e34dde2e218" }
+alloy-zksync = { git = "https://github.com/itegulov/alloy-zksync.git", rev = "c43bba1a6c5e744afb975b261cba6e964d6a58c6" }
 alloy = { version = "0.6", features = ["full", "rlp", "serde", "sol-types"] }
 anyhow = "1.0"
 fs2 = "0.4.3"

--- a/e2e-tests-rust/src/lib.rs
+++ b/e2e-tests-rust/src/lib.rs
@@ -1,6 +1,8 @@
+use alloy::network::Network;
 use alloy::primitives::{Address, TxHash};
 use alloy::providers::{Provider, ProviderCall};
 use alloy::rpc::client::NoParams;
+use alloy::serde::WithOtherFields;
 use alloy::transports::Transport;
 use alloy_zksync::network::Zksync;
 
@@ -50,6 +52,19 @@ where
         self.client()
             .request("anvil_mine", (num_blocks, interval))
             .into()
+    }
+
+    fn mine_detailed(
+        &self,
+    ) -> ProviderCall<
+        T,
+        NoParams,
+        alloy::rpc::types::Block<
+            WithOtherFields<<Zksync as Network>::TransactionResponse>,
+            <Zksync as Network>::HeaderResponse,
+        >,
+    > {
+        self.client().request_noparams("anvil_mine_detailed").into()
     }
 }
 

--- a/e2e-tests-rust/src/lib.rs
+++ b/e2e-tests-rust/src/lib.rs
@@ -41,6 +41,16 @@ where
             .request("anvil_removePoolTransactions", (address,))
             .into()
     }
+
+    fn mine(
+        &self,
+        num_blocks: Option<u64>,
+        interval: Option<u64>,
+    ) -> ProviderCall<T, (Option<u64>, Option<u64>), ()> {
+        self.client()
+            .request("anvil_mine", (num_blocks, interval))
+            .into()
+    }
 }
 
 impl<P, T> EraTestNodeApiProvider<T> for P

--- a/e2e-tests-rust/tests/lib.rs
+++ b/e2e-tests-rust/tests/lib.rs
@@ -128,8 +128,14 @@ async fn no_sealing_timeout() -> anyhow::Result<()> {
         .with_to(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"))
         .with_value(U256::from(100));
     let pending_tx = provider.send_transaction(tx).await?.register().await?;
+    let tx_hash = pending_tx.tx_hash().clone();
     let finalization_result = tokio::time::timeout(Duration::from_secs(3), pending_tx).await;
     assert!(finalization_result.is_err());
+
+    // Mine a block manually and assert that the transaction is finalized now
+    provider.mine(None, None).await?;
+    let receipt = provider.get_transaction_receipt(tx_hash).await?.unwrap();
+    assert!(receipt.status());
 
     Ok(())
 }
@@ -272,6 +278,42 @@ async fn remove_pool_transactions() -> anyhow::Result<()> {
         .await?
         .unwrap();
     assert!(receipt.status());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn manual_mining_two_txs_in_one_block() -> anyhow::Result<()> {
+    // Test that we can submit two transaction and then manually mine one block that contains both
+    // transactions in it.
+    let provider = init(|node| node.no_mine()).await?;
+
+    let tx0 = TransactionRequest::default()
+        .with_from(RICH_WALLET0)
+        .with_to(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"))
+        .with_value(U256::from(100));
+    let pending_tx0 = provider.send_transaction(tx0).await?.register().await?;
+    let tx1 = TransactionRequest::default()
+        .with_from(RICH_WALLET1)
+        .with_to(address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"))
+        .with_value(U256::from(100));
+    let pending_tx1 = provider.send_transaction(tx1).await?.register().await?;
+
+    // Mine a block manually and assert that both transactions are finalized now
+    provider.mine(None, None).await?;
+    let receipt0 = provider
+        .get_transaction_receipt(pending_tx0.await?)
+        .await?
+        .unwrap();
+    assert!(receipt0.status());
+    let receipt1 = provider
+        .get_transaction_receipt(pending_tx1.await?)
+        .await?
+        .unwrap();
+    assert!(receipt1.status());
+
+    assert_eq!(receipt0.block_hash(), receipt1.block_hash());
+    assert_eq!(receipt0.block_number(), receipt1.block_number());
 
     Ok(())
 }

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -22,10 +22,8 @@ impl InMemoryStorage {
         system_contracts_options: &crate::system_contracts::Options,
         use_evm_emulator: bool,
     ) -> Self {
-        let contracts = crate::system_contracts::get_deployed_contracts(
-            system_contracts_options,
-            use_evm_emulator,
-        );
+        let contracts =
+            system_contracts::get_deployed_contracts(system_contracts_options, use_evm_emulator);
 
         let system_context_init_log = get_system_context_init_logs(chain_id);
 

--- a/src/deps/system_contracts.rs
+++ b/src/deps/system_contracts.rs
@@ -1,5 +1,7 @@
+use crate::system_contracts::Options;
 use once_cell::sync::Lazy;
 use serde_json::Value;
+use zksync_types::system_contracts::get_system_smart_contracts;
 use zksync_types::{
     block::DeployedContract, ACCOUNT_CODE_STORAGE_ADDRESS, BOOTLOADER_ADDRESS,
     BOOTLOADER_UTILITIES_ADDRESS, CODE_ORACLE_ADDRESS, COMPRESSOR_ADDRESS,
@@ -190,3 +192,13 @@ pub static COMPILED_IN_SYSTEM_CONTRACTS: Lazy<Vec<DeployedContract>> = Lazy::new
     deployed_system_contracts.extend(empty_system_contracts);
     deployed_system_contracts
 });
+
+pub fn get_deployed_contracts(
+    options: &Options,
+    use_evm_emulator: bool,
+) -> Vec<zksync_types::block::DeployedContract> {
+    match options {
+        Options::BuiltIn | Options::BuiltInWithoutSecurity => COMPILED_IN_SYSTEM_CONTRACTS.clone(),
+        Options::Local => get_system_smart_contracts(use_evm_emulator),
+    }
+}

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -1,11 +1,21 @@
-use jsonrpc_derive::rpc;
-use zksync_types::{Address, H256, U256, U64};
-
 use super::{ResetRequest, RpcResult};
 use crate::utils::Numeric;
+use jsonrpc_derive::rpc;
+use serde::{Deserialize, Serialize};
+use zksync_types::api::{Block, Transaction};
+use zksync_types::web3::Bytes;
+use zksync_types::{Address, H256, U256, U64};
 
 #[rpc]
 pub trait AnvilNamespaceT {
+    /// Mines a single block in the same way as `evm_mine` but returns extra fields.
+    ///
+    ///
+    /// # Returns
+    /// Freshly mined block's representation along with extra fields.
+    #[rpc(name = "anvil_mine_detailed")]
+    fn mine_detailed(&self) -> RpcResult<Block<DetailedTransaction>>;
+
     /// Sets the fork RPC url. Assumes the underlying chain is the same as before.
     ///
     /// # Arguments
@@ -277,4 +287,17 @@ pub trait AnvilNamespaceT {
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "anvil_setStorageAt")]
     fn set_storage_at(&self, address: Address, slot: U256, value: U256) -> RpcResult<bool>;
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct DetailedTransaction {
+    #[serde(flatten)]
+    pub inner: Transaction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub output: Option<Bytes>,
+    #[serde(rename = "revertReason")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub revert_reason: Option<String>,
 }

--- a/src/namespaces/mod.rs
+++ b/src/namespaces/mod.rs
@@ -9,7 +9,7 @@ mod net;
 mod web3;
 mod zks;
 
-pub use anvil::AnvilNamespaceT;
+pub use anvil::{AnvilNamespaceT, DetailedTransaction};
 pub use config::ConfigurationApiNamespaceT;
 pub use debug::DebugNamespaceT;
 pub use eth::EthNamespaceT;

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -1,6 +1,8 @@
+use zksync_types::api::Block;
 use zksync_types::{Address, H256, U256, U64};
 use zksync_web3_decl::error::Web3Error;
 
+use crate::namespaces::DetailedTransaction;
 use crate::utils::Numeric;
 use crate::{
     fork::ForkSource,
@@ -12,6 +14,15 @@ use crate::{
 impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNamespaceT
     for InMemoryNode<S>
 {
+    fn mine_detailed(&self) -> RpcResult<Block<DetailedTransaction>> {
+        self.mine_detailed()
+            .map_err(|err| {
+                tracing::error!("failed mining with detailed view: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
     fn set_rpc_url(&self, url: String) -> RpcResult<()> {
         self.set_rpc_url(url)
             .map_err(|err| {

--- a/src/node/debug.rs
+++ b/src/node/debug.rs
@@ -145,6 +145,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> DebugNames
         let only_top = options.is_some_and(|o| o.tracer_config.only_top_call);
         let inner = self.get_inner().clone();
         let time = self.time.clone();
+        let system_contracts = self.system_contracts.contracts_for_l2_call().clone();
         Box::pin(async move {
             if block.is_some() && !matches!(block, Some(BlockId::Number(BlockNumber::Latest))) {
                 return Err(jsonrpc_core::Error::invalid_params(
@@ -158,7 +159,6 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> DebugNames
                 )))
             })?;
 
-            let system_contracts = inner.system_contracts.contracts_for_l2_call();
             let allow_no_target = system_contracts.evm_emulator.is_some();
             let mut l2_tx = L2Tx::from_request(request.into(), MAX_TX_SIZE, allow_no_target)
                 .map_err(|err| into_jsrpc_error(Web3Error::SerializationError(err)))?;

--- a/src/node/evm.rs
+++ b/src/node/evm.rs
@@ -36,6 +36,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> EvmNamespa
                 tracing::error!("failed mining block: {:?}", err);
                 into_jsrpc_error(Web3Error::InternalError(err))
             })
+            .map(|_| "0x0".to_string())
             .into_boxed_future()
     }
 

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1819,6 +1819,13 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             transaction.transaction_index = Some(Index::zero());
             transaction.l1_batch_number = Some(U64::from(batch_env.number.0));
             transaction.l1_batch_tx_index = Some(Index::zero());
+            if transaction.transaction_type == Some(U64::zero())
+                || transaction.transaction_type.is_none()
+            {
+                transaction.v = transaction
+                    .v
+                    .map(|v| v + 35 + inner.fork_storage.chain_id.as_u64() * 2);
+            }
             transactions.push(TransactionVariant::Full(transaction));
         }
 

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1,15 +1,15 @@
 //! In-memory node, that supports forking other networks.
+use anyhow::{anyhow, Context as _};
+use colored::Colorize;
+use indexmap::IndexMap;
+use once_cell::sync::OnceCell;
+use std::sync::{RwLockReadGuard, RwLockWriteGuard};
 use std::{
     collections::{HashMap, HashSet},
     convert::TryInto,
     str::FromStr,
     sync::{Arc, RwLock},
 };
-
-use anyhow::Context as _;
-use colored::Colorize;
-use indexmap::IndexMap;
-use once_cell::sync::OnceCell;
 use zksync_contracts::BaseSystemContracts;
 use zksync_multivm::{
     interface::{
@@ -1039,6 +1039,18 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
 
     pub fn get_inner(&self) -> Arc<RwLock<InMemoryNodeInner<S>>> {
         self.inner.clone()
+    }
+
+    pub fn read_inner(&self) -> anyhow::Result<RwLockReadGuard<'_, InMemoryNodeInner<S>>> {
+        self.inner
+            .read()
+            .map_err(|e| anyhow!("InMemoryNode lock is poisoned: {}", e))
+    }
+
+    pub fn write_inner(&self) -> anyhow::Result<RwLockWriteGuard<'_, InMemoryNodeInner<S>>> {
+        self.inner
+            .write()
+            .map_err(|e| anyhow!("InMemoryNode lock is poisoned: {}", e))
     }
 
     pub fn get_cache_config(&self) -> Result<CacheConfig, String> {

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -275,6 +275,7 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
         config: &TestNodeConfig,
         time: &TimestampManager,
         impersonation: ImpersonationManager,
+        system_contracts: SystemContracts,
     ) -> Self {
         let updated_config = config.clone();
         if config.enable_auto_impersonate {
@@ -319,10 +320,7 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
                 ),
                 config: updated_config.clone(),
                 console_log_handler: ConsoleLogHandler::default(),
-                system_contracts: SystemContracts::from_options(
-                    &updated_config.system_contracts_options,
-                    updated_config.use_evm_emulator,
-                ),
+                system_contracts,
                 impersonation,
                 rich_accounts: HashSet::new(),
                 previous_states: Default::default(),
@@ -360,10 +358,7 @@ impl<S: std::fmt::Debug + ForkSource> InMemoryNodeInner<S> {
                 ),
                 config: config.clone(),
                 console_log_handler: ConsoleLogHandler::default(),
-                system_contracts: SystemContracts::from_options(
-                    &config.system_contracts_options,
-                    config.use_evm_emulator,
-                ),
+                system_contracts,
                 impersonation,
                 rich_accounts: HashSet::new(),
                 previous_states: Default::default(),
@@ -972,6 +967,7 @@ pub struct InMemoryNode<S: Clone> {
     pub(crate) observability: Option<Observability>,
     pub(crate) pool: TxPool,
     pub(crate) sealer: BlockSealer,
+    pub(crate) system_contracts: SystemContracts,
 }
 
 fn contract_address_from_tx_result(execution_result: &VmExecutionResultAndLogs) -> Option<H160> {
@@ -1009,7 +1005,17 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
         sealer: BlockSealer,
     ) -> Self {
         let system_contracts_options = config.system_contracts_options;
-        let inner = InMemoryNodeInner::new(fork, config, &time, impersonation.clone());
+        let system_contracts = SystemContracts::from_options(
+            &config.system_contracts_options,
+            config.use_evm_emulator,
+        );
+        let inner = InMemoryNodeInner::new(
+            fork,
+            config,
+            &time,
+            impersonation.clone(),
+            system_contracts.clone(),
+        );
         InMemoryNode {
             inner: Arc::new(RwLock::new(inner)),
             snapshots: Default::default(),
@@ -1019,6 +1025,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             observability,
             pool,
             sealer,
+            system_contracts,
         }
     }
 
@@ -1080,7 +1087,13 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
 
     pub fn reset(&self, fork: Option<ForkDetails>) -> Result<(), String> {
         let config = self.get_config()?;
-        let inner = InMemoryNodeInner::new(fork, &config, &self.time, self.impersonation.clone());
+        let inner = InMemoryNodeInner::new(
+            fork,
+            &config,
+            &self.time,
+            self.impersonation.clone(),
+            self.system_contracts.clone(),
+        );
 
         let mut writer = self
             .snapshots
@@ -1154,31 +1167,17 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
         inner.rich_accounts.insert(address);
     }
 
-    pub fn system_contracts_for_l2_call(&self) -> anyhow::Result<BaseSystemContracts> {
-        let inner = self
-            .inner
-            .read()
-            .map_err(|_| anyhow::anyhow!("Failed to acquire read lock"))?;
-        Ok(inner.system_contracts.contracts_for_l2_call().clone())
-    }
-
     pub fn system_contracts_for_tx(
         &self,
         tx_initiator: Address,
     ) -> anyhow::Result<BaseSystemContracts> {
-        let inner = self
-            .inner
-            .read()
-            .map_err(|_| anyhow::anyhow!("Failed to acquire read lock"))?;
-        Ok(if inner.impersonation.is_impersonating(&tx_initiator) {
+        Ok(if self.impersonation.is_impersonating(&tx_initiator) {
             tracing::info!("🕵️ Executing tx from impersonated account {tx_initiator:?}");
-            inner
-                .system_contracts
+            self.system_contracts
                 .contracts(TxExecutionMode::VerifyExecute, true)
                 .clone()
         } else {
-            inner
-                .system_contracts
+            self.system_contracts
                 .contracts(TxExecutionMode::VerifyExecute, false)
                 .clone()
         })

--- a/src/node/in_memory_ext.rs
+++ b/src/node/in_memory_ext.rs
@@ -73,9 +73,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
     /// # Returns
     /// The string "0x0".
     pub fn mine_block(&self) -> Result<String> {
-        let bootloader_code = self
-            .read_inner()
-            .map(|inner| inner.system_contracts.contracts_for_l2_call().clone())?;
+        let bootloader_code = self.system_contracts.contracts_for_l2_call().clone();
         let block_number =
             self.seal_block(&mut self.time.lock(), vec![], bootloader_code.clone())?;
         tracing::info!("👷 Mined block #{}", block_number);
@@ -200,9 +198,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> InMemoryNo
             anyhow::bail!("Provided interval is `0`; unable to produce {num_blocks} blocks with the same timestamp");
         }
 
-        let bootloader_code = self
-            .read_inner()
-            .map(|inner| inner.system_contracts.contracts_for_l2_call().clone())?;
+        let bootloader_code = self.system_contracts.contracts_for_l2_call();
         let mut time = self
             .time
             .lock_with_offsets((0..num_blocks).map(|i| i * interval_sec));
@@ -574,6 +570,7 @@ mod tests {
             observability: None,
             pool,
             sealer: BlockSealer::default(),
+            system_contracts: Default::default(),
         };
 
         let address = Address::from_str("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049").unwrap();

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -391,8 +391,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> ZksNamespa
                         fair_pubdata_price: Some(reader.fee_input_provider.fair_pubdata_price()),
                         base_system_contracts_hashes: reader
                             .system_contracts
-                            .baseline_contracts
-                            .hashes(),
+                            .base_system_contracts_hashes(),
                     },
                     operator_address: Address::zero(),
                     protocol_version: Some(ProtocolVersionId::latest()),

--- a/src/node/zks.rs
+++ b/src/node/zks.rs
@@ -359,6 +359,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> ZksNamespa
         block_number: zksync_types::L2BlockNumber,
     ) -> RpcResult<Option<zksync_types::api::BlockDetails>> {
         let inner = self.get_inner().clone();
+        let base_system_contracts_hashes = self.system_contracts.base_system_contracts_hashes();
         Box::pin(async move {
             let reader = inner.read().map_err(|_e| {
                 let error_message = "Failed to acquire lock. Please ensure the lock is not being held by another process or thread.".to_string();
@@ -389,9 +390,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> ZksNamespa
                         l1_gas_price: 0,
                         l2_fair_gas_price: reader.fee_input_provider.gas_price(),
                         fair_pubdata_price: Some(reader.fee_input_provider.fair_pubdata_price()),
-                        base_system_contracts_hashes: reader
-                            .system_contracts
-                            .base_system_contracts_hashes(),
+                        base_system_contracts_hashes,
                     },
                     operator_address: Address::zero(),
                     protocol_version: Some(ProtocolVersionId::latest()),


### PR DESCRIPTION
# What :computer: 
* Minor refactorings to reduce boilerplate and unnecessary locking
* Makes all manual mining methods take transactions from the mempool when they can

Closes #404 

# Why :hand:
Correct behavior expected by users