### PR TITLE
feat: add `anvil_mine_detailed`

### DIFF
--- a/SUPPORTED_APIS.md
+++ b/SUPPORTED_APIS.md
@@ -14,6 +14,7 @@ The `status` options are:
 
 | Namespace | API | <div style="width:130px">Status</div> | Description |
 | --- | --- | --- | --- |
+| `ANVIL` | `anvil_mine_detailed` | `SUPPORTED` | Mines a single block in the same way as `evm_mine` but returns extra fields |
 | `ANVIL` | `anvil_setRpcUrl` | `SUPPORTED` | Sets the fork RPC url. Assumes the underlying chain is the same as before |
 | `ANVIL` | `anvil_setNextBlockBaseFeePerGas` | `SUPPORTED` | Sets the base fee of the next block |
 | `ANVIL` | `anvil_dropTransaction` | `SUPPORTED` | Removes a transaction from the pool |

--- a/e2e-tests-rust/Cargo.lock
+++ b/e2e-tests-rust/Cargo.lock
@@ -626,8 +626,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-zksync"
-version = "0.6.0"
-source = "git+https://github.com/itegulov/alloy-zksync.git?rev=e0e54a5ac9e24c1c32c7a8783bbf3e34dde2e218#e0e54a5ac9e24c1c32c7a8783bbf3e34dde2e218"
+version = "0.6.1"
+source = "git+https://github.com/itegulov/alloy-zksync.git?rev=c43bba1a6c5e744afb975b261cba6e964d6a58c6#c43bba1a6c5e744afb975b261cba6e964d6a58c6"
 dependencies = [
  "alloy",
  "async-trait",

--- a/e2e-tests-rust/Cargo.toml
+++ b/e2e-tests-rust/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["cryptography"]
 publish = false
 
 [dependencies]
-alloy-zksync = { git = "https://github.com/itegulov/alloy-zksync.git", rev = "e0e54a5ac9e24c1c32c7a8783bbf3e34dde2e218" }
+alloy-zksync = { git = "https://github.com/itegulov/alloy-zksync.git", rev = "c43bba1a6c5e744afb975b261cba6e964d6a58c6" }
 alloy = { version = "0.6", features = ["full", "rlp", "serde", "sol-types"] }
 anyhow = "1.0"
 fs2 = "0.4.3"

--- a/e2e-tests-rust/src/lib.rs
+++ b/e2e-tests-rust/src/lib.rs
@@ -1,6 +1,8 @@
+use alloy::network::Network;
 use alloy::primitives::{Address, TxHash};
 use alloy::providers::{Provider, ProviderCall};
 use alloy::rpc::client::NoParams;
+use alloy::serde::WithOtherFields;
 use alloy::transports::Transport;
 use alloy_zksync::network::Zksync;
 
@@ -50,6 +52,19 @@ where
         self.client()
             .request("anvil_mine", (num_blocks, interval))
             .into()
+    }
+
+    fn mine_detailed(
+        &self,
+    ) -> ProviderCall<
+        T,
+        NoParams,
+        alloy::rpc::types::Block<
+            WithOtherFields<<Zksync as Network>::TransactionResponse>,
+            <Zksync as Network>::HeaderResponse,
+        >,
+    > {
+        self.client().request_noparams("anvil_mine_detailed").into()
     }
 }
 

--- a/src/namespaces/anvil.rs
+++ b/src/namespaces/anvil.rs
@@ -1,11 +1,21 @@
-use jsonrpc_derive::rpc;
-use zksync_types::{Address, H256, U256, U64};
-
 use super::{ResetRequest, RpcResult};
 use crate::utils::Numeric;
