### PR TITLE
fix: proper handling of halted txs

### DIFF
--- a/e2e-tests-rust/src/lib.rs
+++ b/e2e-tests-rust/src/lib.rs
@@ -41,6 +41,18 @@ where
             .request("anvil_removePoolTransactions", (address,))
             .into()
     }
+
+    fn impersonate(&self, address: Address) -> ProviderCall<T, (Address,), bool> {
+        self.client()
+            .request("anvil_impersonateAccount", (address,))
+            .into()
+    }
+
+    fn stop_impersonating(&self, address: Address) -> ProviderCall<T, (Address,), bool> {
+        self.client()
+            .request("anvil_stopImpersonatingAccount", (address,))
+            .into()
+    }
 }
 
 impl<P, T> EraTestNodeApiProvider<T> for P


### PR DESCRIPTION
# What :computer: 
Closes #456, closes #462

This PR makes VM rollback when it encounters a halting transaction. This means we can seal blocks with partially halting transactions now. Also halting transactions no longer crash the node.

# Why :hand:
Better devx