+use jsonrpc_derive::rpc;
+use serde::{Deserialize, Serialize};
+use zksync_types::api::{Block, Transaction};
+use zksync_types::web3::Bytes;
+use zksync_types::{Address, H256, U256, U64};
 
 #[rpc]
 pub trait AnvilNamespaceT {
+    /// Mines a single block in the same way as `evm_mine` but returns extra fields.
+    ///
+    ///
+    /// # Returns
+    /// Freshly mined block's representation along with extra fields.
+    #[rpc(name = "anvil_mine_detailed")]
+    fn mine_detailed(&self) -> RpcResult<Block<DetailedTransaction>>;
+
     /// Sets the fork RPC url. Assumes the underlying chain is the same as before.
     ///
     /// # Arguments
@@ -277,4 +287,17 @@ pub trait AnvilNamespaceT {
     /// A `BoxFuture` containing a `Result` with a `bool` representing the success of the operation.
     #[rpc(name = "anvil_setStorageAt")]
     fn set_storage_at(&self, address: Address, slot: U256, value: U256) -> RpcResult<bool>;
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct DetailedTransaction {
+    #[serde(flatten)]
+    pub inner: Transaction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub output: Option<Bytes>,
+    #[serde(rename = "revertReason")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub revert_reason: Option<String>,
 }

--- a/src/namespaces/mod.rs
+++ b/src/namespaces/mod.rs
@@ -9,7 +9,7 @@ mod net;
 mod web3;
 mod zks;
 
-pub use anvil::AnvilNamespaceT;
+pub use anvil::{AnvilNamespaceT, DetailedTransaction};
 pub use config::ConfigurationApiNamespaceT;
 pub use debug::DebugNamespaceT;
 pub use eth::EthNamespaceT;

--- a/src/node/anvil.rs
+++ b/src/node/anvil.rs
@@ -1,6 +1,8 @@
+use zksync_types::api::Block;
 use zksync_types::{Address, H256, U256, U64};
 use zksync_web3_decl::error::Web3Error;
 
+use crate::namespaces::DetailedTransaction;
 use crate::utils::Numeric;
 use crate::{
     fork::ForkSource,
@@ -12,6 +14,15 @@ use crate::{
 impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> AnvilNamespaceT
     for InMemoryNode<S>
 {
+    fn mine_detailed(&self) -> RpcResult<Block<DetailedTransaction>> {
+        self.mine_detailed()
+            .map_err(|err| {
+                tracing::error!("failed mining with detailed view: {:?}", err);
+                into_jsrpc_error(Web3Error::InternalError(err))
+            })
+            .into_boxed_future()
+    }
+
     fn set_rpc_url(&self, url: String) -> RpcResult<()> {
         self.set_rpc_url(url)
             .map_err(|err| {

--- a/src/node/evm.rs
+++ b/src/node/evm.rs
@@ -36,6 +36,7 @@ impl<S: ForkSource + std::fmt::Debug + Clone + Send + Sync + 'static> EvmNamespa
                 tracing::error!("failed mining block: {:?}", err);
                 into_jsrpc_error(Web3Error::InternalError(err))
             })
+            .map(|_| "0x0".to_string())
             .into_boxed_future()
     }
 

--- a/src/node/in_memory.rs
+++ b/src/node/in_memory.rs
@@ -1819,6 +1819,13 @@ impl<S: ForkSource + std::fmt::Debug + Clone> InMemoryNode<S> {
             transaction.transaction_index = Some(Index::zero());
             transaction.l1_batch_number = Some(U64::from(batch_env.number.0));
             transaction.l1_batch_tx_index = Some(Index::zero());
+            if transaction.transaction_type == Some(U64::zero())
+                || transaction.transaction_type.is_none()
+            {
+                transaction.v = transaction
+                    .v
+                    .map(|v| v + 35 + inner.fork_storage.chain_id.as_u64() * 2);
+            }
             transactions.push(TransactionVariant::Full(transaction));
         }
 


### PR DESCRIPTION
# What :computer: 
Closes #454

The RPC is fairly straightforward but testing it required me to go on a rabbit hole that uncovered that alloy-zksync can't query transactions or hydrated blocks right now. https://github.com/popzxc/alloy-zksync/issues/29 is what I arrived at while working on this, e2e-tests-rust has been updated to use that branch.

# Why :hand:
Feature parity with anvil
